### PR TITLE
Add optional support for HTTP tasks

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -114,6 +114,8 @@ public class HttpTask extends WorkflowSystemTask {
 			return;
 		}
 		
+		boolean isOptionalTask = input.getOptional() != null && input.getOptional();
+		
 		try {
 			
 			HttpResponse response = httpCall(input);
@@ -121,7 +123,7 @@ public class HttpTask extends WorkflowSystemTask {
 				task.setStatus(Status.COMPLETED);
 			} else {
 				task.setReasonForIncompletion(response.body.toString());
-				task.setStatus(Status.FAILED);
+				task.setStatus(isOptionalTask ? Status.COMPLETED_WITH_ERRORS : Status.FAILED);
 			}
 			if(response != null) {
 				task.getOutputData().put("response", response.asMap());
@@ -272,6 +274,8 @@ public class HttpTask extends WorkflowSystemTask {
 		private Object body;
 		
 		private String accept = MediaType.APPLICATION_JSON;
+		
+		private Boolean optional;		
 
 		/**
 		 * @return the method
@@ -359,5 +363,19 @@ public class HttpTask extends WorkflowSystemTask {
 			this.accept = accept;
 		}
 		
+		/**
+		 * @return boolean indicating if the task is optional
+		 */
+		public Boolean getOptional() {
+			return optional;
+		}
+
+		/**
+		 *
+		 * @param optional set to true if the task is optional
+		 */
+		public void setOptional(Boolean optional) {
+			this.optional = optional;
+		}
 	}
 }

--- a/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
@@ -256,6 +256,29 @@ public class TestHttpTask {
 
 	}
 	
+	@Test
+	public void testOptional() throws Exception {
+		Task task = new Task();
+		Input input = new Input();
+		input.setUri("http://localhost:7009/failure");
+		input.setMethod("GET");
+		input.setOptional(true);
+		task.getInputData().put(HttpTask.REQUEST_PARAMETER_NAME, input);
+		
+		//should return COMPLETED_WITH_ERRORS if the task completes but with a non-200 status code
+		httpTask.start(workflow, task, executor);
+		assertEquals("Task output: " + task.getOutputData(), Task.Status.COMPLETED_WITH_ERRORS, task.getStatus());
+		assertEquals(ERROR_RESPONSE, task.getReasonForIncompletion());
+		assertTrue(task.getStatus().isSuccessful());
+
+		//should still return FAILED is the task is not properly configured
+		task.setStatus(Status.SCHEDULED);
+		task.getInputData().remove(HttpTask.REQUEST_PARAMETER_NAME);
+		httpTask.start(workflow, task, executor);
+		assertEquals(Task.Status.FAILED, task.getStatus());
+		assertEquals(HttpTask.MISSING_REQUEST, task.getReasonForIncompletion());
+	}
+	
 	private static class EchoHandler extends AbstractHandler {
 
 		private TypeReference<Map<String, Object>> mapOfObj = new TypeReference<Map<String,Object>>() {};


### PR DESCRIPTION
#### Description

If the HTTP task has the optional parameter set to true and the task fails, the status will be set to COMPLETED_WITH_ERRORS instead of FAILED allowing the workflow to continue.

See also issue #178 

#### Example use : 

```
  "http_request": {
    "uri": "http://host/path",
    "method": "POST",
    "optional": true,
    "body": {
      "var1": true
    }
  }
```