### PR TITLE
Add support for Elasticsearch 5.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ jdk:
 - oraclejdk8
 install: true
 script: "./buildViaTravis.sh"
+git:
+  depth: 150
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ com.netflix.conductor.dao.RedisESWorkflowModule
 
 * The default persistence used is [Dynomite](https://github.com/Netflix/dynomite)
 * For queues, we are relying on [dyno-queues](https://github.com/Netflix/dyno-queues)
-* The indexing backend is [Elasticsearch](https://www.elastic.co/) (2.+)
+* The indexing backend is [Elasticsearch](https://www.elastic.co/) (5.3.0)
 
 ## Other Requirements
 * JDK 1.8+

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ buildscript {
 	
 	repositories {
         jcenter()
+        maven {
+            url "https://artifacts.elastic.co/maven"
+        }
     }
     
     dependencies {
@@ -33,6 +36,9 @@ subprojects {
 
     repositories {
         jcenter()
+        maven {
+            url "https://artifacts.elastic.co/maven"
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
     group = "com.netflix.${githubProjectName}"
     
     tasks.withType(Test)  {
-        maxParallelForks = 1
+        maxParallelForks = 100
     }
     
     license {

--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventExecution.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventExecution.java
@@ -30,7 +30,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler.Action;
 public class EventExecution {
 
 	public enum Status {
-		IN_PROGRESS, COMPLETED, FAILED, SKIPPED
+		IN_PROGRESS, COMPLETED, FAILED, SKIPPED, NO_OP
 	}
 	
 	private String id;

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -32,7 +32,8 @@ public class Task {
 		SCHEDULED(false, true, true), 
 		TIMED_OUT(true, false, true),
 		READY_FOR_RERUN(false, true, true),
-		SKIPPED(true, true, false);
+		SKIPPED(true, true, false),
+		NO_OP(true, true, true);
 		
 		private boolean terminal;
 		

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -60,6 +60,8 @@ public class TaskDef extends Auditable {
 	
 	private int responseTimeoutSeconds = ONE_HOUR;
 	
+	private Integer concurrentExecLimit;
+	
 	private Map<String, Object> inputTemplate = new HashMap<>();
 		
 	public TaskDef() {
@@ -232,6 +234,29 @@ public class TaskDef extends Auditable {
 		return inputTemplate;
 	}
 
+	/**
+	 * 
+	 * @param concurrentExecLimit Limit of number of concurrent task that can be  IN_PROGRESS at a given time.  Seting the value to 0 removes the limit.
+	 */
+	public void setConcurrentExecLimit(Integer concurrentExecLimit) {
+		this.concurrentExecLimit = concurrentExecLimit;
+	}
+	
+	/**
+	 * 
+	 * @return Limit of number of concurrent task that can be  IN_PROGRESS at a given time
+	 */
+	public Integer getConcurrentExecLimit() {
+		return concurrentExecLimit;
+	}
+	/**
+	 * 
+	 * @return concurrency limit
+	 */
+	public int concurrencyLimit() {
+		return concurrentExecLimit == null ? 0 : concurrentExecLimit.intValue();
+	}
+	
 	/**
 	 * @param inputTemplate the inputTemplate to set
 	 * 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -30,7 +30,7 @@ public class TaskResult {
 
 	public enum Status {
 
-		IN_PROGRESS, FAILED, COMPLETED, SCHEDULED;		//SCHEDULED is added for the backward compatibility and should NOT be used when updating the task result
+		IN_PROGRESS, FAILED, COMPLETED, SCHEDULED, NO_OP; //SCHEDULED is added for the backward compatibility and should NOT be used when updating the task result
 	};
 
 	private String workflowInstanceId;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -208,21 +208,22 @@ public class HttpTask extends WorkflowSystemTask {
 
 	@Override
 	public boolean execute(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
-		if (task.getStatus().equals(Status.SCHEDULED)) {
-			long timeSince = System.currentTimeMillis() - task.getScheduledTime();
-			if(timeSince > 600_000) {
-				start(workflow, task, executor);
-				return true;	
-			}else {
-				return false;
-			}				
-		}
 		return false;
 	}
 	
 	@Override
 	public void cancel(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
 		task.setStatus(Status.CANCELED);
+	}
+	
+	@Override
+	public boolean isAsync() {
+		return true;
+	}
+	
+	@Override
+	public int getRetryTimeInSecond() {
+		return 60;
 	}
 	
 	private static ObjectMapper objectMapper() {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/SQSObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/SQSObservableQueue.java
@@ -37,6 +37,7 @@ import com.amazonaws.auth.policy.Statement;
 import com.amazonaws.auth.policy.Statement.Effect;
 import com.amazonaws.auth.policy.actions.SQSActions;
 import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.CreateQueueResult;
 import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
@@ -116,6 +117,13 @@ public class SQSObservableQueue implements ObservableQueue {
 		} catch(Exception e) {
 			return -1;
 		}
+	}
+	
+	@Override
+	public void setUnackTimeout(Message message, long unackTimeout) {
+		int unackTimeoutInSeconds = (int) (unackTimeout / 1000);
+		ChangeMessageVisibilityRequest request = new ChangeMessageVisibilityRequest(queueURL, message.getReceipt(), unackTimeoutInSeconds);
+		client.changeMessageVisibility(request);
 	}
 	
 	@Override

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/sqs/TestQueueManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/sqs/TestQueueManager.java
@@ -137,7 +137,7 @@ public class TestQueueManager {
 		queues.put(Status.COMPLETED, queue);
 		QueueManager qm = new QueueManager(queues, es);
 		qm.update("v_0", "t0", new HashMap<>(), Status.COMPLETED);
-		Uninterruptibles.sleepUninterruptibly(1_00, TimeUnit.MILLISECONDS);
+		Uninterruptibles.sleepUninterruptibly(1_000, TimeUnit.MILLISECONDS);
 		assertEquals("updatedTasks are: " + updatedTasks.toString(), 1, updatedTasks.size());
 	}
 	

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -41,6 +41,14 @@ public interface Configuration {
 	 */
 	public boolean disableSweep();
 	
+	
+	/**
+	 * 
+	 * @return when set to true, the background task workers executing async system tasks (eg HTTP) are disabled
+	 * 
+	 */
+	public boolean disableAsyncWorkers();
+	
 	/**
 	 * 
 	 * @return ID of the server.  Can be host name, IP address or any other meaningful identifier.  Used for logging

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -22,6 +22,10 @@ import com.google.inject.AbstractModule;
 import com.netflix.conductor.core.events.ActionProcessor;
 import com.netflix.conductor.core.events.EventProcessor;
 import com.netflix.conductor.core.events.queue.dyno.DynoEventQueueProvider;
+import com.netflix.conductor.core.execution.tasks.Event;
+import com.netflix.conductor.core.execution.tasks.SubWorkflow;
+import com.netflix.conductor.core.execution.tasks.SystemTaskWorkerCoordinator;
+import com.netflix.conductor.core.execution.tasks.Wait;
 
 
 /**
@@ -35,6 +39,10 @@ public class CoreModule extends AbstractModule {
 		bind(DynoEventQueueProvider.class).asEagerSingleton();
 		bind(ActionProcessor.class).asEagerSingleton();
 		bind(EventProcessor.class).asEagerSingleton();		
+		bind(SystemTaskWorkerCoordinator.class).asEagerSingleton();
+		bind(SubWorkflow.class).asEagerSingleton();
+		bind(Wait.class).asEagerSingleton();
+		bind(Event.class).asEagerSingleton();
 	}
 	
 }

--- a/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
@@ -78,10 +78,13 @@ public class EventProcessor {
 		this.om = om;
 		
 		int executorThreadCount = config.getIntProperty("workflow.event.processor.thread.count", 2);
-		this.executors = Executors.newFixedThreadPool(executorThreadCount);
-		
-		refresh();
-		Executors.newScheduledThreadPool(1).scheduleAtFixedRate(() -> refresh(), 60, 60, TimeUnit.SECONDS);
+		if(executorThreadCount > 0) {
+			this.executors = Executors.newFixedThreadPool(executorThreadCount);
+			refresh();
+			Executors.newScheduledThreadPool(1).scheduleAtFixedRate(() -> refresh(), 60, 60, TimeUnit.SECONDS);
+		} else {
+			logger.warn("Event processing is DISABLED.  executorThreadCount set to {}", executorThreadCount);
+		}
 	}
 	
 	/**

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/ObservableQueue.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/ObservableQueue.java
@@ -65,6 +65,12 @@ public interface ObservableQueue {
 	 */
 	public void publish(List<Message> messages);
 	
+	/**
+	 * Extend the lease of the unacknowledged message for longer period.
+	 * @param message Message for which the timeout has to be changed
+	 * @param unackTimeout timeout in milliseconds for which the unack lease should be extended. (replaces the current value with this value)
+	 */
+	public void setUnackTimeout(Message message, long unackTimeout);
 	
 	/**
 	 * 

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoObservableQueue.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoObservableQueue.java
@@ -54,7 +54,7 @@ public class DynoObservableQueue implements ObservableQueue {
 	public DynoObservableQueue(String queueName, QueueDAO queueDAO, Configuration config) {
 		this.queueName = queueName;
 		this.queueDAO = queueDAO;
-		this.pollTimeInMS = config.getIntProperty("workflow.dyno.queues.pollingInterval", 500);
+		this.pollTimeInMS = config.getIntProperty("workflow.dyno.queues.pollingInterval", 100);
 	}
 	
 	@Override
@@ -69,6 +69,10 @@ public class DynoObservableQueue implements ObservableQueue {
 			queueDAO.remove(queueName, msg.getId());
 		}
 		return messages.stream().map(Message::getId).collect(Collectors.toList());
+	}
+	
+	public void setUnackTimeout(Message message, long unackTimeout) {
+		queueDAO.setUnackTimeout(queueName, message.getId(), unackTimeout);
 	}
 	
 	@Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -283,7 +283,7 @@ public class DeciderService {
 	private Task retry(TaskDef taskDef, WorkflowTask workflowTask, Task task, Workflow workflow) throws TerminateWorkflow {
 
 		int retryCount = task.getRetryCount();
-		if (!task.getStatus().isRetriable() || SystemTaskType.isBuiltIn(task.getTaskType()) || taskDef.getRetryCount() <= retryCount) {
+		if (!task.getStatus().isRetriable() || SystemTaskType.isBuiltIn(task.getTaskType()) || taskDef == null || taskDef.getRetryCount() <= retryCount) {
 			WorkflowStatus status = task.getStatus().equals(Status.TIMED_OUT) ? WorkflowStatus.TIMED_OUT : WorkflowStatus.FAILED;
 			task.setRetried(true);
 			throw new TerminateWorkflow(task.getReasonForIncompletion(), status, task);
@@ -476,7 +476,7 @@ public class DeciderService {
 					workflowVersion = Integer.parseInt(version.toString());
 				}
 				task = SystemTask.subWorkflowTask(
-						workflow.getWorkflowId(), IDGenerator.generate(), workflow.getCorrelationId(), taskToSchedule.getTaskReferenceName(), 
+						workflow.getWorkflowId(), IDGenerator.generate(), workflow.getCorrelationId(), taskToSchedule, 
 						workflowName, workflowVersion, input);
 				tasks.add(task);
 				break;
@@ -485,13 +485,13 @@ public class DeciderService {
 				taskToSchedule.getInputParameters().put("sink", taskToSchedule.getSink());
 				Map<String, Object> eventTaskInput = pu.getTaskInputV2(taskToSchedule.getInputParameters(), workflow, taskId, null);
 				String sink = (String)eventTaskInput.get("sink");				
-				Task eventTask = SystemTask.eventTask(workflow.getWorkflowId(), taskId, workflow.getCorrelationId(), taskToSchedule.getTaskReferenceName(), sink, eventTaskInput);
+				Task eventTask = SystemTask.eventTask(workflow.getWorkflowId(), taskId, workflow.getCorrelationId(), taskToSchedule, sink, eventTaskInput);
 				tasks.add(eventTask);
 				break;
 			case WAIT:
 				if(taskId == null) taskId = IDGenerator.generate();
 				Map<String, Object> waitTaskInput = pu.getTaskInputV2(taskToSchedule.getInputParameters(), workflow, taskId, null);
-				Task waitTask = SystemTask.waitTask(workflow.getWorkflowId(), taskId,  workflow.getCorrelationId(), taskToSchedule.getTaskReferenceName(), waitTaskInput);
+				Task waitTask = SystemTask.waitTask(workflow.getWorkflowId(), taskId,  workflow.getCorrelationId(), taskToSchedule, waitTaskInput);
 				tasks.add(waitTask);
 				break;
 			default:

--- a/core/src/main/java/com/netflix/conductor/core/execution/SystemTask.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/SystemTask.java
@@ -26,6 +26,9 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.tasks.Event;
+import com.netflix.conductor.core.execution.tasks.SubWorkflow;
+import com.netflix.conductor.core.execution.tasks.Wait;
 
 
 
@@ -36,7 +39,7 @@ import com.netflix.conductor.common.run.Workflow;
 public class SystemTask extends Task {
 	
 	private SystemTask(){}
-
+	
 	public static Task decisionTask(String workflowId, String taskId, String correlationId, String refName, Map<String, Object> input, String caseValue, List<String> caseOuput){
 		SystemTask st = new SystemTask();
 		st.setTaskType(SystemTaskType.DECISION.name());
@@ -100,11 +103,11 @@ public class SystemTask extends Task {
 		return st;
 	}	
 	
-	public static Task eventTask(String workflowId, String taskId, String correlationId, String refName, String sink, Map<String, Object> input){
+	public static Task eventTask(String workflowId, String taskId, String correlationId, WorkflowTask taskToSchedule, String sink, Map<String, Object> input){
 		SystemTask st = new SystemTask();
-		st.setTaskType(SystemTaskType.EVENT.name());
-		st.setTaskDefName(SystemTaskType.EVENT.name());
-		st.setReferenceTaskName(refName);
+		st.setTaskType(Event.NAME);
+		st.setTaskDefName(taskToSchedule.getName());
+		st.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
 		st.setWorkflowInstanceId(workflowId);
 		st.setCorrelationId(correlationId);
 		st.setScheduledTime(System.currentTimeMillis());
@@ -112,15 +115,15 @@ public class SystemTask extends Task {
 		st.setInputData(input);
 		st.getInputData().put("sink", sink);
 		st.setTaskId(taskId);
-		st.setStatus(Status.IN_PROGRESS);
+		st.setStatus(Status.SCHEDULED);
 		return st;
 	}	
 	
-	public static Task waitTask(String workflowId, String taskId, String correlationId, String refName, Map<String, Object> input){
+	public static Task waitTask(String workflowId, String taskId, String correlationId, WorkflowTask taskToSchedule, Map<String, Object> input){
 		SystemTask st = new SystemTask();
-		st.setTaskType(SystemTaskType.WAIT.name());
-		st.setTaskDefName(SystemTaskType.WAIT.name());
-		st.setReferenceTaskName(refName);
+		st.setTaskType(Wait.NAME);
+		st.setTaskDefName(taskToSchedule.getName());
+		st.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
 		st.setWorkflowInstanceId(workflowId);
 		st.setCorrelationId(correlationId);
 		st.setScheduledTime(System.currentTimeMillis());
@@ -131,11 +134,11 @@ public class SystemTask extends Task {
 		return st;
 	}	
 	
-	public static Task subWorkflowTask(String workflowId, String taskId, String correlationId, String refName, String subWorkflowName, Integer subWorkflowVersion, Map<String, Object> workflowInput){
+	public static Task subWorkflowTask(String workflowId, String taskId, String correlationId, WorkflowTask taskToSchedule, String subWorkflowName, Integer subWorkflowVersion, Map<String, Object> workflowInput){
 		SystemTask st = new SystemTask();
-		st.setTaskType(SystemTaskType.SUB_WORKFLOW.name());
-		st.setTaskDefName(SystemTaskType.SUB_WORKFLOW.name());
-		st.setReferenceTaskName(refName);
+		st.setTaskType(SubWorkflow.NAME);
+		st.setTaskDefName(taskToSchedule.getName());
+		st.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
 		st.setWorkflowInstanceId(workflowId);
 		st.setCorrelationId(correlationId);
 		st.setScheduledTime(System.currentTimeMillis());

--- a/core/src/main/java/com/netflix/conductor/core/execution/SystemTaskType.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/SystemTaskType.java
@@ -22,11 +22,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.netflix.conductor.core.execution.tasks.Decision;
-import com.netflix.conductor.core.execution.tasks.Event;
 import com.netflix.conductor.core.execution.tasks.Fork;
 import com.netflix.conductor.core.execution.tasks.Join;
-import com.netflix.conductor.core.execution.tasks.SubWorkflow;
-import com.netflix.conductor.core.execution.tasks.Wait;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 
 /**
@@ -36,7 +33,7 @@ import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
  */
 public enum SystemTaskType {
 
-	DECISION(new Decision()), FORK(new Fork()), JOIN(new Join()), SUB_WORKFLOW(new SubWorkflow()), EVENT(new Event()), WAIT(new Wait());
+	DECISION(new Decision()), FORK(new Fork()), JOIN(new Join());
 	
 	private static Set<String> builtInTasks = new HashSet<>();
 	static {
@@ -44,9 +41,6 @@ public enum SystemTaskType {
 		builtInTasks.add(SystemTaskType.DECISION.name());
 		builtInTasks.add(SystemTaskType.FORK.name());
 		builtInTasks.add(SystemTaskType.JOIN.name());
-		builtInTasks.add(SystemTaskType.SUB_WORKFLOW.name());
-		builtInTasks.add(SystemTaskType.WAIT.name());
-		builtInTasks.add(SystemTaskType.EVENT.name());
 	}
 
 	private WorkflowSystemTask impl;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -452,7 +452,6 @@ public class WorkflowExecutor {
 		case COMPLETED:
 			queue.remove(task.getTaskType(), result.getTaskId());
 			break;
-
 		case CANCELED:
 			queue.remove(task.getTaskType(), result.getTaskId());
 			break;
@@ -464,6 +463,9 @@ public class WorkflowExecutor {
 			long callBack = result.getCallbackAfterSeconds();
 			queue.remove(task.getTaskType(), task.getTaskId());			
 			queue.push(task.getTaskType(), task.getTaskId(), callBack); // Milliseconds
+			break;
+		case NO_OP:
+			queue.remove(task.getTaskType(), result.getTaskId());
 			break;
 		default:
 			break;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -20,7 +20,6 @@ package com.netflix.conductor.core.execution;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -726,8 +725,7 @@ public class WorkflowExecutor {
 		List<Task> created = edao.createTasks(tasks);
 		List<Task> createdSystemTasks = created.stream().filter(task -> SystemTaskType.is(task.getTaskType())).collect(Collectors.toList());
 		List<Task> toBeQueued = created.stream().filter(task -> !SystemTaskType.is(task.getTaskType())).collect(Collectors.toList());
-		boolean startedSystemTasks = false;
-		Set<String> startedSystemTaks = new HashSet<>();
+		boolean startedSystemTasks = false;		
 		for(Task task : createdSystemTasks) {
 
 			WorkflowSystemTask stt = WorkflowSystemTask.get(task.getTaskType());
@@ -738,7 +736,6 @@ public class WorkflowExecutor {
 			if(!stt.isAsync()) {
 				stt.start(workflow, task, this);
 				startedSystemTasks = true;
-				startedSystemTaks.add(task.getTaskId());
 				edao.updateTask(task);
 			} else {
 				toBeQueued.add(task);

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -531,11 +531,14 @@ public class WorkflowExecutor {
 				}
 			}
 			stateChanged = scheduleTask(workflow, tasksToBeScheduled) || stateChanged;
-
-			edao.updateTasks(tasksToBeUpdated);
-			if(stateChanged) {
+			
+			if(!outcome.tasksToBeUpdated.isEmpty() || !outcome.tasksToBeScheduled.isEmpty()) {
+				edao.updateTasks(tasksToBeUpdated);
 				edao.updateWorkflow(workflow);
-				queue.push(deciderQueue, workflow.getWorkflowId(), config.getSweepFrequency());
+				queue.push(deciderQueue, workflow.getWorkflowId(), config.getSweepFrequency());	
+			}
+
+			if(stateChanged) {				
 				decide(workflowId);
 			}
 			
@@ -742,7 +745,7 @@ public class WorkflowExecutor {
 			}
 		}
 		addTaskToQueue(toBeQueued);
-		return !toBeQueued.isEmpty() || startedSystemTasks;
+		return startedSystemTasks;
 	}
 
 	private void addTaskToQueue(final List<Task> tasks) throws Exception {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
@@ -63,9 +63,14 @@ public class WorkflowSweeper {
 		this.config = config;
 		this.queues = queues;
 		this.executorThreadPoolSize = config.getIntProperty("workflow.sweeper.thread.count", 5);
-		this.es = Executors.newFixedThreadPool(executorThreadPoolSize);
-		init(executor);
-		logger.info("Workflow Sweeper Initialized");
+		if(this.executorThreadPoolSize > 0) {
+			this.es = Executors.newFixedThreadPool(executorThreadPoolSize);
+			init(executor);
+			logger.info("Workflow Sweeper Initialized");
+		} else {
+			logger.warn("Workflow sweeper is DISABLED");
+		}
+		
 	}
 
 	public void init(WorkflowExecutor executor) {
@@ -76,7 +81,6 @@ public class WorkflowSweeper {
 
 			try{
 				boolean disable = config.disableSweep();
-				logger.debug("Workflow Sweep disabled? {}", disable);
 				if (disable) {
 					logger.info("Workflow sweep is disabled.");
 					return;

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
@@ -133,6 +133,6 @@ public class Event extends WorkflowSystemTask {
 	
 	@Override
 	public boolean isAsync() {
-		return true;
+		return false;
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
@@ -48,8 +48,10 @@ public class Event extends WorkflowSystemTask {
 	
 	private ParametersUtils pu = new ParametersUtils();
 	
+	public static final String NAME = "EVENT";
+	
 	public Event() {
-		super("EVENT");
+		super(NAME);
 	}
 	
 	@Override
@@ -69,22 +71,14 @@ public class Event extends WorkflowSystemTask {
 			queue.publish(Arrays.asList(message));
 			task.getOutputData().putAll(payload);
 			task.setStatus(Status.COMPLETED);
+		} else {
+			task.setReasonForIncompletion("No queue found to publish.");
+			task.setStatus(Status.FAILED);
 		}
 	}
 
 	@Override
 	public boolean execute(Workflow workflow, Task task, WorkflowExecutor provider) throws Exception {
-		
-		if (task.getStatus().equals(Status.SCHEDULED)) {
-			long timeSince = System.currentTimeMillis() - task.getScheduledTime();
-			if(timeSince > 600_000) {
-				start(workflow, task, provider);
-				return true;
-			}else {
-				return false;
-			}				
-		}
-
 		return false;
 	}
 	
@@ -135,5 +129,10 @@ public class Event extends WorkflowSystemTask {
 			return null;			
 		}
 		
+	}
+	
+	@Override
+	public boolean isAsync() {
+		return true;
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -112,7 +112,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 	
 	@Override
 	public boolean isAsync() {
-		return true;
+		return false;
 	}
 
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * 
+ */
+package com.netflix.conductor.core.execution.tasks;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.metrics.Monitors;
+
+/**
+ * @author Viren
+ *
+ */
+@Singleton
+public class SystemTaskWorkerCoordinator {
+
+	private static Logger logger = LoggerFactory.getLogger(SystemTaskWorkerCoordinator.class);
+	
+	private QueueDAO taskQueues;
+	
+	private WorkflowExecutor executor;
+	
+	private ExecutorService es;
+	
+	private int workerQueueSize;
+	
+	private int pollCount;
+	
+	private LinkedBlockingQueue<Runnable> workerQueue;
+	
+	private int unackTimeout;
+	
+	private String workerId;
+	
+	private Configuration config;
+	
+	private static BlockingQueue<WorkflowSystemTask> queue = new LinkedBlockingQueue<>();
+	
+	private static Set<WorkflowSystemTask> listeningTasks = new HashSet<>();
+	
+	private static final String className = SystemTaskWorkerCoordinator.class.getName();
+		
+	@Inject
+	public SystemTaskWorkerCoordinator(QueueDAO taskQueues, WorkflowExecutor executor, Configuration config) {
+		this.taskQueues = taskQueues;
+		this.executor = executor;
+		this.config = config;
+		this.workerId = config.getServerId();
+		this.unackTimeout = config.getIntProperty("workflow.system.task.worker.callback.seconds", 30);
+		int threadCount = config.getIntProperty("workflow.system.task.worker.thread.count", 5);
+		this.pollCount = config.getIntProperty("workflow.system.task.worker.poll.count", 5);
+		this.workerQueueSize = config.getIntProperty("workflow.system.task.worker.queue.size", 100);
+		this.workerQueue = new LinkedBlockingQueue<Runnable>(workerQueueSize);
+		if(threadCount > 0) {
+			ThreadFactory tf = new ThreadFactoryBuilder().setNameFormat("system-task-worker-%d").build();
+			this.es = new ThreadPoolExecutor(threadCount, threadCount,
+	                0L, TimeUnit.MILLISECONDS,
+	                workerQueue,
+	                tf);
+
+			new Thread(()->listen()).start();
+			logger.info("System Task Worker Initialized with {} threads and a callback time of {} second and queue size {} with pollCount {}", threadCount, unackTimeout, workerQueueSize, pollCount);
+		} else {
+			logger.info("System Task Worker DISABLED");
+		}
+	}
+
+	static synchronized void add(WorkflowSystemTask systemTask) {
+		logger.info("Adding system task {}", systemTask.getName());
+		queue.add(systemTask);
+	}
+	
+	private void listen() {
+		try {
+			for(;;) {
+				WorkflowSystemTask st = queue.poll(60, TimeUnit.SECONDS);				
+				if(st != null && st.isAsync() && !listeningTasks.contains(st)) {
+					listen(st);
+					listeningTasks.add(st);
+				}
+			}
+		}catch(InterruptedException ie) {
+			logger.warn(ie.getMessage(), ie);
+		}
+	}
+	
+	private void listen(WorkflowSystemTask systemTask) {
+		Executors.newScheduledThreadPool(1).scheduleWithFixedDelay(()->pollAndExecute(systemTask), 1000, 500, TimeUnit.MILLISECONDS);
+		logger.info("Started listening {}", systemTask.getName());
+	}
+
+	private void pollAndExecute(WorkflowSystemTask systemTask) {
+		try {
+			
+			if(config.disableAsyncWorkers()) {
+				logger.warn("System Task Worker is DISABLED.  Not polling.");
+				return;
+			}
+			
+			if(workerQueue.size() >= workerQueueSize) {
+				logger.warn("All workers are busy, not polling.  queue size {}, max {}", workerQueue.size(), workerQueueSize);
+				return;
+			}
+			
+			String name = systemTask.getName();
+			List<String> polled = taskQueues.pop(name, pollCount, 200);
+			Monitors.recordTaskPoll(name);
+			logger.debug("Polling for {}, got {}", name, polled.size());
+			for(String task : polled) {
+				try {
+					es.submit(()->executor.executeSystemTask(systemTask, task, workerId, unackTimeout));
+				}catch(RejectedExecutionException ree) {
+					logger.warn("Queue full for workers {}", workerQueue.size());
+				}
+			}
+			
+		} catch (Exception e) {
+			Monitors.error(className, "pollAndExecute");
+			logger.error(e.getMessage(), e);
+		}
+	}
+	
+}	

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
@@ -18,6 +18,7 @@
  */
 package com.netflix.conductor.core.execution.tasks;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ public class WorkflowSystemTask {
 	public WorkflowSystemTask(String name) {
 		this.name = name;
 		registry.put(name, this);
+		SystemTaskWorkerCoordinator.add(this);
 	}
 
 	/**
@@ -75,6 +77,21 @@ public class WorkflowSystemTask {
 	
 	/**
 	 * 
+	 * @return True if the task is supposed to be started asynchronously using internal queues.
+	 */
+	public boolean isAsync() {
+		return false;
+	}
+	
+	/**
+	 * 
+	 * @return Time in seconds after which the task should be retried if rate limited or remains in in_progress after start method execution. 
+	 */
+	public int getRetryTimeInSecond() {
+		return 30;
+	}
+	/**
+	 * 
 	 * @return name of the system task
 	 */
 	public String getName(){
@@ -82,10 +99,9 @@ public class WorkflowSystemTask {
 	}
 	
 	@Override
-	public String toString(){
+	public String toString() {
 		return name;
 	}
-	
 	
 	public static boolean is(String type){
 		return registry.containsKey(type);
@@ -94,6 +110,9 @@ public class WorkflowSystemTask {
 	public static WorkflowSystemTask get(String type) {
 		return registry.get(type);
 	}
-
+	
+	public static Collection<WorkflowSystemTask> all() {
+		return registry.values();
+	}
 	
 }

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.netflix.conductor.common.metadata.events.EventExecution;
 import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.events.queue.Message;
@@ -70,6 +71,14 @@ public interface ExecutionDAO {
 	 *  
 	 */
 	public abstract void updateTask(Task task);
+	
+	/**
+	 * Checks if the number of tasks in progress for the given taskDef will exceed the limit if the task is scheduled to be in progress (given to the worker or for system tasks start() method called)
+	 * @param task The task to be executed.  Limit is set in the Task's definition 
+	 * @return true if by executing this task, the limit is breached.  false otherwise.
+	 * @see TaskDef#concurrencyLimit()
+	 */
+	public abstract boolean exceedsInProgressLimit(Task task);
 	
 	/**
 	 * 
@@ -193,7 +202,12 @@ public interface ExecutionDAO {
 	 */
 	public abstract long getPendingWorkflowCount(String workflowName);
 
-	
+	/**
+	 * 
+	 * @param taskDefName Name of the task
+	 * @return Number of task currently in IN_PROGRESS status
+	 */
+	public abstract long getInProgressTaskCount(String taskDefName);
 
 	/**
 	 * 

--- a/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
@@ -55,6 +55,17 @@ public interface IndexDAO {
 	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort);
 
 	/**
+	 * 
+	 * @param query SQL like query for workflow search parameters.
+	 * @param freeText	Additional query in free text.  Lucene syntax
+	 * @param start	start start index for pagination
+	 * @param count	count # of task ids to be returned
+	 * @param sort sort options
+	 * @return List of task ids for the matching query
+	 */
+	public SearchResult<String> searchTasks(String query, String freeText, int start, int count, List<String> sort);
+
+	/**
 	 * Remove the workflow index
 	 * @param workflowId workflow to be removed
 	 */

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -118,5 +118,10 @@ public interface QueueDAO {
 	 * @return key : queue name, value: map of shard name to size and unack queue size
 	 */
 	public Map<String, Map<String, Map<String, Long>>> queuesDetailVerbose();
+	
+	public default void processUnacks(String queueName) {
+		
+	}
+	
 
 }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -168,7 +168,11 @@ public class Monitors {
 	}
 
 	public static void recordQueueDepth(String taskType, long size, String ownerApp) {
-		gauge(classQualifier, "task_queue_depth", size, "taskType", taskType, "ownerApp", ownerApp);
+		gauge(classQualifier, "task_queue_depth", size, "taskType", taskType, "ownerApp", ""+ownerApp);
+	}
+	
+	public static void recordTaskInProgress(String taskType, long size, String ownerApp) {
+		gauge(classQualifier, "task_in_progress", size, "taskType", taskType, "ownerApp", ""+ownerApp);
 	}
 
 	public static void recordRunningWorkflows(long count, String name, String version, String ownerApp) {
@@ -198,5 +202,9 @@ public class Monitors {
 
 	public static void recordWorkflowCompletion(String workflowType, long duration) {
 		getTimer(classQualifier, "workflow_execution", "workflowName", workflowType).record(duration, TimeUnit.MILLISECONDS);
+	}
+
+	public static void recordTaskRateLimited(String taskDefName, int limit) {
+		gauge(classQualifier, "task_rate_limited", limit, "taskType", taskDefName);
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -34,6 +34,7 @@ import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.config.Configuration;
@@ -289,6 +290,27 @@ public class ExecutionService {
 		int missing = result.getResults().size() - workflows.size();
 		long totalHits = result.getTotalHits() - missing;
 		SearchResult<WorkflowSummary> sr = new SearchResult<>(totalHits, workflows);
+		
+		return sr;
+	}
+	
+	public SearchResult<TaskSummary> searchTasks(String query, String freeText, int start, int size, List<String> sortOptions) {
+		
+		SearchResult<String> result = indexer.searchTasks(query, freeText, start, size, sortOptions);
+		List<TaskSummary> tasks = result.getResults().stream().parallel().map(taskId -> {
+			try {
+				
+				TaskSummary summary = new TaskSummary(edao.getTask(taskId));
+				return summary;
+				
+			} catch(Exception e) {
+				logger.error(e.getMessage(), e);
+				return null;
+			}
+		}).filter(summary -> summary != null).collect(Collectors.toList());
+		int missing = result.getResults().size() - tasks.size();
+		long totalHits = result.getTotalHits() - missing;
+		SearchResult<TaskSummary> sr = new SearchResult<>(totalHits, tasks);
 		
 		return sr;
 	}

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowMonitor.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowMonitor.java
@@ -98,7 +98,11 @@ public class WorkflowMonitor {
 
 				tasks.forEach(task -> {
 					long size = queue.getSize(task.getName());
+					long inProgressCount = edao.getInProgressTaskCount(task.getName());
 					Monitors.recordQueueDepth(task.getName(), size, task.getOwnerApp());
+					if(task.concurrencyLimit() > 0) {
+						Monitors.recordTaskInProgress(task.getName(), inProgressCount, task.getOwnerApp());
+					}
 				});
 
 				refreshCounter--;

--- a/core/src/test/java/com/netflix/conductor/core/events/MockObservableQueue.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/MockObservableQueue.java
@@ -82,6 +82,10 @@ public class MockObservableQueue implements ObservableQueue {
 	}
 
 	@Override
+	public void setUnackTimeout(Message message, long unackTimeout) {
+	}
+	
+	@Override
 	public long size() {
 		return messages.size();
 	}

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
@@ -38,6 +38,11 @@ public class TestConfiguration implements Configuration {
 	public boolean disableSweep() {
 		return false;
 	}
+	
+	@Override
+	public boolean disableAsyncWorkers() {
+		return false;
+	}
 
 	@Override
 	public String getServerId() {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * 
+ */
+package com.netflix.conductor.core.execution;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.tasks.Wait;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.QueueDAO;
+
+/**
+ * @author Viren
+ *
+ */
+public class TestWorkflowExecutor {
+
+	@Test
+	public void test() throws Exception {
+		
+		AtomicBoolean httpTaskExecuted = new AtomicBoolean(false);
+		AtomicBoolean http2TaskExecuted = new AtomicBoolean(false);
+	
+		new Wait();
+		new WorkflowSystemTask("HTTP") {
+			@Override
+			public boolean isAsync() {
+				return true;
+			}
+			
+			@Override
+			public void start(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
+				httpTaskExecuted.set(true);
+				task.setStatus(Status.COMPLETED);
+				super.start(workflow, task, executor);
+			}
+			
+		};
+		
+		new WorkflowSystemTask("HTTP2") {
+			
+			@Override
+			public void start(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
+				http2TaskExecuted.set(true);
+				task.setStatus(Status.COMPLETED);
+				super.start(workflow, task, executor);
+			}
+			
+		};
+		
+		Workflow workflow = new Workflow();
+		workflow.setWorkflowId("1");
+		
+		TestConfiguration config = new TestConfiguration();
+		MetadataDAO metadata = mock(MetadataDAO.class);
+		ExecutionDAO edao = mock(ExecutionDAO.class);
+		QueueDAO queue = mock(QueueDAO.class);
+		ObjectMapper om = new ObjectMapper();
+		
+		WorkflowExecutor executor = new WorkflowExecutor(metadata, edao, queue, om, config);
+		List<Task> tasks = new LinkedList<>();
+		
+		WorkflowTask taskToSchedule = new WorkflowTask();
+		taskToSchedule.setWorkflowTaskType(Type.USER_DEFINED);
+		taskToSchedule.setType("HTTP");
+		
+		WorkflowTask taskToSchedule2 = new WorkflowTask();
+		taskToSchedule2.setWorkflowTaskType(Type.USER_DEFINED);
+		taskToSchedule2.setType("HTTP2");
+		
+		WorkflowTask wait = new WorkflowTask();
+		wait.setWorkflowTaskType(Type.WAIT);
+		wait.setType("WAIT");
+		wait.setTaskReferenceName("wait");
+		
+		Task task1 = SystemTask.userDefined(workflow, taskToSchedule, null, 0, "1", new HashMap<>());
+		Task task2 = SystemTask.waitTask(workflow.getWorkflowId(), "2", null, wait, new HashMap<>());
+		Task task3 = SystemTask.userDefined(workflow, taskToSchedule2, null, 0, "1", new HashMap<>());
+		
+		tasks.add(task1);
+		tasks.add(task2);
+		tasks.add(task3);
+		
+		
+		when(edao.createTasks(tasks)).thenReturn(tasks);
+		AtomicInteger startedTaskCount = new AtomicInteger(0);
+		doAnswer(new Answer<Void>() {
+
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				startedTaskCount.incrementAndGet();
+				return null;
+			}
+		}).when(edao).updateTask(any());
+
+		AtomicInteger queuedTaskCount = new AtomicInteger(0);		
+		doAnswer(new Answer<Void>() {
+
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				String queueName = invocation.getArgumentAt(0, String.class);
+				System.out.println(queueName);
+				queuedTaskCount.incrementAndGet();
+				return null;
+			}
+		}).when(queue).push(any(), any(), anyInt());
+
+		boolean stateChanged = executor.scheduleTask(workflow, tasks);
+		assertEquals(2, startedTaskCount.get());
+		assertEquals(1, queuedTaskCount.get());
+		assertTrue(stateChanged);
+		assertFalse(httpTaskExecuted.get());
+		assertTrue(http2TaskExecuted.get());
+	}
+	
+	
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestEvent.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestEvent.java
@@ -233,7 +233,7 @@ public class TestEvent {
 		assertEquals(Task.Status.SCHEDULED, task.getStatus());
 		
 		task.setScheduledTime(System.currentTimeMillis() - 610_000);
-		event.execute(workflow, task, null);
+		event.start(workflow, task, null);
 		assertEquals(Task.Status.FAILED, task.getStatus());
 	}
 	

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTasks.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTasks.java
@@ -32,10 +32,11 @@ public class TestSystemTasks {
 
 	@Test
 	public void test(){
+		new SubWorkflow();
 		assertTrue(SystemTaskType.is(SystemTaskType.JOIN.name()));
 		assertTrue(SystemTaskType.is(SystemTaskType.FORK.name()));
 		assertTrue(SystemTaskType.is(SystemTaskType.DECISION.name()));
-		assertTrue(SystemTaskType.is(SystemTaskType.SUB_WORKFLOW.name()));
+		assertTrue(SystemTaskType.is(SubWorkflow.NAME));
 	}
 
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -46,7 +46,9 @@ services:
           - dyno1
 
   elasticsearch:
-    image: elasticsearch:2.4
+    environment:
+      - xpack.security.enabled=false
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.0
     ports:
       - 9300:9300
       - 9200:9200

--- a/redis-persistence/build.gradle
+++ b/redis-persistence/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compile 'org.elasticsearch:elasticsearch:2.+'
 	compile 'org.elasticsearch:elasticsearch:5.3.0'
 	compile 'org.elasticsearch.client:transport:5.3.0'
+	compile 'org.elasticsearch.client:x-pack-transport:5.3.0'
 
 	//In memory redis for unit testing
  	testCompile 'org.rarefiedredis.redis:redis-java:0.0.17'

--- a/redis-persistence/build.gradle
+++ b/redis-persistence/build.gradle
@@ -7,6 +7,8 @@ dependencies {
  	compile ('com.netflix.dyno-queues:dyno-queues-redis:1.0.6') {
  	}
 	compile 'org.elasticsearch:elasticsearch:2.+'
+	compile 'org.elasticsearch:elasticsearch:5.3.0'
+	compile 'org.elasticsearch.client:transport:5.3.0'
 
 	//In memory redis for unit testing
  	testCompile 'org.rarefiedredis.redis:redis-java:0.0.17'

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/DynoProxy.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/DynoProxy.java
@@ -38,6 +38,7 @@ import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.Tuple;
+import redis.clients.jedis.params.sortedset.ZAddParams;
 
 /**
  * 
@@ -116,6 +117,12 @@ public class DynoProxy {
 		return retVal;
 	}
 
+	public Long zaddnx(String key, double score, String member) {
+		ZAddParams params = ZAddParams.zAddParams().nx();
+		Long retVal = dynoClient.zadd(key, score, member, params);
+		return retVal;
+	}
+
 	public Long hset(String key, String field, String value) {
 		Long retVal = dynoClient.hset(key, field, value);
 		return retVal;
@@ -123,6 +130,11 @@ public class DynoProxy {
 	
 	public Long hsetnx(String key, String field, String value) {
 		Long retVal = dynoClient.hsetnx(key, field, value);
+		return retVal;
+	}
+	
+	public Long hlen(String key) {
+		Long retVal = dynoClient.hlen(key);
 		return retVal;
 	}
 
@@ -207,6 +219,10 @@ public class DynoProxy {
 		logger.trace("srem {} {}", key, member);
 		Long retVal = dynoClient.srem(key, member);
 		return retVal;
+	}
+	
+	public boolean sismember(String key, String member) {
+		return dynoClient.sismember(key, member);
 	}
 
 	public Set<String> smembers(String key) {

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -89,7 +89,7 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 		Map<String, TaskDef> map = new HashMap<>();
 		getAllTaskDefs().forEach(taskDef -> map.put(taskDef.getName(), taskDef));
 		this.taskDefCache = map;
-		logger.info("Refreshed task defs " + this.taskDefCache.size());
+		logger.debug("Refreshed task defs " + this.taskDefCache.size());
 	}
 	
 	@Override

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -17,10 +17,13 @@ package com.netflix.conductor.dao.dynomite;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -49,9 +52,14 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 	private final static String EVENT_HANDLERS_BY_EVENT = "EVENT_HANDLERS_BY_EVENT";
 	private final static String LATEST = "latest";
 
+	private Map<String, TaskDef> taskDefCache = new HashMap<>();
+	
 	@Inject
 	public RedisMetadataDAO(DynoProxy dynoClient, ObjectMapper om, Configuration config) {
 		super(dynoClient, om, config);
+		refreshTaskDefs();
+		int cacheRefreshTime = config.getIntProperty("conductor.taskdef.cache.refresh.time.seconds", 60);
+		Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(()->refreshTaskDefs(), cacheRefreshTime, cacheRefreshTime, TimeUnit.SECONDS);
 	}
 
 	@Override
@@ -73,20 +81,34 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 
 		// Store all task def in under one key
 		dynoClient.hset(nsKey(ALL_TASK_DEFS), taskDef.getName(), toJson(taskDef));
-
+		refreshTaskDefs();
 		return taskDef.getName();
 	}
 
+	private void refreshTaskDefs() {
+		Map<String, TaskDef> map = new HashMap<>();
+		getAllTaskDefs().forEach(taskDef -> map.put(taskDef.getName(), taskDef));
+		this.taskDefCache = map;
+		logger.info("Refreshed task defs " + this.taskDefCache.size());
+	}
+	
 	@Override
 	public TaskDef getTaskDef(String name) {
+		TaskDef taskDef = taskDefCache.get(name);
+		if(taskDef == null) {
+			taskDef = getTaskDefFromDB(name);
+		}
+		return taskDef;
+	}
+	
+	public TaskDef getTaskDefFromDB(String name) {
 		Preconditions.checkNotNull(name, "TaskDef name cannot be null");
+		
 		TaskDef taskDef = null;
-
 		String taskDefJsonStr = dynoClient.hget(nsKey(ALL_TASK_DEFS), name);
 		if (taskDefJsonStr != null) {
 			taskDef = readValue(taskDefJsonStr, TaskDef.class);
-		}
-
+		}	
 		return taskDef;
 	}
 
@@ -113,6 +135,7 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 		if (!result.equals(1L)) {
 			throw new ApplicationException(Code.NOT_FOUND, "Cannot remove the task - no such task definition");
 		}
+		refreshTaskDefs();
 	}
 
 	@Override

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
@@ -39,6 +39,7 @@ import com.netflix.dyno.queues.DynoQueue;
 import com.netflix.dyno.queues.Message;
 import com.netflix.dyno.queues.ShardSupplier;
 import com.netflix.dyno.queues.redis.DynoShardSupplier;
+import com.netflix.dyno.queues.redis.RedisDynoQueue;
 import com.netflix.dyno.queues.redis.RedisQueues;
 
 import redis.clients.jedis.JedisCommands;
@@ -200,6 +201,10 @@ public class DynoQueueDAO implements QueueDAO {
 		Map<String, Map<String, Map<String, Long>>> map = queues.queues().stream()
 				.collect(Collectors.toMap(queue -> queue.getName(), q -> q.shardSizes()));
 		return map;
+	}
+	
+	public void processUnacks(String queueName) {
+		((RedisDynoQueue)queues.get(queueName)).processUnacks();;
 	}
 
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticSearchDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticSearchDAO.java
@@ -329,13 +329,25 @@ public class ElasticSearchDAO implements IndexDAO {
 
 		try {
 			
-			return search(query, start, count, sort, freeText);
+			return search(query, start, count, sort, freeText, WORKFLOW_DOC_TYPE);
 			
 		} catch (ParserException e) {
 			throw new ApplicationException(Code.BACKEND_ERROR, e.getMessage(), e);
 		}
 	}
 
+	@Override
+	public SearchResult<String> searchTasks(String query, String freeText, int start, int count, List<String> sort) {
+
+		try {
+			
+			return search(query, start, count, sort, freeText, TASK_DOC_TYPE);
+			
+		} catch (ParserException e) {
+			throw new ApplicationException(Code.BACKEND_ERROR, e.getMessage(), e);
+		}
+	}
+	
 	@Override
 	public void remove(String workflowId) {
 		try {
@@ -367,7 +379,7 @@ public class ElasticSearchDAO implements IndexDAO {
 		}
 	}
 	
-	private SearchResult<String> search(String structuredQuery, int start, int size, List<String> sortOptions, String freeTextQuery) throws ParserException {
+	private SearchResult<String> search(String structuredQuery, int start, int size, List<String> sortOptions, String freeTextQuery, String type) throws ParserException {
 		QueryBuilder qf = QueryBuilders.matchAllQuery();
 		if(StringUtils.isNotEmpty(structuredQuery)) {
 			Expression expression = Expression.fromString(structuredQuery);
@@ -377,7 +389,7 @@ public class ElasticSearchDAO implements IndexDAO {
 		BoolQueryBuilder filterQuery = QueryBuilders.boolQuery().must(qf);
 		QueryStringQueryBuilder stringQuery = QueryBuilders.queryStringQuery(freeTextQuery);
 		BoolQueryBuilder fq = QueryBuilders.boolQuery().must(stringQuery).must(filterQuery);
-		final SearchRequestBuilder srb = client.prepareSearch(indexName).setQuery(fq).setTypes(WORKFLOW_DOC_TYPE).storedFields("_id").setFrom(start).setSize(size);
+		final SearchRequestBuilder srb = client.prepareSearch(indexName).setQuery(fq).setTypes(type).storedFields("_id").setFrom(start).setSize(size);
 		if(sortOptions != null){
 			sortOptions.forEach(sortOption -> {
 				SortOrder order = SortOrder.ASC;
@@ -398,6 +410,6 @@ public class ElasticSearchDAO implements IndexDAO {
 		long count = response.getHits().getTotalHits();
 		return new SearchResult<String>(count, result);
 	}
-	
-	
+
+
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticsearchModule.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticsearchModule.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.elasticsearch.xpack.client.PreBuiltXPackTransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.slf4j.Logger;
@@ -42,6 +43,8 @@ import com.netflix.conductor.core.config.Configuration;
 public class ElasticsearchModule extends AbstractModule {
 
 	private static Logger log = LoggerFactory.getLogger(ElasticSearchDAO.class);
+	private static final String DEFAULT_USER = "elastic";
+	private static final String DEFAULT_PASSWORD = "changeme";
 	
 	@Provides
 	@Singleton
@@ -52,10 +55,17 @@ public class ElasticsearchModule extends AbstractModule {
 			log.warn("workflow.elasticsearch.url is not set.  Indexing will remain DISABLED.");
 		}
 		
+		String credentials = config.getProperty("elasticsearch.xpack.security.user", "");
+		if(credentials.equals("")) {
+			credentials = DEFAULT_USER + ":" + DEFAULT_PASSWORD;
+			log.warn("elasticsearch.xpack.security.user is not set.  Will try using default values: " + credentials);
+		}
+		
         Settings settings = Settings.builder().put("client.transport.ignore_cluster_name",true)
-                                              .put("client.transport.sniff", true).build();
+                                              .put("client.transport.sniff", true)
+                                              .put("xpack.security.user", credentials).build();
         
-        TransportClient tc = new PreBuiltTransportClient(settings);
+        TransportClient tc = new PreBuiltXPackTransportClient(settings);
         String[] hosts = clusterAddress.split(",");
         for (String host : hosts) {
             String[] hostparts = host.split(":");

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticsearchModule.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/index/ElasticsearchModule.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.slf4j.Logger;
@@ -51,11 +52,10 @@ public class ElasticsearchModule extends AbstractModule {
 			log.warn("workflow.elasticsearch.url is not set.  Indexing will remain DISABLED.");
 		}
 		
-    	Settings.Builder settings = Settings.settingsBuilder();
-        settings.put("client.transport.ignore_cluster_name", true);
-        settings.put("client.transport.sniff", true);
+        Settings settings = Settings.builder().put("client.transport.ignore_cluster_name",true)
+                                              .put("client.transport.sniff", true).build();
         
-        TransportClient tc = TransportClient.builder().settings(settings).build();
+        TransportClient tc = new PreBuiltTransportClient(settings);
         String[] hosts = clusterAddress.split(",");
         for (String host : hosts) {
             String[] hostparts = host.split(":");

--- a/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -40,6 +40,11 @@ public class TestConfiguration implements Configuration {
 	}
 
 	@Override
+	public boolean disableAsyncWorkers() {
+		return false;
+	}
+	
+	@Override
 	public String getServerId() {
 		return "server_id";
 	}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -39,6 +39,13 @@ dependencies {
 	
 	//In memory
 	compile 'org.rarefiedredis.redis:redis-java:0.0.17'
+
+	//log4j
+	compile 'org.apache.logging.log4j:log4j-api:2.8.+'
+	compile 'org.apache.logging.log4j:log4j-core:2.8.+'
+
+	//netty
+	compile 'org.elasticsearch.plugin:transport-netty4-client:5.3.0'
 }
 
 shadowJar {

--- a/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
@@ -54,6 +54,12 @@ public class ConductorConfig implements Configuration {
 	}
 
 	@Override
+	public boolean disableAsyncWorkers() {
+		String disable = getProperty("conductor.disable.async.workers", "false");
+		return Boolean.getBoolean(disable);
+	}
+	
+	@Override
 	public String getServerId() {
 		try {
 			return InetAddress.getLocalHost().getHostName();

--- a/server/src/main/resources/log4j2.properties
+++ b/server/src/main/resources/log4j2.properties
@@ -1,0 +1,6 @@
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+
+rootLogger.level = Aall
+rootLogger.appenderRef.console.ref = console

--- a/server/src/main/resources/log4j2.properties
+++ b/server/src/main/resources/log4j2.properties
@@ -2,5 +2,5 @@ appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
 
-rootLogger.level = Aall
+rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = console

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
@@ -55,7 +55,9 @@ public class TestModule extends AbstractModule {
 	
 	@Override
 	protected void configure() {
-		
+		System.setProperty("workflow.system.task.worker.callback.seconds", "0");
+		System.setProperty("workflow.system.task.worker.queue.size", "10000");
+		System.setProperty("workflow.system.task.worker.thread.count", "10");
 		configureExecutorService();
 		ConductorConfig config = new ConductorConfig();
 		bind(Configuration.class).toInstance(config);
@@ -79,11 +81,12 @@ public class TestModule extends AbstractModule {
 		bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
 		bind(DynoQueueDAO.class).toInstance(queueDao);
 		bind(QueueDAO.class).to(DynoQueueDAO.class);
-		bind(IndexDAO.class).to(MockIndexDAO.class);
-		
+		bind(IndexDAO.class).to(MockIndexDAO.class);		
 		DynoProxy proxy = new DynoProxy(jedisMock);
 		bind(DynoProxy.class).toInstance(proxy);
 		install(new CoreModule());
+		bind(UserTask.class).asEagerSingleton();
+		
 	}
 	
 	@Provides

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/UserTask.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/UserTask.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * 
+ */
+package com.netflix.conductor.tests.utils;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+
+/**
+ * @author Viren
+ *
+ */
+public class UserTask extends WorkflowSystemTask {
+
+	public UserTask() {
+		super("USER_TASK");
+	}
+	
+	@Override
+	public void start(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
+		Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+		task.setStatus(Status.COMPLETED);
+	}
+	
+	@Override
+	public boolean isAsync() {
+		return true;
+	}
+}

--- a/ui/src/api/wfe.js
+++ b/ui/src/api/wfe.js
@@ -49,7 +49,7 @@ router.get('/id/:workflowId', async (req, res, next) => {
     const subworkflows = {};
     result.tasks.forEach(task=>{
       if(task.taskType == 'SUB_WORKFLOW'){
-        subs.push({name: task.inputData.subWorkflowName, version: task.inputData.subWorkflowVersion, referenceTaskName: task.referenceTaskName, subWorkflowId: task.inputData.subWorkflowId});
+        subs.push({name: task.inputData.subWorkflowName, version: task.inputData.subWorkflowVersion, referenceTaskName: task.referenceTaskName, subWorkflowId: task.outputData.subWorkflowId});
       }
     });
     let submeta = {};

--- a/ui/src/api/wfegraph.js
+++ b/ui/src/api/wfegraph.js
@@ -75,6 +75,10 @@ class Workflow2Graph {
           style = 'stroke: #cccccc; fill: #ccc';
           labelStyle = 'fill:#ffffff; stroke-width: 1px';
           break;
+        case 'NO_OP':
+          style = 'stroke: #cccccc; fill: #ccc';
+          labelStyle = 'fill:#ffffff; stroke-width: 1px';
+          break;
         case '':
           break;
         default:


### PR DESCRIPTION
Couple of Notes:

1. Technically Elasticsearch says Embedded Elasticsearch is not supported:
https://www.elastic.co/blog/elasticsearch-the-server

I went with an approach similar to
https://github.com/elastic/elasticsearch-hadoop/blob/fefcf8b191d287aca93a04144c67b803c6c81db5/mr/src/itest/java/org/elasticsearch/hadoop/EsEmbeddedServer.java
for the Embedded Elasticsearch that is used for the in memory persistence.


2. The new elasticsearch is preinstalled with X-Pack:
https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html

Therefore the transport client is having connection issues since there is authentication (default username: elastic/ default password: changeme)

For a quick and easy bringup with the docker-compose, I have elected to disable this security feature in the docker-compose.yml for now:

```
 environment:
     - xpack.security.enabled=false
```


