### PR TITLE
Add OAuth 1.0 authentication support to HTTP tasks

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -5,13 +5,13 @@ dependencies {
 
 	compile 'com.amazonaws:aws-java-sdk-sqs:latest.release'
 	compile ('com.google.inject:guice:4.1+') { force= true}
-	
+
+	compile 'com.sun.jersey.contribs.jersey-oauth:oauth-client:1.19.+'
+	compile 'com.sun.jersey.contribs.jersey-oauth:oauth-signature:1.19.+'
+
 	provided 'javax.ws.rs:jsr311-api:1.1.1'
 	provided 'io.swagger:swagger-jaxrs:1.5.9'
-	
-	
+
 	testCompile 'org.eclipse.jetty:jetty-server:9.3.9.+'
 	testCompile 'org.eclipse.jetty:jetty-servlet:9.3.9.+'
-	
-    
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -47,6 +47,9 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.UniformInterfaceException;
 import com.sun.jersey.api.client.WebResource.Builder;
+import com.sun.jersey.oauth.client.OAuthClientFilter;
+import com.sun.jersey.oauth.signature.OAuthParameters;
+import com.sun.jersey.oauth.signature.OAuthSecrets;
 
 /**
  * @author Viren
@@ -144,7 +147,16 @@ public class HttpTask extends WorkflowSystemTask {
 	 */
 	protected HttpResponse httpCall(Input input) throws Exception {
 		Client client = rcm.getClient(input);
+
+		if(input.oauthConsumerKey != null) {
+			logger.info("Configuring OAuth filter");
+			OAuthParameters params = new OAuthParameters().consumerKey(input.oauthConsumerKey).signatureMethod("HMAC-SHA1").version("1.0");
+			OAuthSecrets secrets = new OAuthSecrets().consumerSecret(input.oauthConsumerSecret);
+			client.addFilter(new OAuthClientFilter(client.getProviders(), params, secrets));
+		}
+
 		Builder builder = client.resource(input.uri).type(MediaType.APPLICATION_JSON);
+
 		if(input.body != null) {
 			builder.entity(input.body);
 		}
@@ -275,6 +287,10 @@ public class HttpTask extends WorkflowSystemTask {
 		private Object body;
 		
 		private String accept = MediaType.APPLICATION_JSON;
+		
+		private String oauthConsumerKey;
+
+		private String oauthConsumerSecret;
 
 		/**
 		 * @return the method
@@ -362,5 +378,32 @@ public class HttpTask extends WorkflowSystemTask {
 			this.accept = accept;
 		}
 		
+		/**
+		 * @return the OAuth consumer Key
+		 */
+		public String getOauthConsumerKey() {
+			return oauthConsumerKey;
+		}
+
+		/**
+		 * @param oauthConsumerKey the OAuth consumer key to set
+		 */
+		public void setOauthConsumerKey(String oauthConsumerKey) {
+			this.oauthConsumerKey = oauthConsumerKey;
+		}
+
+		/**
+		 * @return the OAuth consumer secret
+		 */
+		public String getOauthConsumerSecret() {
+			return oauthConsumerSecret;
+		}
+
+		/**
+		 * @param oauthConsumerSecret the OAuth consumer secret to set
+		 */
+		public void setOauthConsumerSecret(String oauthConsumerSecret) {
+			this.oauthConsumerSecret = oauthConsumerSecret;
+		}
 	}
 }


### PR DESCRIPTION
This small PR adds support for calling HTTP endpoints secured with OAuth 1.0

If the OAuth parameters (consumer key and consumer secret) are present in the input parameters for the HTTP tasks, those will be used for authentication against the endpoint.

We tested this internally successfully with our OAuth endpoints.
