### PR TITLE
adds information about how to run it on docker compose

### DIFF
--- a/docs/docs/intro/index.md
+++ b/docs/docs/intro/index.md
@@ -33,13 +33,21 @@ Swagger APIs can be accessed at [http://localhost:8080/](http://localhost:8080/)
 cd ui
 gulp watch
 ```
-Launch UI at [http://localhost:3000/](http://localhost:3000/)
+
+#### Or Start all the services using [docker-compose](/docker/docker-compose.yaml)
+
+```shell
+cd docker
+docker-compose up
+```
+
+If you ran it locally, launch UI at [http://localhost:3000/](http://localhost:3000/) or if you have ran it using docker-compose launch the UI at [http://localhost:5000/](http://localhost:5000/)
 
 !!!Note:
 	The server will load a sample kitchen sink workflow definition by default.  See [here](/metadata/kitchensink/) for details.
 
 
-#Runtime Model
+# Runtime Model
 Conductor follows RPC based communication model where workers are running on a separate machine from the server.  Workers communicate with server over HTTP based endpoints and employs polling model for managing work queues.
 
 ![name_for_alt](overview.png)

--- a/docs/docs/intro/index.md
+++ b/docs/docs/intro/index.md
@@ -18,7 +18,7 @@ Follow the steps below to quickly bring up a local Conductor instance backed by 
 #### Checkout the source from github
 
 ```
-git clone git@github.com/Netflix/conductor.git
+git clone https://github.com/Netflix/conductor.git
 ```
 #### Start Local Server
 ```shell


### PR DESCRIPTION
I'm reading/following the quickstart documentation (more specifically the intro) and I saw that it was possible to use `docker-compose` and I thought it'd be good to have this information there.

About the `clone` change, I was following the quickstart guide and then it raised a silly error.

> $ git clone git@github.com/Netflix/conductor.git
> fatal: repository 'git@github.com/Netflix/conductor.git' does not exist