### PR TITLE
adds full cloned repository

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -y \
   && chmod +x /app/startup.sh
 
 # Get and install conductor
-RUN git clone --depth 1 https://github.com/Netflix/conductor.git \
+RUN git clone https://github.com/Netflix/conductor.git \
   && cd conductor \
   && ./gradlew build -x test \
 

--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -y \
   && apt-get install -y nodejs build-essential
 
 # Get and install conductor
-RUN git clone --depth 1 https://github.com/Netflix/conductor.git \
+RUN git clone https://github.com/Netflix/conductor.git \
   && cd conductor \
   && ./gradlew build -x test \
 

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y \
   && chmod +x /app/startup.sh
 
 # Get and install conductor UI
-RUN git clone --depth 1 https://github.com/netflix/conductor.git \
+RUN git clone https://github.com/netflix/conductor.git \
 
   # Get UI project
   && mv /conductor/ui /app \


### PR DESCRIPTION
The plugin `nebula.netflixoss` (walk) requires a "full" cloned repo otherwise, the build will fail.
```
FAILURE: Build failed with an exception.

* Where:
Build file '/conductor/build.gradle' line: 13

* What went wrong:
An exception occurred applying plugin request [id: 'nebula.netflixoss', version: '3.6.0']
> Failed to apply plugin [class 'nebula.plugin.bintray.NebulaBintrayPublishingPlugin']
   > Walk failure.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```