### PR TITLE
HTTP task : add HTTP reason phrase in the response metadata

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -177,6 +177,7 @@ public class HttpTask extends WorkflowSystemTask {
 				response.body = extractBody(cr);
 			}
 			response.statusCode = cr.getStatus();
+			response.reasonPhrase = cr.getStatusInfo().getReasonPhrase();
 			response.headers = cr.getHeaders();
 			return response;
 
@@ -191,6 +192,7 @@ public class HttpTask extends WorkflowSystemTask {
 				}
 				response.headers = cr.getHeaders();
 				response.statusCode = cr.getStatus();
+				response.reasonPhrase = cr.getStatusInfo().getReasonPhrase();
 				return response;
 				
 			}else {
@@ -263,9 +265,11 @@ public class HttpTask extends WorkflowSystemTask {
 		
 		public int statusCode;
 
+		public String reasonPhrase;
+
 		@Override
 		public String toString() {
-			return "HttpResponse [body=" + body + ", headers=" + headers + ", statusCode=" + statusCode + "]";
+			return "HttpResponse [body=" + body + ", headers=" + headers + ", statusCode=" + statusCode + ", reasonPhrase=" + reasonPhrase + "]";
 		}
 		
 		public Map<String, Object> asMap() {
@@ -274,6 +278,7 @@ public class HttpTask extends WorkflowSystemTask {
 			map.put("body", body);
 			map.put("headers", headers);
 			map.put("statusCode", statusCode);
+			map.put("reasonPhrase", reasonPhrase);
 			
 			return map;
 		}


### PR DESCRIPTION
When debugging failing HTTP tasks, it's helpful to include the HTTP reason phrase instead of exposing only the status code. This is specially useful for non common status codes.

Here is an example output for an HTTP task returning a 424 (Failed Dependency) response code:

```
{
   "response": {
      "headers": {
         ...
      },
      "reasonPhrase": "Failed Dependency",
      "body": {
         "code": "EXTERNAL_ERROR",
         "message": "An error occurred while creating or modifying your account"
      },
      "statusCode": 424
   }
}
```