### PR TITLE
Add an optional description in WorkflowTask model

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -59,7 +59,9 @@ public class WorkflowTask {
 	private String name;
 	
 	private String taskReferenceName;
-	
+
+	private String description;
+
 	//Key: Name of the input parameter.  MUST be one of the keys defined in TaskDef (e.g. fileName)
 	//Value: mapping of the parameter from another task (e.g. task1.someOutputParameterAsFileName)
 	private Map<String, Object> inputParameters = new HashMap<String, Object>();
@@ -122,6 +124,20 @@ public class WorkflowTask {
 	 */
 	public void setTaskReferenceName(String taskReferenceName) {
 		this.taskReferenceName = taskReferenceName;
+	}
+
+	/**
+	 * @return the description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @param description the description to set
+	 */
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	/**

--- a/docs/docs/metadata/index.md
+++ b/docs/docs/metadata/index.md
@@ -98,7 +98,7 @@ Below are the mandatory minimum parameters required for each task:
 |name|Name of the task.  MUST be registered as a task type with Conductor before starting workflow||
 |taskReferenceName|Alias used to refer the task within the workflow.  MUST be unique.||
 |type|Type of task. SIMPLE for tasks executed by remote workers, or one of the system task types||
-|description|Optional description of the task.||
+|description|Description of the task|optional|
 |optional|true  or false.  When set to true - workflow continues even if the task fails.  The status of the task is reflected as `COMPLETED_WITH_ERRORS`|Defaults to `false`|
 |inputParameters|JSON template that defines the input given to the task|See "wiring inputs and outputs" for details|
 

--- a/docs/docs/metadata/index.md
+++ b/docs/docs/metadata/index.md
@@ -98,6 +98,7 @@ Below are the mandatory minimum parameters required for each task:
 |name|Name of the task.  MUST be registered as a task type with Conductor before starting workflow||
 |taskReferenceName|Alias used to refer the task within the workflow.  MUST be unique.||
 |type|Type of task. SIMPLE for tasks executed by remote workers, or one of the system task types||
+|description|Optional description of the task.||
 |optional|true  or false.  When set to true - workflow continues even if the task fails.  The status of the task is reflected as `COMPLETED_WITH_ERRORS`|Defaults to `false`|
 |inputParameters|JSON template that defines the input given to the task|See "wiring inputs and outputs" for details|
 


### PR DESCRIPTION
Hello,

We thought it would be useful to allow workflow designers to add a description in tasks. For instance, considering a generic task like the HTTP system task, its usage may differ from one to another. Thus, being able to specify what is happening could be useful.

Thanks in advance for any feedback!

Nicolas