### PR TITLE
Migrate docker images to Alpine Linux

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,42 +1,22 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jdk
+FROM java:8-jre-alpine
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 
 # Make app folders
 RUN mkdir -p /app/config /app/logs /app/libs
 
-# Startup script(s)
-COPY ./bin /app
+# Copy the project directly onto the image
+COPY ./docker/server/bin /app
+COPY ./docker/server/config /app/config
+COPY ./server/build/libs/conductor-server-*-all.jar /app/libs
 
-# Configs
-COPY ./config /app/config
-
-# Get all the dependencies
-RUN apt-get update -y \
-  && apt-get -y install git \
-
-  # Chmod scripts
-  && chmod +x /app/startup.sh
-
-# Get and install conductor
-RUN git clone https://github.com/Netflix/conductor.git \
-  && cd conductor \
-  && ./gradlew build -x test \
-
-  # Get Server Jar
-  && mv ./server/build/libs/conductor-server-*-all.jar /app/libs/ \
-
-  # Go back to root
-  && cd / \
-
-  # Clean up
-  && rm -rf conductor
-
+# Copy the files for the server into the app folders
+RUN chmod +x /app/startup.sh
 
 EXPOSE 8080
 
-CMD ["/app/startup.sh"]
-ENTRYPOINT ["/bin/bash"]
+CMD [ "/app/startup.sh" ]
+ENTRYPOINT [ "/bin/sh"]

--- a/docker/server/Dockerfile.build
+++ b/docker/server/Dockerfile.build
@@ -1,0 +1,13 @@
+#
+# conductor:server - Netflix conductor server
+#
+FROM java:8-jdk
+
+MAINTAINER Netflix OSS <conductor@netflix.com>
+
+# Copy the project directly onto the image
+COPY . /conductor
+WORKDIR /conductor
+
+# Build the server on run
+ENTRYPOINT ./gradlew build -x test

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -3,7 +3,12 @@
 This Dockerfile create the conductor:server image
 
 ## Building the image
-`docker build -t conductor:server .`
+
+Run the following commands from the project root.
+
+`docker build -f docker/server/Dockerfile.build -t conductor:server-build .`
+`docker run -v $(pwd):/conductor conductor:server-build`
+`docker build -f docker/server/Dockerfile -t conductor:server .`
 
 ## Running the conductor server
  - Standalone server (interal DB): `docker run -p 8080:8080 -d -t conductor:server`

--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # startup.sh - startup script for the server docker image
 
 echo "Starting Conductor server"
@@ -18,4 +18,4 @@ if [ -z "$CONFIG_PROP" ];
     export config_file=/app/config/$CONFIG_PROP
 fi
 
-nohup java -jar conductor-server-*-all.jar $config_file 1>&2 > /app/logs/server.log
+java -jar conductor-server-*-all.jar $config_file

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -1,38 +1,42 @@
 #
 # conductor:ui - Netflix conductor UI
 #
-FROM node
-
+FROM node:alpine
 MAINTAINER Netflix OSS <conductor@netflix.com>
 
+# Install the required packages for the node build
+# to run on alpine
+RUN apk update && apk add \
+  autoconf \
+  automake \
+  libtool \
+  build-base \
+  libstdc++ \
+  gcc \
+  abuild \
+  binutils \
+  nasm \
+  libpng \
+  libpng-dev \
+  libjpeg-turbo \
+  libjpeg-turbo-dev 
+
 # Make app folders
-RUN mkdir -p /app/config /app/logs /app/libs
+RUN mkdir -p /app/ui
 
-# Startup script(s)
-COPY ./bin /app
+# Copy the ui files onto the image
+COPY ./docker/ui/bin /app
+COPY ./ui /app/ui
 
-# Get all the dependencies
-RUN apt-get update -y \
-  && apt-get -y install git \
-
-  # Chmod scripts
-  && chmod +x /app/startup.sh
+# Copy the files for the server into the app folders
+RUN chmod +x /app/startup.sh
 
 # Get and install conductor UI
-RUN git clone https://github.com/netflix/conductor.git \
-
-  # Get UI project
-  && mv /conductor/ui /app \
-
-  # Remove the conductor project
-  && rm -rf conductor \
-
-  # Install UI packages
-  && cd /app/ui \
+RUN cd /app/ui \
   && npm install \
   && npm run build --server
 
 EXPOSE 5000
 
-CMD ["/app/startup.sh"]
-ENTRYPOINT ["/bin/bash"]
+CMD [ "/app/startup.sh" ]
+ENTRYPOINT ["/bin/sh"]

--- a/docker/ui/README.md
+++ b/docker/ui/README.md
@@ -3,7 +3,10 @@
 This Dockerfile create the conductor:ui image
 
 ## Building the image
-`docker build -t conductor:ui .`
+
+Run the following commands from the project root.
+
+`docker build -f docker/ui/Dockerfile -t conductor:ui .`
 
 ## Running the conductor server
  - With localhost conductor server: `docker run -p 5000:5000 -d -t conductor:ui`

--- a/docker/ui/bin/startup.sh
+++ b/docker/ui/bin/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # startup.sh - startup script for the UI docker image
 
 echo "Starting Conductor UI"
@@ -12,4 +12,4 @@ if [ -z "$WF_SERVER" ];
     echo "using Conductor API server from '$WF_SERVER'"
 fi
 
-nohup node server.js 1>&2 > /app/logs/ui.log
+node server.js


### PR DESCRIPTION
Pull Request for Issue #280 

Objectives
-----------
* Migrate server build to a 2-step process where the server is built using the java:8-jdk and is then copied to a java:8-jre-alpine runtime image.
* Migrate ui build to a node:alpine image.
* Run ui and api in the foreground.
* Log to STDOUT instead of log files.

Details
-------
* Modified the dockerfiles to use Alpine as the base image.
* Modified the dockerfiles to load the code from the local context in order to allow users to build docker images which contain changes which have not yet been merged into netflix/conductor:master.
* Modified the startup scripts to remove the `nohup` command and to instead run the application in the foreground.  
* Modified the startup scripts to remove the stream redirect into log files so that the message stream is sent directly to STDOUT.
* Updated the readme files to instruct users to execute the docker builds from the project root so that the context parameter `.` will move all of the required files to the image at build time.