### PR TITLE
Docker compose fix

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,9 @@
 This dockerfile runs using dynomite and elasticsearch. The conductor is split into the backend (server) and the frontend (ui). If an image with both of these items combined is desired, build the Dockerfile in the folder serverAndUI
 
 ## Building the image
+Dependency (build the jar files in ./server from project root)
+- `gradlew build`
+
 Building the images:
  - `docker build -t conductor:server ./server`
  - `docker build -t conductor:ui ./ui`

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
       - CONFIG_PROP=config.properties
     image: conductor:server
     build:
-      context: ./server
-      dockerfile: Dockerfile
+      context: ../
+      dockerfile: docker/server/Dockerfile
     ports:
       - 8080:8080
     links:
@@ -19,8 +19,8 @@ services:
       - WF_SERVER=http://conductor-server:8080/api/
     image: conductor:ui
     build:
-      context: ./ui
-      dockerfile: Dockerfile
+      context: ../
+      dockerfile: docker/ui/Dockerfile
     ports:
       - 5000:5000
     links:


### PR DESCRIPTION
Update README to include dependency on running `gradlew build`
Change build context in docker-compose to enable child Dockerfiles to reference the ./server and ./ui paths