### PR TITLE
polling tasks only when worker is not fully occupied

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -133,14 +133,16 @@ public class SystemTaskWorkerCoordinator {
 				logger.warn("System Task Worker is DISABLED.  Not polling.");
 				return;
 			}
-			
-			if(workerQueue.size() >= workerQueueSize) {
-				logger.warn("All workers are busy, not polling.  queue size {}, max {}", workerQueue.size(), workerQueueSize);
-				return;
+
+			// get the remaining capacity of worker queue to prevent queue full exception
+			int realPollCount = Math.min(workerQueue.remainingCapacity(), pollCount);
+			if (realPollCount <= 0) {
+                logger.warn("All workers are busy, not polling.  queue size {}, max {}", workerQueue.size(), workerQueueSize);
+                return;
 			}
-			
+
 			String name = systemTask.getName();
-			List<String> polled = taskQueues.pop(name, pollCount, 200);
+			List<String> polled = taskQueues.pop(name, realPollCount, 200);
 			Monitors.recordTaskPoll(name);
 			logger.debug("Polling for {}, got {}", name, polled.size());
 			for(String task : polled) {


### PR DESCRIPTION
Without this PR, this worker keeps polling tasks even though it is currently fully occupied, the consequence is that:
                a). even if we start another instance (B) of worker to help, it may not be able to get any tasks, it would be idle even though A has tasks on the queue waiting to be executed
                b). if the max size of the queue is reached, tasks would be dropped as exception happens
