### PR TITLE
Allow overriding UI port with environment variable

### DIFF
--- a/ui/src/server.js
+++ b/ui/src/server.js
@@ -18,7 +18,7 @@ app.use('/api/wfe', wfeAPI);
 app.use('/api/sys', sysAPI);
 app.use('/api/events', eventsAPI);
 
-let server = app.listen(5000, function () {
+let server = app.listen(process.env.NODE_PORT || 5000, function () {
   var host = server.address().address;
   var port = server.address().port;
   log.info('Workflow UI listening at http://%s:%s', host, port);


### PR DESCRIPTION
This PR is simply to allow overriding the NodeJS port for the UI using an environment variable (NODE_PORT)