### PR TITLE
Fix : Cannot override system properties when launching the conductor server using the gradle command-line

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -76,6 +76,7 @@ build.dependsOn('shadowJar')
 task server(type: JavaExec) {
   systemProperty 'workflow.elasticsearch.url', 'localhost:9300'
   systemProperty 'loadSample', 'true'
+  systemProperties System.properties
   main = 'com.netflix.conductor.server.Main'
   classpath = sourceSets.test.runtimeClasspath  
 }


### PR DESCRIPTION
Currently, if you try to override system properties when launching the conductor server, those are not taken into consideration

Example : `../gradlew server -DloadSample=false -Dport=8888`

This PR adds a missing line in the gradle build to allow overrides from the command-line