### PR TITLE
Fix incorrect dyno-jedis dependency version

### DIFF
--- a/redis-persistence/build.gradle
+++ b/redis-persistence/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compile 'redis.clients:jedis:2.8.1'
 	compile 'com.google.inject:guice:3.0'
 	compile 'com.netflix.dyno:dyno-core:1.5.9'
+	compile 'com.netflix.dyno:dyno-jedis:1.5.9'
  	compile 'com.netflix.dyno-queues:dyno-queues-redis:1.0.7'
 	compile 'org.elasticsearch:elasticsearch:2.+'
 


### PR DESCRIPTION
As mentioned in https://github.com/Netflix/conductor/issues/290, the dependency for `dyno-jedis` needs to be `1.5.6+`

Recent upgrade of `dyno-queues-redis` from `1.0.6` to `1.0.7` has downgraded `dyno-jedis` to 1.4.7 causing the issue #290.

Explicitly adding the dependency in `redis-persistence/build.gradle` to the latest (`1.5.9`, same as `dyno-core`) fixes the issue