### PR TITLE
Always return 0 for the responsetimeout.

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -393,8 +393,9 @@ public class Task {
 	 * 
 	 * @return the timeout for task to send response.  After this timeout, the task will be re-queued
 	 */
+	@Deprecated
 	public int getResponseTimeoutSeconds() {
-		return responseTimeoutSeconds;
+		return 0;
 	}
 	
 	/**


### PR DESCRIPTION
…ecated and using it is known to cause issues with long running tasks.