### PR TITLE
Downgrade Flyway version because of incompatibility with Percona 5.7 in strict mode

### DIFF
--- a/mysql-persistence/build.gradle
+++ b/mysql-persistence/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	compile 'commons-io:commons-io:2.4+'
 	compile 'mysql:mysql-connector-java:5.1.43'
 	compile 'com.zaxxer:HikariCP:2.6.3'
-	compile 'org.flywaydb:flyway-core:4.2.0'
+	compile 'org.flywaydb:flyway-core:4.0.3'
 
 	testCompile 'ch.vorburger.mariaDB4j:mariaDB4j:2.2.3'
 	testCompile 'ch.qos.logback:logback-core:1.2.3'


### PR DESCRIPTION
We found out that Flyway versions greater than 4.1.x are not compatible with Percona XtraDB Cluster (see open issue on Flyway project: https://github.com/flyway/flyway/issues/1556)

So as a temporary workaround, I'm downgrading to the latest Flyway version that doesn't use the locking mode incompatible with Percona which is **4.0.3**
