### PR TITLE
Don't try to index an empty task exec log (es5)

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAO.java
@@ -240,15 +240,18 @@ public class ElasticSearchDAO implements IndexDAO {
 	
 
 	@Override
-	public void add(List<TaskExecLog> logs) {
+	public void add(List<TaskExecLog> taskExecLogs) {
+		if (taskExecLogs.isEmpty()) {
+			return;
+        }
 		int retry = 3;
 		while(retry > 0) {
 			try {
 				
 				BulkRequestBuilder brb = client.prepareBulk();
-				for(TaskExecLog log : logs) {
+				for(TaskExecLog taskExecLog : taskExecLogs) {
 					IndexRequest request = new IndexRequest(logIndexName, LOG_DOC_TYPE);
-					request.source(om.writeValueAsBytes(log), XContentType.JSON);
+					request.source(om.writeValueAsBytes(taskExecLog), XContentType.JSON);
 					brb.add(request);
 				}
 				BulkResponse response = brb.execute().actionGet();


### PR DESCRIPTION
When Task Exec Logs are empty, trying to execute a request will lead to exceptions, so if they are empty do not try to perform this action.