### PR TITLE
add support for specifying the request content type in HTTP Task

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -160,7 +160,7 @@ public class HttpTask extends WorkflowSystemTask {
 			client.addFilter(new OAuthClientFilter(client.getProviders(), params, secrets));
 		}
 
-		Builder builder = client.resource(input.uri).type(MediaType.APPLICATION_JSON);
+		Builder builder = client.resource(input.uri).type(input.contentType);
 
 		if(input.body != null) {
 			builder.entity(input.body);
@@ -297,6 +297,8 @@ public class HttpTask extends WorkflowSystemTask {
 		private Object body;
 		
 		private String accept = MediaType.APPLICATION_JSON;
+
+		private String contentType = MediaType.APPLICATION_JSON;
 		
 		private String oauthConsumerKey;
 
@@ -387,7 +389,21 @@ public class HttpTask extends WorkflowSystemTask {
 		public void setAccept(String accept) {
 			this.accept = accept;
 		}
-		
+
+		/**
+		 * @return the content type
+		 */
+		public String getContentType() {
+			return contentType;
+		}
+
+		/**
+		 * @param contentType the content type to set
+		 */
+		public void setContentType(String contentType) {
+			this.contentType = contentType;
+		}
+
 		/**
 		 * @return the OAuth consumer Key
 		 */


### PR DESCRIPTION
## Context 

Currently, the documentation mentions that for HTTP tasks the "contentType" parameter is supported but it turns out that it's always hardcoded to `APPLICATION_JSON`.

This PR simply adds support for using this parameter to set the request content type if present and if not falls back to `APPLICATION_JSON`.