### PR TITLE
Include python for node.js build

### DIFF
--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -19,7 +19,8 @@ RUN apk update && apk add \
   libpng \
   libpng-dev \
   libjpeg-turbo \
-  libjpeg-turbo-dev 
+  libjpeg-turbo-dev \
+  python
 
 # Make app folders
 RUN mkdir -p /app/ui


### PR DESCRIPTION
The docker build for the `conductor-ui` image fails due to missing python:

```
> dtrace-provider@0.8.6 install /app/ui/node_modules/dtrace-provider
> node-gyp rebuild || node suppress-error.js

gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:483:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:397:16)
gyp ERR! stack     at F (/usr/local/lib/node_modules/npm/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/usr/local/lib/node_modules/npm/node_modules/which/which.js:80:29)
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/which.js:89:16
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:166:21)
gyp ERR! System Linux 4.9.60-linuxkit-aufs
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /app/ui/node_modules/dtrace-provider
gyp ERR! node -v v9.4.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
```

Adding python to the list of installed deps to make the build work.