### PR TITLE
Replace QueueType with String

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/core/events/sqs/SQSEventQueueProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/core/events/sqs/SQSEventQueueProvider.java
@@ -29,7 +29,6 @@ import com.netflix.conductor.contribs.queue.sqs.SQSObservableQueue;
 import com.netflix.conductor.contribs.queue.sqs.SQSObservableQueue.Builder;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.events.EventQueues;
-import com.netflix.conductor.core.events.EventQueues.QueueType;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 
 /**
@@ -46,7 +45,7 @@ public class SQSEventQueueProvider implements EventQueueProvider {
 	@Inject
 	public SQSEventQueueProvider(AmazonSQSClient client) {
 		this.client = client;
-		EventQueues.registerProvider(QueueType.sqs, this);
+		EventQueues.registerProvider("sqs", this);
 	}
 	
 	@Override

--- a/core/src/main/java/com/netflix/conductor/core/events/EventQueues.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/EventQueues.java
@@ -38,18 +38,14 @@ public class EventQueues {
 	private static Logger logger = LoggerFactory.getLogger(EventQueues.class);
 	
 	private static ParametersUtils pu = new ParametersUtils();
-	
-	public enum QueueType {
-		sqs, conductor
-	}
-	
-	private static Map<QueueType, EventQueueProvider> providers = new HashMap<>();
+
+	private static Map<String, EventQueueProvider> providers = new HashMap<>();
 
 	private EventQueues() {
 		
 	}
 
-	public static void registerProvider(QueueType type, EventQueueProvider provider) {
+	public static void registerProvider(String type, EventQueueProvider provider) {
 		providers.put(type, provider);
 	}
 	
@@ -59,9 +55,8 @@ public class EventQueues {
 	
 	public static ObservableQueue getQueue(String eventt, boolean throwException) {
 		String event = pu.replace(eventt).toString();
-		String typeVal = event.substring(0, event.indexOf(':'));
+		String type = event.substring(0, event.indexOf(':'));
 		String queueURI = event.substring(event.indexOf(':') + 1);
-		QueueType type = QueueType.valueOf(typeVal);
 		EventQueueProvider provider = providers.get(type);
 		if(provider != null) {
 			try {
@@ -72,6 +67,8 @@ public class EventQueues {
 					throw e;
 				}
 			}
+		} else {
+			throw new IllegalArgumentException("Unknown queue type " + type);
 		}
 		return null;
 		

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoEventQueueProvider.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoEventQueueProvider.java
@@ -27,7 +27,6 @@ import javax.inject.Singleton;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.events.EventQueues;
-import com.netflix.conductor.core.events.EventQueues.QueueType;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.dao.QueueDAO;
 
@@ -48,7 +47,7 @@ public class DynoEventQueueProvider implements EventQueueProvider {
 	public DynoEventQueueProvider(QueueDAO dao, Configuration config) {
 		this.dao = dao;
 		this.config = config;
-		EventQueues.registerProvider(QueueType.conductor, this);
+		EventQueues.registerProvider("conductor", this);
 	}
 	
 	@Override

--- a/core/src/test/java/com/netflix/conductor/core/events/MockQueueProvider.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/MockQueueProvider.java
@@ -18,7 +18,6 @@
  */
 package com.netflix.conductor.core.events;
 
-import com.netflix.conductor.core.events.EventQueues.QueueType;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 
 /**
@@ -27,9 +26,9 @@ import com.netflix.conductor.core.events.queue.ObservableQueue;
  */
 public class MockQueueProvider implements EventQueueProvider {
 
-	private QueueType type;
+	private String type;
 	
-	public MockQueueProvider(QueueType type) {
+	public MockQueueProvider(String type) {
 		this.type = type;
 		EventQueues.registerProvider(type, this);
 	}
@@ -37,7 +36,7 @@ public class MockQueueProvider implements EventQueueProvider {
 	
 	@Override
 	public ObservableQueue getQueue(String queueURI) {
-		return new MockObservableQueue(queueURI, queueURI, type.name());
+		return new MockObservableQueue(queueURI, queueURI, type);
 	}
 
 }

--- a/core/src/test/java/com/netflix/conductor/core/events/TestEventProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestEventProcessor.java
@@ -42,7 +42,6 @@ import com.netflix.conductor.common.metadata.events.EventHandler.Action;
 import com.netflix.conductor.common.metadata.events.EventHandler.Action.Type;
 import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.core.events.EventQueues.QueueType;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.core.execution.TestConfiguration;
@@ -76,7 +75,7 @@ public class TestEventProcessor {
 		when(provider.getQueue(queueURI)).thenReturn(queue);
 		
 		
-		EventQueues.registerProvider(QueueType.sqs, provider);
+		EventQueues.registerProvider("sqs", provider);
 		
 		EventHandler eh = new EventHandler();
 		eh.setName(UUID.randomUUID().toString());

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestEvent.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestEvent.java
@@ -39,7 +39,6 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.core.events.EventQueues.QueueType;
 import com.netflix.conductor.core.events.MockQueueProvider;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
@@ -56,8 +55,8 @@ public class TestEvent {
 
 	@Before
 	public void setup() {
-		new MockQueueProvider(QueueType.sqs);
-		new MockQueueProvider(QueueType.conductor);
+		new MockQueueProvider("sqs");
+		new MockQueueProvider("conductor");
 	}
 	
 	@Test


### PR DESCRIPTION
Replace the `QueueType` enum with a plain `String`. It currently works as a bit of a constraint, preventing the addition of queue types that are not known at compile time.

Aside from allowing unknown queue types to be registered at runtime, there is also a behavior change. If previously known queue types were not registered for some reason (e.g. starting up without the contribs module, so `QueueType.sqs` was not registered), would result in returning `null` at the `EventQueues.getQueue` level.
