### PR TITLE
Sql2o removal for MySQL JDBC

### DIFF
--- a/mysql-persistence/.gitignore
+++ b/mysql-persistence/.gitignore
@@ -1,1 +1,2 @@
 out/
+build/

--- a/mysql-persistence/build.gradle
+++ b/mysql-persistence/build.gradle
@@ -3,7 +3,6 @@ dependencies {
 	compile "com.google.inject:guice:${revGuice}"
 	compile "org.elasticsearch:elasticsearch:${revElasticSearch2}"
 
-	compile "org.sql2o:sql2o:${revSql2o}"
 	compile "commons-io:commons-io:${revCommonsIo}"
 	compile "mysql:mysql-connector-java:${revMySqlConnector}"
 	compile "com.zaxxer:HikariCP:${revHikariCP}"

--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -89,10 +89,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "compileClasspath": {
@@ -185,10 +181,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "default": {
@@ -281,10 +273,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "runtime": {
@@ -377,10 +365,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "runtimeClasspath": {
@@ -473,10 +457,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "testCompile": {
@@ -589,10 +569,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "testCompileClasspath": {
@@ -705,10 +681,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "testRuntime": {
@@ -821,10 +793,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     },
     "testRuntimeClasspath": {
@@ -937,10 +905,6 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "1.7.25"
-        },
-        "org.sql2o:sql2o": {
-            "locked": "1.5.4",
-            "requested": "1.5.4"
         }
     }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/ExecuteFunction.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/ExecuteFunction.java
@@ -1,0 +1,12 @@
+package com.netflix.conductor.dao.mysql;
+
+import java.sql.SQLException;
+
+/**
+ * Functional interface for {@link Query} executions with no expected result.
+ * @author mustafa
+ */
+@FunctionalInterface
+public interface ExecuteFunction {
+	void apply(Query query) throws SQLException;
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/LazyToString.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/LazyToString.java
@@ -1,0 +1,23 @@
+package com.netflix.conductor.dao.mysql;
+
+
+import java.util.function.Supplier;
+
+/**
+ * Functional class to support the lazy execution of a String result.
+ */
+class LazyToString {
+    private final Supplier<String> supplier;
+
+    /**
+     * @param supplier Supplier to execute when {@link #toString()} is called.
+     */
+    LazyToString(Supplier<String> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public String toString() {
+        return supplier.get();
+    }
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLBaseDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLBaseDAO.java
@@ -1,91 +1,185 @@
 package com.netflix.conductor.dao.mysql;
 
-import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.netflix.conductor.core.execution.ApplicationException;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sql2o.Connection;
-import org.sql2o.Sql2o;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 
-abstract class MySQLBaseDAO {
+/**
+ * @author mustafa
+ */
+public abstract class MySQLBaseDAO {
+    private static final List<String> EXCLUDED_STACKTRACE_CLASS = ImmutableList.of(
+            MySQLBaseDAO.class.getName(),
+            Thread.class.getName()
+    );
 
-	private static final List<String> EXCLUDED_STACKTRACE_CLASS = ImmutableList.of("com.netflix.conductor.dao.mysql.MySQLBaseDAO", "java.lang.Thread");
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final ObjectMapper objectMapper;
+    protected final DataSource dataSource;
 
-	protected final Sql2o sql2o;
-	protected final ObjectMapper om;
-	protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected MySQLBaseDAO(ObjectMapper om, DataSource dataSource) {
+        this.objectMapper = om;
+        this.dataSource = dataSource;
+    }
 
-	protected MySQLBaseDAO(ObjectMapper om, Sql2o sql2o) {
-		this.om = om;
-		this.sql2o = sql2o;
-	}
+    protected final LazyToString getCallingMethod() {
+        return new LazyToString(() -> Arrays.stream(Thread.currentThread().getStackTrace())
+                .filter(ste -> !EXCLUDED_STACKTRACE_CLASS.contains(ste.getClassName()))
+                .findFirst()
+                .map(StackTraceElement::getMethodName)
+                .orElseThrow(() -> new NullPointerException("Cannot find Caller")));
+    }
 
-	protected String toJson(Object value) {
-		try {
-			return om.writeValueAsString(value);
-		} catch (JsonProcessingException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    protected String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, ex);
+        }
+    }
 
-	protected <T>T readValue(String json, Class<T> clazz) {
-		try {
-			return om.readValue(json, clazz);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    protected <T> T readValue(String json, Class<T> tClass) {
+        try {
+            return objectMapper.readValue(json, tClass);
+        } catch (IOException ex) {
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, ex);
+        }
+    }
 
-	protected <R> R getWithTransaction(Function<Connection, R> function) {
-		Instant start = Instant.now();
-		StackTraceElement caller = Arrays.stream(Thread.currentThread().getStackTrace()).filter(ste -> !EXCLUDED_STACKTRACE_CLASS.contains(ste.getClassName())).findFirst().get();
-		logger.debug("{} : starting transaction", caller.getMethodName());
-		try (Connection connection = sql2o.beginTransaction(TRANSACTION_READ_COMMITTED)) {
-			final R result = function.apply(connection);
-			connection.commit();
-			return result;
-		} finally {
-			Instant end = Instant.now();
-			logger.debug("{} : took {}ms", caller.getMethodName(), Duration.between(start, end).toMillis());
-		}
-	}
+    protected <T> T readValue(String json, TypeReference<T> typeReference) {
+        try {
+            return objectMapper.readValue(json, typeReference);
+        } catch (IOException ex) {
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, ex);
+        }
+    }
 
-	protected void withTransaction(Consumer<Connection> consumer) {
-		getWithTransaction(connection -> {
-			consumer.accept(connection);
-			return null;
-		});
-	}
+    /**
+     * Initialize a new transactional {@link Connection} from {@link #dataSource} and pass it to {@literal function}.
+     * <p/>
+     * Successful executions of {@literal function} will result in a commit and return of
+     * {@link TransactionalFunction#apply(Connection)}.
+     * <p/>
+     * If any {@link Throwable} thrown from {@code TransactionalFunction#apply(Connection)} will result in a rollback
+     * of the transaction
+     * and will be wrapped in an {@link ApplicationException} if it is not already one.
+     * <p/>
+     * Generally this is used to wrap multiple {@link #execute(Connection, String, ExecuteFunction)} or
+     * {@link #query(Connection, String, QueryFunction)} invocations that produce some expected return value.
+     *
+     * @param function The function to apply with a new transactional {@link Connection}
+     * @param <R>      The return type.
+     * @return The result of {@code TransactionalFunction#apply(Connection)}
+     * @throws ApplicationException If any errors occur.
+     */
+    protected <R> R getWithTransaction(TransactionalFunction<R> function) {
+        Instant start = Instant.now();
+        LazyToString callingMethod = getCallingMethod();
+        logger.trace("{} : starting transaction", callingMethod);
 
-	/**
-	 * This will inject a series of p1, p2, ... placeholders in the given query template so it can then be used
-	 * in conjunction with the withParams method on the Sql2o Query object.
-	 *
-	 * The withParams method in the Query class loops through each element in the given array and adds a prepared statement for each.
-	 * For each element found in the array, a pN placeholder should exists in the query.
-	 *
-	 * This is useful for generating the IN clause since Sql2o does not support passing directly a list
-	 *
-	 * @param queryTemplate a query template with a %s placeholder where the variable size parameters placeholders should be injected
-	 * @param numPlaceholders the number of placeholders to generated
-	 * @return
-	 */
-	protected String generateQueryWithParametersListPlaceholders(String queryTemplate, int numPlaceholders) {
-		String paramsPlaceholders = String.join(",", IntStream.rangeClosed(1, numPlaceholders).mapToObj(paramNumber -> ":p" + paramNumber).collect(Collectors.toList()));
-		return String.format(queryTemplate, paramsPlaceholders);
-	}
+        try(Connection tx = dataSource.getConnection()) {
+            boolean previousAutoCommitMode = tx.getAutoCommit();
+            tx.setAutoCommit(false);
+            try {
+                R result = function.apply(tx);
+                tx.commit();
+                return result;
+            } catch (Throwable th) {
+                tx.rollback();
+                throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, th.getMessage(), th);
+            } finally {
+                tx.setAutoCommit(previousAutoCommitMode);
+            }
+        } catch (SQLException ex) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, ex.getMessage(), ex);
+        } finally {
+            logger.trace("{} : took {}ms", callingMethod, Duration.between(start, Instant.now()).toMillis());
+        }
+    }
+
+    /**
+     * Wraps {@link #getWithTransaction(TransactionalFunction)} with no return value.
+     * <p/>
+     * Generally this is used to wrap multiple {@link #execute(Connection, String, ExecuteFunction)} or
+     * {@link #query(Connection, String, QueryFunction)} invocations that produce no expected return value.
+     *
+     * @param consumer The {@link Consumer} callback to pass a transactional {@link Connection} to.
+     * @throws ApplicationException If any errors occur.
+     * @see #getWithTransaction(TransactionalFunction)
+     */
+    protected void withTransaction(Consumer<Connection> consumer) {
+        getWithTransaction(connection -> {
+            consumer.accept(connection);
+            return null;
+        });
+    }
+
+    /**
+     * Initiate a new transaction and execute a {@link Query} within that context,
+     * then return the results of {@literal function}.
+     *
+     * @param query    The query string to prepare.
+     * @param function The functional callback to pass a {@link Query} to.
+     * @param <R>      The expected return type of {@literal function}.
+     * @return The results of applying {@literal function}.
+     */
+    protected <R> R queryWithTransaction(String query, QueryFunction<R> function) {
+        return getWithTransaction(tx -> query(tx, query, function));
+    }
+
+    /**
+     * Execute a {@link Query} within the context of a given transaction and return the results of {@literal function}.
+     *
+     * @param tx       The transactional {@link Connection} to use.
+     * @param query    The query string to prepare.
+     * @param function The functional callback to pass a {@link Query} to.
+     * @param <R>      The expected return type of {@literal function}.
+     * @return The results of applying {@literal function}.
+     */
+    protected <R> R query(Connection tx, String query, QueryFunction<R> function) {
+        try (Query q = new Query(objectMapper, tx, query)) {
+            return function.apply(q);
+        } catch (SQLException ex) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Execute a statement with no expected return value within a given transaction.
+     *
+     * @param tx       The transactional {@link Connection} to use.
+     * @param query    The query string to prepare.
+     * @param function The functional callback to pass a {@link Query} to.
+     */
+    protected void execute(Connection tx, String query, ExecuteFunction function) {
+        try (Query q = new Query(objectMapper, tx, query)) {
+            function.apply(q);
+        } catch (SQLException ex) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Instantiates a new transactional connection and invokes {@link #execute(Connection, String, ExecuteFunction)}
+     *
+     * @param query    The query string to prepare.
+     * @param function The functional callback to pass a {@link Query} to.
+     */
+    protected void executeWithTransaction(String query, ExecuteFunction function) {
+        withTransaction(tx -> execute(tx, query, function));
+    }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -1,19 +1,5 @@
 package com.netflix.conductor.dao.mysql;
 
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
-import org.sql2o.Connection;
-import org.sql2o.ResultSetHandler;
-import org.sql2o.Sql2o;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -29,746 +15,829 @@ import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.metrics.Monitors;
-
-class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
-
-	private static final String ARCHIVED_FIELD = "archived";
-	private static final String RAW_JSON_FIELD = "rawJSON";
-
-	private IndexDAO indexer;
-
-	private MetadataDAO metadata;
-
-	@Inject
-	MySQLExecutionDAO(IndexDAO indexer, MetadataDAO metadata, ObjectMapper om, Sql2o sql2o) {
-		super(om, sql2o);
-		this.indexer = indexer;
-		this.metadata = metadata;
-	}
-
-	@Override
-	public List<Task> getPendingTasksByWorkflow(String taskDefName, String workflowId) {
-		return getWithTransaction(connection -> {
-
-			String GET_IN_PROGRESS_TASKS_FOR_WORKFLOW =
-				"SELECT json_data FROM task_in_progress tip INNER JOIN task t ON t.task_id = tip.task_id \n" +
-				" WHERE task_def_name = :taskDefName AND workflow_id = :workflowId";
-
-			ResultSetHandler<Task> resultSetHandler = resultSet -> readValue(resultSet.getString("json_data"), Task.class);
-
-			return connection.createQuery(GET_IN_PROGRESS_TASKS_FOR_WORKFLOW)
-					.addParameter("taskDefName", taskDefName)
-					.addParameter("workflowId", workflowId)
-					.executeAndFetch(resultSetHandler);
-		});
-	}
-
-	@Override
-	public List<Task> getTasks(String taskDefName, String startKey, int count) {
-		List<Task> tasks = new ArrayList<>(count);
-
-		List<Task> pendingTasks = getPendingTasksForTaskType(taskDefName);
-		boolean startKeyFound = startKey == null;
-		int found = 0;
-		for (Task pendingTask : pendingTasks) {
-			if (!startKeyFound) {
-				if (pendingTask.getTaskId().equals(startKey)) {
-					startKeyFound = true;
-					if (startKey != null) {
-						continue;
-					}
-				}
-			}
-			if (startKeyFound && found < count) {
-				tasks.add(pendingTask);
-				found++;
-			}
-		}
-
-		return tasks;
-	}
-
-	@Override
-	public List<Task> createTasks(List<Task> tasks) {
-		List<Task> created = Lists.newLinkedList();
-
-		withTransaction(connection -> {
-			for (Task task : tasks) {
-				validate(task);
-
-				task.setScheduledTime(System.currentTimeMillis());
-
-				String taskKey = task.getReferenceTaskName() + "_" + task.getRetryCount();
-
-				boolean scheduledTaskAdded = addScheduledTask(connection, task, taskKey);
-
-				if (!scheduledTaskAdded) {
-					logger.info("Task already scheduled, skipping the run " + task.getTaskId() + ", ref=" + task.getReferenceTaskName() + ", key=" + taskKey);
-					continue;
-				}
-
-				insertOrUpdateTaskData(connection, task);
-				addWorkflowToTaskMapping(connection, task);
-				addTaskInProgress(connection, task);
-				updateTask(connection, task);
-
-				created.add(task);
-			}
-		});
-
-		return created;
-	}
-
-	@Override
-	public void updateTask(Task task) {
-		withTransaction(connection -> updateTask(connection, task));
-	}
-
-	@Override
-	public boolean exceedsInProgressLimit(Task task) {
-		TaskDef taskDef = metadata.getTaskDef(task.getTaskDefName());
-		if (taskDef == null) return false;
-
-		int limit = taskDef.concurrencyLimit();
-		if (limit <= 0) return false;
-
-		long current = getInProgressTaskCount(task.getTaskDefName());
-
-		if (current >= limit) {
-			Monitors.recordTaskRateLimited(task.getTaskDefName(), limit);
-			return true;
-		}
-
-		logger.info("Task execution count for {}: limit={}, current={}", task.getTaskDefName(), limit, getInProgressTaskCount(task.getTaskDefName()));
-
-		String taskId = task.getTaskId();
-
-		List<String> tasksInProgressInOrderOfArrival = findAllTasksInProgressInOrderOfArrival(task, limit);
-
-		boolean rateLimited = !tasksInProgressInOrderOfArrival.contains(taskId);
-
-		if (rateLimited) {
-			logger.info("Task execution count limited. {}, limit {}, current {}", task.getTaskDefName(), limit, getInProgressTaskCount(task.getTaskDefName()));
-			Monitors.recordTaskRateLimited(task.getTaskDefName(), limit);
-		}
-
-		return rateLimited;
-	}
-
-	@Override
-	public void updateTasks(List<Task> tasks) {
-		withTransaction(connection -> tasks.forEach(task -> updateTask(connection, task)));
-	}
-
-	@Override
-	public void addTaskExecLog(List<TaskExecLog> log) {
-		indexer.addTaskExecutionLogs(log);
-	}
-
-	@Override
-	public void removeTask(String taskId) {
-		Task task = getTask(taskId);
-
-		if(task == null) {
-			logger.warn("No such Task by id {}", taskId);
-			return;
-		}
-
-		String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
-
-		withTransaction(connection -> {
-			removeScheduledTask(connection, task, taskKey);
-			removeWorkflowToTaskMapping(connection, task);
-			removeTaskInProgress(connection, task);
-			removeTaskData(connection, task);
-		});
-	}
-
-	@Override
-	public Task getTask(String taskId) {
-		String GET_TASK = "SELECT json_data FROM task WHERE task_id = :taskId";
-		String taskJsonStr = getWithTransaction(c -> c.createQuery(GET_TASK).addParameter("taskId", taskId).executeScalar(String.class));
-		return taskJsonStr != null ? readValue(taskJsonStr, Task.class) : null;
-	}
-
-	@Override
-	public List<Task> getTasks(List<String> taskIds) {
-		if (taskIds.isEmpty()) return Lists.newArrayList();
-		return getWithTransaction(c -> getTasks(c, taskIds));
-	}
-
-	private List<Task> getTasks(Connection connection, List<String> taskIds) {
-		if (taskIds.isEmpty()) return Lists.newArrayList();
-
-		String GET_TASKS_FOR_IDS = "SELECT json_data FROM task WHERE task_id IN (%s) AND json_data IS NOT NULL";
-		String query = generateQueryWithParametersListPlaceholders(GET_TASKS_FOR_IDS, taskIds.size());
-
-		ResultSetHandler<Task> resultSetHandler = resultSet -> readValue(resultSet.getString("json_data"), Task.class);
-
-		return connection.createQuery(query).withParams(taskIds.toArray()).executeAndFetch(resultSetHandler);
-	}
-
-	@Override
-	public List<Task> getPendingTasksForTaskType(String taskName) {
-		Preconditions.checkNotNull(taskName, "task name cannot be null");
-		return getWithTransaction(connection -> {
-
-			String GET_IN_PROGRESS_TASKS_FOR_TYPE =
-				"SELECT json_data FROM task_in_progress tip INNER JOIN task t ON t.task_id = tip.task_id WHERE task_def_name = :taskDefName";
-
-			ResultSetHandler<Task> resultSetHandler = resultSet -> readValue(resultSet.getString("json_data"), Task.class);
-
-			return connection.createQuery(GET_IN_PROGRESS_TASKS_FOR_TYPE).addParameter("taskDefName", taskName).executeAndFetch(resultSetHandler);
-		});
-	}
-
-	@Override
-	public List<Task> getTasksForWorkflow(String workflowId) {
-		return getWithTransaction(connection -> {
-			String GET_TASKS_FOR_WORKFLOW = "SELECT task_id FROM workflow_to_task WHERE workflow_id = :workflowId";
-			List<String> taskIds = connection.createQuery(GET_TASKS_FOR_WORKFLOW).addParameter("workflowId", workflowId).executeScalarList(String.class);
-			return getTasks(connection, taskIds);
-		});
-	}
-
-	@Override
-	public String createWorkflow(Workflow workflow) {
-		workflow.setCreateTime(System.currentTimeMillis());
-		return insertOrUpdateWorkflow(workflow, false);
-	}
-
-	@Override
-	public String updateWorkflow(Workflow workflow) {
-		workflow.setUpdateTime(System.currentTimeMillis());
-		return insertOrUpdateWorkflow(workflow, true);
-	}
-
-	@Override
-	public void removeWorkflow(String workflowId, boolean archiveWorkflow) {
-		try {
-			Workflow wf = getWorkflow(workflowId, true);
-
-			if (archiveWorkflow) {
-				//Add to elasticsearch
-				indexer.updateWorkflow(workflowId,
-				               new String[] {RAW_JSON_FIELD, ARCHIVED_FIELD},
-				               new Object[] {om.writeValueAsString(wf), true});
-			}
-			else {
-				// Not archiving, also remove workflowId from index
-				indexer.removeWorkflow(workflowId);
-			}
-
-			withTransaction(connection -> {
-				removeWorkflowDefToWorkflowMapping(connection, wf);
-				removeWorkflow(connection, workflowId);
-				removePendingWorkflow(connection, wf.getWorkflowType(), workflowId);
-			});
-
-			for(Task task : wf.getTasks()) {
-				removeTask(task.getTaskId());
-			}
-
-		} catch(Exception e) {
-			throw new ApplicationException("Unable to remove workflow " + workflowId, e);
-		}
-	}
-
-	@Override
-	public void removeFromPendingWorkflow(String workflowType, String workflowId) {
-		withTransaction(connection -> removePendingWorkflow(connection, workflowType, workflowId));
-	}
-
-	@Override
-	public Workflow getWorkflow(String workflowId) {
-		return getWorkflow(workflowId, true);
-	}
-
-	@Override
-	public Workflow getWorkflow(String workflowId, boolean includeTasks) {
-		Workflow workflow = getWithTransaction(tx -> readWorkflow(tx, workflowId));
-
-		if (workflow != null) {
-			if (includeTasks) {
-				List<Task> tasks = getTasksForWorkflow(workflowId);
-				tasks.sort(Comparator.comparingLong(Task::getScheduledTime).thenComparingInt(Task::getSeq));
-				workflow.setTasks(tasks);
-			}
-			return workflow;
-		}
-
-		//try from the archive
-		workflow = readWorkflowFromArchive(workflowId);
-
-		if(!includeTasks) {
-			workflow.getTasks().clear();
-		}
-
-		return workflow;
-	}
-
-	@Override
-	public List<String> getRunningWorkflowIds(String workflowName) {
-		Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
-		String GET_PENDING_WORKFLOW_IDS = "SELECT workflow_id FROM workflow_pending WHERE workflow_type = :workflowType";
-		return getWithTransaction(tx -> tx.createQuery(GET_PENDING_WORKFLOW_IDS).addParameter("workflowType", workflowName).executeScalarList(String.class));
-	}
-
-	@Override
-	public List<Workflow> getPendingWorkflowsByType(String workflowName) {
-		Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
-		return getRunningWorkflowIds(workflowName).stream().map(this::getWorkflow).collect(Collectors.toList());
-	}
-
-	@Override
-	public long getPendingWorkflowCount(String workflowName) {
-		Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
-		String GET_PENDING_WORKFLOW_COUNT = "SELECT COUNT(*) FROM workflow_pending WHERE workflow_type = :workflowType";
-		return getWithTransaction(tx -> tx.createQuery(GET_PENDING_WORKFLOW_COUNT).addParameter("workflowType", workflowName).executeScalar(Long.class));
-	}
-
-	@Override
-	public long getInProgressTaskCount(String taskDefName) {
-		String GET_IN_PROGRESS_TASK_COUNT = "SELECT COUNT(*) FROM task_in_progress WHERE task_def_name = :taskDefName AND in_progress_status = true";
-		return getWithTransaction(c -> c.createQuery(GET_IN_PROGRESS_TASK_COUNT)
-				.addParameter("taskDefName", taskDefName)
-				.executeScalar(Long.class));
-	}
-
-	@Override
-	public List<Workflow> getWorkflowsByType(String workflowName, Long startTime, Long endTime) {
-		Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
-		Preconditions.checkNotNull(startTime, "startTime cannot be null");
-		Preconditions.checkNotNull(endTime, "endTime cannot be null");
-
-		List<Workflow> workflows = new LinkedList<Workflow>();
-
-		withTransaction(tx -> {
-			String GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF = "SELECT workflow_id FROM workflow_def_to_workflow WHERE workflow_def = :workflowType AND date_str BETWEEN :start AND :end";
-			List<String> workflowIds = tx.createQuery(GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF)
-					.addParameter("workflowType", workflowName)
-					.addParameter("start", dateStr(startTime))
-					.addParameter("end", dateStr(endTime))
-					.executeScalarList(String.class);
-
-			workflowIds.forEach(workflowId -> {
-				try {
-					Workflow wf = getWorkflow(workflowId);
-					if (wf.getCreateTime() >= startTime && wf.getCreateTime() <= endTime) {
-						workflows.add(wf);
-					}
-				} catch(Exception e) {
-					logger.error("Unable to load workflow id {} with name {}", workflowId, workflowName, e);
-				}
-			});
-		});
-
-		return workflows;
-	}
-
-	@Override
-	public List<Workflow> getWorkflowsByCorrelationId(String correlationId) {
-		Preconditions.checkNotNull(correlationId, "correlationId cannot be null");
-		String GET_WORKFLOWS_BY_CORRELATION_ID = "SELECT workflow_id FROM workflow WHERE correlation_id = :correlationId";
-		return getWithTransaction(tx -> tx.createQuery(GET_WORKFLOWS_BY_CORRELATION_ID)
-				.addParameter("correlationId", correlationId)
-				.executeScalarList(String.class)).stream()
-				.map(this::getWorkflow)
-				.collect(Collectors.toList());
-	}
-
-	@Override
-	public boolean addEventExecution(EventExecution eventExecution) {
-		try {
-			boolean added = getWithTransaction(tx -> insertEventExecution(tx, eventExecution));
-			if (added) {
-				indexer.addEventExecution(eventExecution);
-				return true;
-			}
-			return false;
-		} catch (Exception e) {
-			throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, "Unable to add event execution " + eventExecution.getId(), e);
-		}
-	}
-
-	@Override
-	public void updateEventExecution(EventExecution eventExecution) {
-		try {
-			withTransaction(tx -> updateEventExecution(tx, eventExecution));
-			indexer.addEventExecution(eventExecution);
-		} catch (Exception e) {
-			throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, "Unable to update event execution " + eventExecution.getId(), e);
-		}
-	}
-
-	@Override
-	public List<EventExecution> getEventExecutions(String eventHandlerName, String eventName, String messageId, int max) {
-		try {
-			List<EventExecution> executions = Lists.newLinkedList();
-			withTransaction(tx ->  {
-				for(int i = 0; i < max; i++) {
-					String executionId = messageId + "_" + i; //see EventProcessor.handle to understand how the execution id is set
-					EventExecution ee = readEventExecution(tx, eventHandlerName, eventName, messageId, executionId);
-					if (ee == null) break;
-					executions.add(ee);
-				}
-			});
-			return executions;
-		} catch (Exception e) {
-			String message = String.format("Unable to get event executions for eventHandlerName=%s, eventName=%s, messageId=%s", eventHandlerName, eventName, messageId);
-			throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, message, e);
-		}
-	}
-
-	@Override
-	public void addMessage(String queue, Message msg) {
-		indexer.addMessage(queue, msg);
-	}
-
-	@Override
-	public void updateLastPoll(String taskDefName, String domain, String workerId) {
-		Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
-		PollData pollData = new PollData(taskDefName, domain, workerId, System.currentTimeMillis());
-		String effectiveDomain = (domain == null) ? "DEFAULT" : domain;
-		withTransaction(tx -> insertOrUpdatePollData(tx, pollData, effectiveDomain));
-	}
-
-	@Override
-	public PollData getPollData(String taskDefName, String domain) {
-		Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
-		String effectiveDomain = (domain == null) ? "DEFAULT" : domain;
-		return getWithTransaction(tx -> readPollData(tx, taskDefName, effectiveDomain));
-	}
-
-	@Override
-	public List<PollData> getPollData(String taskDefName) {
-		Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
-		return readAllPollData(taskDefName);
-	}
-
-	private String insertOrUpdateWorkflow(Workflow workflow, boolean update) {
-		Preconditions.checkNotNull(workflow, "workflow object cannot be null");
-
-		boolean terminal = workflow.getStatus().isTerminal();
-
-		if (terminal) workflow.setEndTime(System.currentTimeMillis());
-
-		List<Task> tasks = workflow.getTasks();
-		workflow.setTasks(Lists.newLinkedList());
-
-		withTransaction(tx -> {
-			if (!update) {
-				addWorkflow(tx, workflow);
-				addWorkflowDefToWorkflowMapping(tx, workflow);
-			} else {
-				updateWorkflow(tx, workflow);
-			}
-
-			if (terminal) {
-				removePendingWorkflow(tx, workflow.getWorkflowType(), workflow.getWorkflowId());
-			} else {
-				addPendingWorkflow(tx, workflow.getWorkflowType(), workflow.getWorkflowId());
-			}
-		});
-
-		workflow.setTasks(tasks);
-		indexer.indexWorkflow(workflow);
-		return workflow.getWorkflowId();
-	}
-
-	private void updateTask(Connection connection, Task task) {
-		task.setUpdateTime(System.currentTimeMillis());
-		if (task.getStatus() != null && task.getStatus().isTerminal()) {
-			task.setEndTime(System.currentTimeMillis());
-		}
-
-		TaskDef taskDef = metadata.getTaskDef(task.getTaskDefName());
-
-		if (taskDef != null && taskDef.concurrencyLimit() > 0) {
-			boolean inProgress = task.getStatus() != null && task.getStatus().equals(Task.Status.IN_PROGRESS);
-			updateInProgressStatus(connection, task, inProgress);
-		}
-
-		insertOrUpdateTaskData(connection, task);
-
-		if (task.getStatus() != null && task.getStatus().isTerminal()) {
-			removeTaskInProgress(connection, task);
-		}
-
-		indexer.indexTask(task);
-	}
-
-	private Workflow readWorkflow(Connection connection, String workflowId) {
-		String GET_WORKFLOW = "SELECT json_data FROM workflow WHERE workflow_id = :workflowId";
-		String json = connection.createQuery(GET_WORKFLOW).addParameter("workflowId", workflowId).executeScalar(String.class);
-		return json != null ? readValue(json, Workflow.class) : null;
-	}
-
-	private Workflow readWorkflowFromArchive(String workflowId) {
-		String json = indexer.get(workflowId, RAW_JSON_FIELD);
-		if (json != null) {
-			return readValue(json, Workflow.class);
-		} else {
-			throw new ApplicationException(ApplicationException.Code.NOT_FOUND, "No such workflow found by id: " + workflowId);
-		}
-	}
-
-	private void addWorkflow(Connection connection, Workflow workflow) {
-		String INSERT_WORKFLOW = "INSERT INTO workflow (workflow_id, correlation_id, json_data) VALUES (:workflowId, :correlationId, :jsonData)";
-		connection.createQuery(INSERT_WORKFLOW)
-				.addParameter("workflowId", workflow.getWorkflowId())
-				.addParameter("correlationId", workflow.getCorrelationId())
-				.addParameter("jsonData", toJson(workflow))
-				.executeUpdate();
-	}
-
-	private void updateWorkflow(Connection connection, Workflow workflow) {
-		String UPDATE_WORKFLOW = "UPDATE workflow SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE workflow_id = :workflowId";
-		connection.createQuery(UPDATE_WORKFLOW)
-				.addParameter("workflowId", workflow.getWorkflowId())
-				.addParameter("jsonData", toJson(workflow))
-				.executeUpdate();
-	}
-
-	private void removeWorkflow(Connection connection, String workflowId) {
-		String REMOVE_WORKFLOW = "DELETE FROM workflow WHERE workflow_id = :workflowId";
-		connection.createQuery(REMOVE_WORKFLOW)
-				.addParameter("workflowId", workflowId)
-				.executeUpdate();
-	}
-
-	private void addPendingWorkflow(Connection connection, String workflowType, String workflowId) {
-		String EXISTS_PENDING_WORKFLOW = "SELECT EXISTS(SELECT 1 FROM workflow_pending WHERE workflow_type = :workflowType AND workflow_id = :workflowId)";
-		boolean exist = connection.createQuery(EXISTS_PENDING_WORKFLOW)
-				.addParameter("workflowType", workflowType)
-				.addParameter("workflowId", workflowId)
-				.executeScalar(Boolean.class);
-
-		if (!exist) {
-			String INSERT_PENDING_WORKFLOW = "INSERT INTO workflow_pending (workflow_type, workflow_id) VALUES (:workflowType, :workflowId)";
-			connection.createQuery(INSERT_PENDING_WORKFLOW)
-					.addParameter("workflowType", workflowType)
-					.addParameter("workflowId", workflowId)
-					.executeUpdate();
-		}
-	}
-
-	private void removePendingWorkflow(Connection connection, String workflowType, String workflowId) {
-		String REMOVE_PENDING_WORKFLOW = "DELETE FROM workflow_pending WHERE workflow_type = :workflowType AND workflow_id = :workflowId";
-		connection.createQuery(REMOVE_PENDING_WORKFLOW)
-				.addParameter("workflowType", workflowType)
-				.addParameter("workflowId", workflowId)
-				.executeUpdate();
-	}
-
-	private void insertOrUpdateTaskData(Connection connection, Task task) {
-		String UPDATE_TASK = "UPDATE task SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE task_id = :taskId";
-		int result = connection.createQuery(UPDATE_TASK).addParameter("taskId", task.getTaskId()).addParameter("jsonData", toJson(task)).executeUpdate().getResult();
-		if (result == 0) {
-			String INSERT_TASK = "INSERT INTO task (task_id, json_data) VALUES (:taskId, :jsonData)";
-			connection.createQuery(INSERT_TASK).addParameter("taskId", task.getTaskId()).addParameter("jsonData", toJson(task)).executeUpdate().getResult();
-		}
-	}
-
-	private void removeTaskData(Connection connection, Task task) {
-		String REMOVE_TASK = "DELETE FROM task WHERE task_id = :taskId";
-		connection.createQuery(REMOVE_TASK)
-				.addParameter("taskId", task.getTaskId())
-				.executeUpdate();
-	}
-
-	private void addWorkflowToTaskMapping(Connection connection, Task task) {
-		String EXISTS_WORKFLOW_TO_TASK = "SELECT EXISTS(SELECT 1 FROM workflow_to_task WHERE workflow_id = :workflowId AND task_id = :taskId)";
-		boolean exist = connection.createQuery(EXISTS_WORKFLOW_TO_TASK)
-				.addParameter("workflowId", task.getWorkflowInstanceId())
-				.addParameter("taskId", task.getTaskId())
-				.executeScalar(Boolean.class);
-
-		if (!exist) {
-			String INSERT_WORKFLOW_TO_TASK = "INSERT INTO workflow_to_task (workflow_id, task_id) VALUES (:workflowId, :taskId)";
-			connection.createQuery(INSERT_WORKFLOW_TO_TASK)
-					.addParameter("workflowId", task.getWorkflowInstanceId())
-					.addParameter("taskId", task.getTaskId())
-					.executeUpdate();
-		}
-	}
-
-	private void removeWorkflowToTaskMapping(Connection connection, Task task) {
-		String REMOVE_WORKFLOW_TO_TASK = "DELETE FROM workflow_to_task WHERE workflow_id = :workflowId AND task_id = :taskId";
-		connection.createQuery(REMOVE_WORKFLOW_TO_TASK)
-				.addParameter("workflowId", task.getWorkflowInstanceId())
-				.addParameter("taskId", task.getTaskId())
-				.executeUpdate();
-	}
-
-	private void addWorkflowDefToWorkflowMapping(Connection connection, Workflow workflow) {
-		String INSERT_WORKFLOW_DEF_TO_WORKFLOW = "INSERT INTO workflow_def_to_workflow (workflow_def, date_str, workflow_id) VALUES (:workflowType, :dateStr, :workflowId)";
-		connection.createQuery(INSERT_WORKFLOW_DEF_TO_WORKFLOW)
-				.bind(workflow)
-				.addParameter("dateStr", dateStr(workflow.getCreateTime()))
-				.executeUpdate();
-	}
-
-	private void removeWorkflowDefToWorkflowMapping(Connection connection, Workflow workflow) {
-		String REMOVE_WORKFLOW_DEF_TO_WORKFLOW = "DELETE FROM workflow_def_to_workflow WHERE workflow_def = :workflowType AND date_str = :dateStr AND workflow_id = :workflowId";
-		connection.createQuery(REMOVE_WORKFLOW_DEF_TO_WORKFLOW)
-				.bind(workflow)
-				.addParameter("dateStr", dateStr(workflow.getCreateTime()))
-				.executeUpdate();
-	}
-
-	private boolean addScheduledTask(Connection connection, Task task, String taskKey) {
-		String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled WHERE workflow_id = :workflowId AND task_key = :taskKey)";
-		boolean exist = connection.createQuery(EXISTS_SCHEDULED_TASK)
-				.addParameter("workflowId", task.getWorkflowInstanceId())
-				.addParameter("taskKey", taskKey)
-				.executeScalar(Boolean.class);
-
-		if (!exist) {
-			String INSERT_SCHEDULED_TASK = "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (:workflowId, :taskKey, :taskId)";
-			connection.createQuery(INSERT_SCHEDULED_TASK)
-					.addParameter("workflowId", task.getWorkflowInstanceId())
-					.addParameter("taskKey", taskKey)
-					.addParameter("taskId", task.getTaskId())
-					.executeUpdate()
-					.getResult();
-			return true;
-		}
-
-		return false;
-	}
-
-	private void removeScheduledTask(Connection connection, Task task, String taskKey) {
-		String REMOVE_SCHEDULED_TASK = "DELETE FROM task_scheduled WHERE workflow_id = :workflowId AND task_key = :taskKey";
-		connection.createQuery(REMOVE_SCHEDULED_TASK)
-				.addParameter("workflowId", task.getWorkflowInstanceId())
-				.addParameter("taskKey", taskKey)
-				.executeUpdate()
-				.getResult();
-	}
-
-	private void addTaskInProgress(Connection connection, Task task) {
-		String EXISTS_IN_PROGRESS_TASK = "SELECT EXISTS(SELECT 1 FROM task_in_progress WHERE task_def_name = :taskDefName AND task_id = :taskId)";
-		boolean exist = connection.createQuery(EXISTS_IN_PROGRESS_TASK)
-				.addParameter("taskDefName", task.getTaskDefName())
-				.addParameter("taskId", task.getTaskId())
-				.executeScalar(Boolean.class);
-
-		if (!exist) {
-			String INSERT_IN_PROGRESS_TASK = "INSERT INTO task_in_progress (task_def_name, task_id, workflow_id) VALUES (:taskDefName, :taskId, :workflowId)";
-			connection.createQuery(INSERT_IN_PROGRESS_TASK)
-					.addParameter("taskDefName", task.getTaskDefName())
-					.addParameter("taskId", task.getTaskId())
-					.addParameter("workflowId", task.getWorkflowInstanceId())
-					.executeUpdate();
-		}
-	}
-
-	private void removeTaskInProgress(Connection connection, Task task) {
-		String REMOVE_IN_PROGRESS_TASK = "DELETE FROM task_in_progress WHERE task_def_name = :taskDefName AND task_id = :taskId";
-		connection.createQuery(REMOVE_IN_PROGRESS_TASK)
-				.addParameter("taskDefName", task.getTaskDefName())
-				.addParameter("taskId", task.getTaskId())
-				.executeUpdate();
-	}
-
-	private void updateInProgressStatus(Connection connection, Task task, boolean inProgress) {
-		String UPDATE_IN_PROGRESS_TASK_STATUS = "UPDATE task_in_progress SET in_progress_status = :inProgress, modified_on = CURRENT_TIMESTAMP WHERE task_def_name = :taskDefName AND task_id = :taskId";
-		connection.createQuery(UPDATE_IN_PROGRESS_TASK_STATUS)
-				.addParameter("taskDefName", task.getTaskDefName())
-				.addParameter("taskId", task.getTaskId())
-				.addParameter("inProgress", inProgress)
-				.executeUpdate();
-	}
-
-	private boolean insertEventExecution(Connection  connection, EventExecution eventExecution) {
-		String EXISTS_EVENT_EXECUTION = "SELECT EXISTS(SELECT 1 FROM event_execution WHERE event_handler_name = :name AND event_name = :event AND message_id = :messageId AND execution_id = :id)";
-		boolean exist = connection.createQuery(EXISTS_EVENT_EXECUTION).bind(eventExecution).executeScalar(Boolean.class);
-		if (!exist) {
-			String INSERT_EVENT_EXECUTION = "INSERT INTO event_execution (event_handler_name, event_name, message_id, execution_id, json_data) VALUES (:name, :event, :messageId, :id, :jsonData)";
-			connection.createQuery(INSERT_EVENT_EXECUTION).bind(eventExecution).addParameter("jsonData", toJson(eventExecution)).executeUpdate();
-			return true;
-		}
-		return false;
-	}
-
-	private void updateEventExecution(Connection  connection, EventExecution eventExecution) {
-		String UPDATE_EVENT_EXECUTION = "UPDATE event_execution SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE event_handler_name = :name AND execution_event = :event AND message_id = :messageId AND execution_id = :id";
-		connection.createQuery(UPDATE_EVENT_EXECUTION).bind(eventExecution).addParameter("jsonData", toJson(eventExecution)).executeUpdate();
-	}
-
-	private EventExecution readEventExecution(Connection connection, String eventHandlerName, String eventName, String messageId, String executionId) {
-		String GET_EVENT_EXECUTION = "SELECT json_data FROM event_execution WHERE event_handler_name = :name AND event_name = :event AND message_id = :messageId AND execution_id = :id";
-		String jsonStr = connection.createQuery(GET_EVENT_EXECUTION)
-				.addParameter("name", eventHandlerName)
-				.addParameter("event", eventName)
-				.addParameter("messageId", messageId)
-				.addParameter("id", executionId)
-				.executeScalar(String.class);
-		return jsonStr != null ? readValue(jsonStr, EventExecution.class) : null;
-	}
-
-	private void insertOrUpdatePollData(Connection connection, PollData pollData, String domain) {
-		String UPDATE_POLL_DATA = "UPDATE poll_data SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE queue_name = :queueName AND domain = :domain";
-		int result = connection.createQuery(UPDATE_POLL_DATA)
-				.addParameter("queueName", pollData.getQueueName())
-				.addParameter("domain", domain)
-				.addParameter("jsonData", toJson(pollData))
-				.executeUpdate()
-				.getResult();
-		if (result == 0) {
-			String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data) VALUES (:queueName, :domain, :jsonData)";
-			connection.createQuery(INSERT_POLL_DATA)
-					.addParameter("queueName", pollData.getQueueName())
-					.addParameter("domain", domain)
-					.addParameter("jsonData", toJson(pollData))
-					.executeUpdate()
-					.getResult();
-		}
-	}
-
-	private PollData readPollData(Connection connection, String queueName, String domain) {
-		String GET_POLL_DATA = "SELECT json_data FROM poll_data WHERE queue_name = :queueName AND domain = :domain";
-		String jsonStr = connection.createQuery(GET_POLL_DATA)
-				.addParameter("queueName", queueName)
-				.addParameter("domain", domain)
-				.executeScalar(String.class);
-		return jsonStr != null ? readValue(jsonStr, PollData.class) : null;
-	}
-
-	private List<PollData> readAllPollData(String queueName) {
-		String GET_ALL_POLL_DATA = "SELECT json_data FROM poll_data WHERE queue_name = :queueName";
-		return getWithTransaction(tx -> tx.createQuery(GET_ALL_POLL_DATA)
-				.addParameter("queueName", queueName)
-				.executeScalarList(String.class)
-				.stream()
-				.map(jsonData -> readValue(jsonData, PollData.class))
-				.collect(Collectors.toList()));
-	}
-
-	private List<String> findAllTasksInProgressInOrderOfArrival(Task task, int limit) {
-		String GET_IN_PROGRESS_TASKS_WITH_LIMIT = "SELECT task_id FROM task_in_progress WHERE task_def_name = :taskDefName ORDER BY id LIMIT :limit";
-		return getWithTransaction(connection ->
-			connection.createQuery(GET_IN_PROGRESS_TASKS_WITH_LIMIT)
-					.addParameter("taskDefName", task.getTaskDefName())
-					.addParameter("limit", limit)
-					.executeScalarList(String.class));
-	}
-
-	private void validate(Task task) {
-		Preconditions.checkNotNull(task, "task object cannot be null");
-		Preconditions.checkNotNull(task.getTaskId(), "Task id cannot be null");
-		Preconditions.checkNotNull(task.getWorkflowInstanceId(), "Workflow instance id cannot be null");
-		Preconditions.checkNotNull(task.getReferenceTaskName(), "Task reference name cannot be null");
-	}
-
-	private static String dateStr(Long timeInMs) {
-		Date date = new Date(timeInMs);
-		return dateStr(date);
-	}
-
-	private static String dateStr(Date date) {
-		SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
-		return format.format(date);
-	}
+import java.sql.Connection;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
+
+    private static final String ARCHIVED_FIELD = "archived";
+    private static final String RAW_JSON_FIELD = "rawJSON";
+
+    private IndexDAO indexer;
+
+    private MetadataDAO metadata;
+
+    @Inject
+    public MySQLExecutionDAO(IndexDAO indexer, MetadataDAO metadata, ObjectMapper om, DataSource dataSource) {
+        super(om, dataSource);
+        this.indexer = indexer;
+        this.metadata = metadata;
+    }
+
+    private static String dateStr(Long timeInMs) {
+        Date date = new Date(timeInMs);
+        return dateStr(date);
+    }
+
+    private static String dateStr(Date date) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        return format.format(date);
+    }
+
+    @Override
+    public List<Task> getPendingTasksByWorkflow(String taskDefName, String workflowId) {
+        //@formatter:off
+        String GET_IN_PROGRESS_TASKS_FOR_WORKFLOW =
+                "SELECT json_data FROM task_in_progress tip "
+                        + "INNER JOIN task t ON t.task_id = tip.task_id "
+                        + "WHERE task_def_name = ? AND workflow_id = ?";
+        //@formatter:on
+
+        return queryWithTransaction(GET_IN_PROGRESS_TASKS_FOR_WORKFLOW,
+                q -> q.addParameter(taskDefName).addParameter(workflowId).executeAndFetch(Task.class));
+    }
+
+    @Override
+    public List<Task> getTasks(String taskDefName, String startKey, int count) {
+        List<Task> tasks = new ArrayList<>(count);
+
+        List<Task> pendingTasks = getPendingTasksForTaskType(taskDefName);
+        boolean startKeyFound = startKey == null;
+        int found = 0;
+        for (Task pendingTask : pendingTasks) {
+            if (!startKeyFound) {
+                if (pendingTask.getTaskId().equals(startKey)) {
+                    startKeyFound = true;
+                    //noinspection ConstantConditions
+                    if (startKey != null) {
+                        continue;
+                    }
+                }
+            }
+            if (startKeyFound && found < count) {
+                tasks.add(pendingTask);
+                found++;
+            }
+        }
+
+        return tasks;
+    }
+
+    @Override
+    public List<Task> createTasks(List<Task> tasks) {
+        List<Task> created = Lists.newArrayListWithCapacity(tasks.size());
+
+        withTransaction(connection -> {
+            for (Task task : tasks) {
+                validate(task);
+
+                task.setScheduledTime(System.currentTimeMillis());
+
+                String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
+
+                boolean scheduledTaskAdded = addScheduledTask(connection, task, taskKey);
+
+                if (!scheduledTaskAdded) {
+                    logger.info("Task already scheduled, skipping the run " + task.getTaskId() + ", ref=" +
+                            task.getReferenceTaskName() + ", key=" + taskKey);
+                    continue;
+                }
+
+                insertOrUpdateTaskData(connection, task);
+                addWorkflowToTaskMapping(connection, task);
+                addTaskInProgress(connection, task);
+                updateTask(connection, task);
+
+                created.add(task);
+            }
+        });
+
+        return created;
+    }
+
+    @Override
+    public void updateTask(Task task) {
+        withTransaction(connection -> updateTask(connection, task));
+    }
+
+    @Override
+    public boolean exceedsInProgressLimit(Task task) {
+        TaskDef taskDef = metadata.getTaskDef(task.getTaskDefName());
+        if (taskDef == null) {
+            return false;
+        }
+
+        int limit = taskDef.concurrencyLimit();
+        if (limit <= 0) {
+            return false;
+        }
+
+        long current = getInProgressTaskCount(task.getTaskDefName());
+
+        if (current >= limit) {
+            Monitors.recordTaskRateLimited(task.getTaskDefName(), limit);
+            return true;
+        }
+
+        logger.info("Task execution count for {}: limit={}, current={}", task.getTaskDefName(), limit,
+                getInProgressTaskCount(task.getTaskDefName()));
+
+        String taskId = task.getTaskId();
+
+        List<String> tasksInProgressInOrderOfArrival = findAllTasksInProgressInOrderOfArrival(task, limit);
+
+        boolean rateLimited = !tasksInProgressInOrderOfArrival.contains(taskId);
+
+        if (rateLimited) {
+            logger.info("Task execution count limited. {}, limit {}, current {}", task.getTaskDefName(), limit,
+                    getInProgressTaskCount(task.getTaskDefName()));
+            Monitors.recordTaskRateLimited(task.getTaskDefName(), limit);
+        }
+
+        return rateLimited;
+    }
+
+    @Override
+    public void updateTasks(List<Task> tasks) {
+        withTransaction(connection -> tasks.forEach(task -> updateTask(connection, task)));
+    }
+
+    @Override
+    public void addTaskExecLog(List<TaskExecLog> log) {
+        indexer.addTaskExecutionLogs(log);
+    }
+
+    @Override
+    public void removeTask(String taskId) {
+        Task task = getTask(taskId);
+
+        if (task == null) {
+            logger.warn("No such Task by id {}", taskId);
+            return;
+        }
+
+        String taskKey = task.getReferenceTaskName() + "_" + task.getRetryCount();
+
+        withTransaction(connection -> {
+            removeScheduledTask(connection, task, taskKey);
+            removeWorkflowToTaskMapping(connection, task);
+            removeTaskInProgress(connection, task);
+            removeTaskData(connection, task);
+        });
+    }
+
+    @Override
+    public Task getTask(String taskId) {
+        String GET_TASK = "SELECT json_data FROM task WHERE task_id = ?";
+        return queryWithTransaction(GET_TASK, q -> q.addParameter(taskId).executeAndFetchFirst(Task.class));
+    }
+
+    @Override
+    public List<Task> getTasks(List<String> taskIds) {
+        if (taskIds.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        return getWithTransaction(c -> getTasks(c, taskIds));
+    }
+
+    @Override
+    public List<Task> getPendingTasksForTaskType(String taskName) {
+        Preconditions.checkNotNull(taskName, "task name cannot be null");
+        //@formatter:off
+        String GET_IN_PROGRESS_TASKS_FOR_TYPE =
+                "SELECT json_data FROM task_in_progress tip "
+                        + "INNER JOIN task t ON t.task_id = tip.task_id "
+                        + "WHERE task_def_name = ?";
+        //@formatter:on
+
+        return queryWithTransaction(GET_IN_PROGRESS_TASKS_FOR_TYPE,
+                q -> q.addParameter(taskName).executeAndFetch(Task.class));
+    }
+
+    @Override
+    public List<Task> getTasksForWorkflow(String workflowId) {
+        String GET_TASKS_FOR_WORKFLOW = "SELECT task_id FROM workflow_to_task WHERE workflow_id = ?";
+        return getWithTransaction(tx -> query(tx, GET_TASKS_FOR_WORKFLOW, q -> {
+            List<String> taskIds = q.addParameter(workflowId).executeScalarList(String.class);
+            return getTasks(tx, taskIds);
+        }));
+    }
+
+    @Override
+    public String createWorkflow(Workflow workflow) {
+        workflow.setCreateTime(System.currentTimeMillis());
+        return insertOrUpdateWorkflow(workflow, false);
+    }
+
+    @Override
+    public String updateWorkflow(Workflow workflow) {
+        workflow.setUpdateTime(System.currentTimeMillis());
+        return insertOrUpdateWorkflow(workflow, true);
+    }
+
+    @Override
+    public void removeWorkflow(String workflowId, boolean archiveWorkflow) {
+        try {
+            Workflow wf = getWorkflow(workflowId, true);
+
+            if (archiveWorkflow) {
+                //Add to elasticsearch
+                indexer.updateWorkflow(workflowId, new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD},
+                        new Object[]{objectMapper.writeValueAsString(wf), true});
+            } else {
+                // Not archiving, also remove workflowId from index
+                indexer.removeWorkflow(workflowId);
+            }
+
+            withTransaction(connection -> {
+                removeWorkflowDefToWorkflowMapping(connection, wf);
+                removeWorkflow(connection, workflowId);
+                removePendingWorkflow(connection, wf.getWorkflowType(), workflowId);
+            });
+
+            for (Task task : wf.getTasks()) {
+                removeTask(task.getTaskId());
+            }
+
+        } catch (Exception e) {
+            throw new ApplicationException("Unable to remove workflow " + workflowId, e);
+        }
+    }
+
+    @Override
+    public void removeFromPendingWorkflow(String workflowType, String workflowId) {
+        withTransaction(connection -> removePendingWorkflow(connection, workflowType, workflowId));
+    }
+
+    @Override
+    public Workflow getWorkflow(String workflowId) {
+        return getWorkflow(workflowId, true);
+    }
+
+    @Override
+    public Workflow getWorkflow(String workflowId, boolean includeTasks) {
+        Workflow workflow = getWithTransaction(tx -> readWorkflow(tx, workflowId));
+
+        if (workflow != null) {
+            if (includeTasks) {
+                List<Task> tasks = getTasksForWorkflow(workflowId);
+                tasks.sort(Comparator.comparingLong(Task::getScheduledTime).thenComparingInt(Task::getSeq));
+                workflow.setTasks(tasks);
+            }
+            return workflow;
+        }
+
+        //try from the archive
+        workflow = readWorkflowFromArchive(workflowId);
+
+        if (!includeTasks) {
+            workflow.getTasks().clear();
+        }
+
+        return workflow;
+    }
+
+    @Override
+    public List<String> getRunningWorkflowIds(String workflowName) {
+        Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
+        String GET_PENDING_WORKFLOW_IDS = "SELECT workflow_id FROM workflow_pending WHERE workflow_type = ?";
+
+        return queryWithTransaction(GET_PENDING_WORKFLOW_IDS,
+                q -> q.addParameter(workflowName).executeScalarList(String.class));
+    }
+
+    @Override
+    public List<Workflow> getPendingWorkflowsByType(String workflowName) {
+        Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
+        return getRunningWorkflowIds(workflowName).stream().map(this::getWorkflow).collect(Collectors.toList());
+    }
+
+    @Override
+    public long getPendingWorkflowCount(String workflowName) {
+        Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
+        String GET_PENDING_WORKFLOW_COUNT = "SELECT COUNT(*) FROM workflow_pending WHERE workflow_type = ?";
+
+        return queryWithTransaction(GET_PENDING_WORKFLOW_COUNT, q -> q.addParameter(workflowName).executeCount());
+    }
+
+    @Override
+    public long getInProgressTaskCount(String taskDefName) {
+        String GET_IN_PROGRESS_TASK_COUNT =
+                "SELECT COUNT(*) FROM task_in_progress WHERE task_def_name = ? AND in_progress_status = true";
+
+        return queryWithTransaction(GET_IN_PROGRESS_TASK_COUNT, q -> q.addParameter(taskDefName).executeCount());
+    }
+
+    @Override
+    public List<Workflow> getWorkflowsByType(String workflowName, Long startTime, Long endTime) {
+        Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
+        Preconditions.checkNotNull(startTime, "startTime cannot be null");
+        Preconditions.checkNotNull(endTime, "endTime cannot be null");
+
+        List<Workflow> workflows = new LinkedList<>();
+
+        withTransaction(tx -> {
+            //@formatter:off
+            String GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF =
+                    "SELECT workflow_id FROM workflow_def_to_workflow "
+                            + "WHERE workflow_def = ? AND date_str BETWEEN ? AND ?";
+            //@formatter:on
+
+            List<String> workflowIds = query(tx, GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF, q -> q.addParameter(workflowName)
+                    .addParameter(
+                            dateStr(startTime))
+                    .addParameter(
+                            dateStr(endTime))
+                    .executeScalarList(
+                            String.class));
+            workflowIds.forEach(workflowId -> {
+                try {
+                    Workflow wf = getWorkflow(workflowId);
+                    if (wf.getCreateTime() >= startTime && wf.getCreateTime() <= endTime) {
+                        workflows.add(wf);
+                    }
+                } catch (Exception e) {
+                    logger.error("Unable to load workflow id {} with name {}", workflowId, workflowName, e);
+                }
+            });
+        });
+
+        return workflows;
+    }
+
+    @Override
+    public List<Workflow> getWorkflowsByCorrelationId(String correlationId) {
+        Preconditions.checkNotNull(correlationId, "correlationId cannot be null");
+        String GET_WORKFLOWS_BY_CORRELATION_ID =
+                "SELECT workflow_id FROM workflow WHERE correlation_id = ?";
+
+        return queryWithTransaction(GET_WORKFLOWS_BY_CORRELATION_ID, q -> q.addParameter(correlationId)
+                .executeScalarList(String.class)
+                .stream()
+                .map(this::getWorkflow)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public boolean addEventExecution(EventExecution eventExecution) {
+        try {
+            boolean added = getWithTransaction(tx -> insertEventExecution(tx, eventExecution));
+            if (added) {
+                indexer.addEventExecution(eventExecution);
+                return true;
+            }
+            return false;
+        } catch (Exception e) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR,
+                    "Unable to add event execution " + eventExecution.getId(), e);
+        }
+    }
+
+    @Override
+    public void updateEventExecution(EventExecution eventExecution) {
+        try {
+            withTransaction(tx -> updateEventExecution(tx, eventExecution));
+            indexer.addEventExecution(eventExecution);
+        } catch (Exception e) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR,
+                    "Unable to update event execution " + eventExecution.getId(), e);
+        }
+    }
+
+    @Override
+    public List<EventExecution> getEventExecutions(String eventHandlerName, String eventName, String messageId,
+            int max) {
+        try {
+            List<EventExecution> executions = Lists.newLinkedList();
+            withTransaction(tx -> {
+                for (int i = 0; i < max; i++) {
+                    String executionId =
+                            messageId + "_" + i; //see EventProcessor.handle to understand how the execution id is set
+                    EventExecution ee = readEventExecution(tx, eventHandlerName, eventName, messageId, executionId);
+                    if (ee == null) {
+                        break;
+                    }
+                    executions.add(ee);
+                }
+            });
+            return executions;
+        } catch (Exception e) {
+            String message = String.format(
+                    "Unable to get event executions for eventHandlerName=%s, eventName=%s, messageId=%s",
+                    eventHandlerName,
+                    eventName, messageId);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, message, e);
+        }
+    }
+
+    @Override
+    public void addMessage(String queue, Message msg) {
+        indexer.addMessage(queue, msg);
+    }
+
+    @Override
+    public void updateLastPoll(String taskDefName, String domain, String workerId) {
+        Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
+        PollData pollData = new PollData(taskDefName, domain, workerId, System.currentTimeMillis());
+        String effectiveDomain = (domain == null) ? "DEFAULT" : domain;
+        withTransaction(tx -> insertOrUpdatePollData(tx, pollData, effectiveDomain));
+    }
+
+    @Override
+    public PollData getPollData(String taskDefName, String domain) {
+        Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
+        String effectiveDomain = (domain == null) ? "DEFAULT" : domain;
+        return getWithTransaction(tx -> readPollData(tx, taskDefName, effectiveDomain));
+    }
+
+    @Override
+    public List<PollData> getPollData(String taskDefName) {
+        Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
+        return readAllPollData(taskDefName);
+    }
+
+    private List<Task> getTasks(Connection connection, List<String> taskIds) {
+        if (taskIds.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        // Generate a formatted query string with a variable number of bind params based on taskIds.size()
+        final String GET_TASKS_FOR_IDS = String.format(
+                "SELECT json_data FROM task WHERE task_id IN (%s) AND json_data IS NOT NULL",
+                Query.generateInBindings(taskIds.size()));
+
+        return query(connection, GET_TASKS_FOR_IDS, q -> q.addParameters(taskIds).executeAndFetch(Task.class));
+    }
+
+    private String insertOrUpdateWorkflow(Workflow workflow, boolean update) {
+        Preconditions.checkNotNull(workflow, "workflow object cannot be null");
+
+        boolean terminal = workflow.getStatus().isTerminal();
+
+        if (terminal) {
+            workflow.setEndTime(System.currentTimeMillis());
+        }
+
+        List<Task> tasks = workflow.getTasks();
+        workflow.setTasks(Lists.newLinkedList());
+
+        withTransaction(tx -> {
+            if (!update) {
+                addWorkflow(tx, workflow);
+                addWorkflowDefToWorkflowMapping(tx, workflow);
+            } else {
+                updateWorkflow(tx, workflow);
+            }
+
+            if (terminal) {
+                removePendingWorkflow(tx, workflow.getWorkflowType(), workflow.getWorkflowId());
+            } else {
+                addPendingWorkflow(tx, workflow.getWorkflowType(), workflow.getWorkflowId());
+            }
+        });
+
+        workflow.setTasks(tasks);
+        indexer.indexWorkflow(workflow);
+        return workflow.getWorkflowId();
+    }
+
+    private void updateTask(Connection connection, Task task) {
+        task.setUpdateTime(System.currentTimeMillis());
+        if (task.getStatus() != null && task.getStatus().isTerminal()) {
+            task.setEndTime(System.currentTimeMillis());
+        }
+
+        TaskDef taskDef = metadata.getTaskDef(task.getTaskDefName());
+
+        if (taskDef != null && taskDef.concurrencyLimit() > 0) {
+            boolean inProgress = task.getStatus() != null && task.getStatus().equals(Task.Status.IN_PROGRESS);
+            updateInProgressStatus(connection, task, inProgress);
+        }
+
+        insertOrUpdateTaskData(connection, task);
+
+        if (task.getStatus() != null && task.getStatus().isTerminal()) {
+            removeTaskInProgress(connection, task);
+        }
+
+        indexer.indexTask(task);
+    }
+
+    private Workflow readWorkflow(Connection connection, String workflowId) {
+        String GET_WORKFLOW = "SELECT json_data FROM workflow WHERE workflow_id = ?";
+
+        return query(connection, GET_WORKFLOW, q -> q.addParameter(workflowId).executeAndFetchFirst(Workflow.class));
+    }
+
+    private Workflow readWorkflowFromArchive(String workflowId) {
+        String json = indexer.get(workflowId, RAW_JSON_FIELD);
+        if (json != null) {
+            return readValue(json, Workflow.class);
+        } else {
+            throw new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                    "No such workflow found by id: " + workflowId);
+        }
+    }
+
+    private void addWorkflow(Connection connection, Workflow workflow) {
+        String INSERT_WORKFLOW = "INSERT INTO workflow (workflow_id, correlation_id, json_data) VALUES (?, ?, ?)";
+
+        execute(connection, INSERT_WORKFLOW, q -> q.addParameter(workflow.getWorkflowId())
+                .addParameter(workflow.getCorrelationId())
+                .addJsonParameter(workflow)
+                .executeUpdate());
+    }
+
+    private void updateWorkflow(Connection connection, Workflow workflow) {
+        String UPDATE_WORKFLOW =
+                "UPDATE workflow SET json_data = ?, modified_on = CURRENT_TIMESTAMP WHERE workflow_id = ?";
+
+        execute(connection, UPDATE_WORKFLOW,
+                q -> q.addJsonParameter(workflow).addParameter(workflow.getWorkflowId()).executeUpdate());
+    }
+
+    private void removeWorkflow(Connection connection, String workflowId) {
+        String REMOVE_WORKFLOW = "DELETE FROM workflow WHERE workflow_id = ?";
+        execute(connection, REMOVE_WORKFLOW, q -> q.addParameter(workflowId).executeDelete());
+    }
+
+    private void addPendingWorkflow(Connection connection, String workflowType, String workflowId) {
+        String EXISTS_PENDING_WORKFLOW =
+                "SELECT EXISTS(SELECT 1 FROM workflow_pending WHERE workflow_type = ? AND workflow_id = ?)";
+
+        boolean exist = query(connection, EXISTS_PENDING_WORKFLOW,
+                q -> q.addParameter(workflowType).addParameter(workflowId).exists());
+
+        if (!exist) {
+            String INSERT_PENDING_WORKFLOW = "INSERT INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?)";
+
+            execute(connection, INSERT_PENDING_WORKFLOW,
+                    q -> q.addParameter(workflowType).addParameter(workflowId).executeUpdate());
+        }
+    }
+
+    private void removePendingWorkflow(Connection connection, String workflowType, String workflowId) {
+        String REMOVE_PENDING_WORKFLOW = "DELETE FROM workflow_pending WHERE workflow_type = ? AND workflow_id = ?";
+
+        execute(connection, REMOVE_PENDING_WORKFLOW,
+                q -> q.addParameter(workflowType).addParameter(workflowId).executeDelete());
+    }
+
+    private void insertOrUpdateTaskData(Connection connection, Task task) {
+        String UPDATE_TASK =
+                "UPDATE task SET json_data = ?, modified_on = CURRENT_TIMESTAMP WHERE task_id = ?";
+
+        int result = query(connection, UPDATE_TASK,
+                q -> q.addJsonParameter(task).addParameter(task.getTaskId()).executeUpdate());
+
+        if (result == 0) {
+            String INSERT_TASK = "INSERT INTO task (task_id, json_data) VALUES (?, ?)";
+
+            execute(connection, INSERT_TASK,
+                    q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
+        }
+    }
+
+    private void removeTaskData(Connection connection, Task task) {
+        String REMOVE_TASK = "DELETE FROM task WHERE task_id = ?";
+        execute(connection, REMOVE_TASK, q -> q.addParameter(task.getTaskId()).executeDelete());
+    }
+
+    private void addWorkflowToTaskMapping(Connection connection, Task task) {
+        String EXISTS_WORKFLOW_TO_TASK =
+                "SELECT EXISTS(SELECT 1 FROM workflow_to_task WHERE workflow_id = ? AND task_id = ?)";
+
+        boolean exist = query(connection, EXISTS_WORKFLOW_TO_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
+                .addParameter(task.getTaskId())
+                .exists());
+
+        if (!exist) {
+            String INSERT_WORKFLOW_TO_TASK = "INSERT INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?)";
+
+            execute(connection, INSERT_WORKFLOW_TO_TASK,
+                    q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeUpdate());
+        }
+    }
+
+    private void removeWorkflowToTaskMapping(Connection connection, Task task) {
+        String REMOVE_WORKFLOW_TO_TASK = "DELETE FROM workflow_to_task WHERE workflow_id = ? AND task_id = ?";
+
+        execute(connection, REMOVE_WORKFLOW_TO_TASK,
+                q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeDelete());
+    }
+
+    private void addWorkflowDefToWorkflowMapping(Connection connection, Workflow workflow) {
+        String INSERT_WORKFLOW_DEF_TO_WORKFLOW =
+                "INSERT INTO workflow_def_to_workflow (workflow_def, date_str, workflow_id) VALUES (?, ?, ?)";
+
+        execute(connection, INSERT_WORKFLOW_DEF_TO_WORKFLOW, q -> q.addParameter(workflow.getWorkflowType())
+                .addParameter(dateStr(workflow.getCreateTime()))
+                .addParameter(workflow.getWorkflowId())
+                .executeUpdate());
+    }
+
+    private void removeWorkflowDefToWorkflowMapping(Connection connection, Workflow workflow) {
+        String REMOVE_WORKFLOW_DEF_TO_WORKFLOW =
+                "DELETE FROM workflow_def_to_workflow WHERE workflow_def = ? AND date_str = ? AND workflow_id = ?";
+
+        execute(connection, REMOVE_WORKFLOW_DEF_TO_WORKFLOW, q -> q.addParameter(workflow.getWorkflowType())
+                .addParameter(dateStr(workflow.getCreateTime()))
+                .addParameter(workflow.getWorkflowId())
+                .executeUpdate());
+    }
+
+    private boolean addScheduledTask(Connection connection, Task task, String taskKey) {
+        String EXISTS_SCHEDULED_TASK =
+                "SELECT EXISTS(SELECT 1 FROM task_scheduled WHERE workflow_id = ? AND task_key = ?)";
+        boolean exist = query(connection, EXISTS_SCHEDULED_TASK,
+                q -> q.addParameter(task.getWorkflowInstanceId())
+                        .addParameter(taskKey).exists());
+
+        if (!exist) {
+            String INSERT_SCHEDULED_TASK =
+                    "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?)";
+
+            execute(connection, INSERT_SCHEDULED_TASK,
+                    q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(taskKey)
+                            .addParameter(task.getTaskId()).executeUpdate());
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private void removeScheduledTask(Connection connection, Task task, String taskKey) {
+        String REMOVE_SCHEDULED_TASK = "DELETE FROM task_scheduled WHERE workflow_id = ? AND task_key = ?";
+        execute(connection, REMOVE_SCHEDULED_TASK,
+                q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(taskKey).executeDelete());
+    }
+
+    private void addTaskInProgress(Connection connection, Task task) {
+        String EXISTS_IN_PROGRESS_TASK =
+                "SELECT EXISTS(SELECT 1 FROM task_in_progress WHERE task_def_name = ? AND task_id = ?)";
+
+        boolean exist = query(connection, EXISTS_IN_PROGRESS_TASK,
+                q -> q.addParameter(task.getTaskDefName()).addParameter(task.getTaskId()).exists());
+
+        if (!exist) {
+            String INSERT_IN_PROGRESS_TASK =
+                    "INSERT INTO task_in_progress (task_def_name, task_id, workflow_id) VALUES (?, ?, ?)";
+
+            execute(connection, INSERT_IN_PROGRESS_TASK,
+                    q -> q.addParameter(task.getTaskDefName())
+                            .addParameter(task.getTaskId())
+                            .addParameter(task.getWorkflowInstanceId())
+                            .executeUpdate());
+        }
+    }
+
+    private void removeTaskInProgress(Connection connection, Task task) {
+        String REMOVE_IN_PROGRESS_TASK =
+                "DELETE FROM task_in_progress WHERE task_def_name = ? AND task_id = ?";
+
+        execute(connection, REMOVE_IN_PROGRESS_TASK, q ->
+                q.addParameter(task.getTaskDefName())
+                        .addParameter(task.getTaskId())
+                        .executeUpdate());
+    }
+
+    private void updateInProgressStatus(Connection connection, Task task, boolean inProgress) {
+        String UPDATE_IN_PROGRESS_TASK_STATUS =
+                "UPDATE task_in_progress SET in_progress_status = ?, modified_on = CURRENT_TIMESTAMP "
+                        + "WHERE task_def_name = ? AND task_id = ?";
+
+        execute(connection, UPDATE_IN_PROGRESS_TASK_STATUS, q ->
+                q.addParameter(inProgress)
+                        .addParameter(task.getTaskDefName())
+                        .addParameter(task.getTaskId())
+                        .executeUpdate());
+    }
+
+    private boolean insertEventExecution(Connection connection, EventExecution eventExecution) {
+        //@formatter:off
+        String EXISTS_EVENT_EXECUTION =
+                "SELECT EXISTS(SELECT 1 FROM event_execution "
+                        + "WHERE event_handler_name = ? "
+                        + "AND event_name = ? "
+                        + "AND message_id = ? "
+                        + "AND execution_id = ?)";
+        //@formatter:on
+
+        boolean exist = query(connection, EXISTS_EVENT_EXECUTION, q ->
+                q.addParameter(eventExecution.getName())
+                        .addParameter(eventExecution.getEvent())
+                        .addParameter(eventExecution.getMessageId())
+                        .addParameter(eventExecution.getId()).exists());
+
+        if (!exist) {
+            String INSERT_EVENT_EXECUTION =
+                    "INSERT INTO event_execution (event_handler_name, event_name, message_id, execution_id, json_data) "
+                            + "VALUES (?, ?, ?, ?, ?)";
+
+            execute(connection, INSERT_EVENT_EXECUTION, q ->
+                    q.addParameter(eventExecution.getName())
+                            .addParameter(eventExecution.getEvent())
+                            .addParameter(eventExecution.getMessageId())
+                            .addParameter(eventExecution.getId())
+                            .addJsonParameter(eventExecution).executeUpdate());
+        }
+        return false;
+    }
+
+    private void updateEventExecution(Connection connection, EventExecution eventExecution) {
+        //@formatter:off
+        String UPDATE_EVENT_EXECUTION = "UPDATE event_execution SET "
+                + "json_data = ?, "
+                + "modified_on = CURRENT_TIMESTAMP "
+                + "WHERE event_handler_name = ? "
+                + "AND execution_event = ? "
+                + "AND message_id = ? "
+                + "AND execution_id = ?";
+        //@formatter:on
+
+        execute(connection, UPDATE_EVENT_EXECUTION, q ->
+                q.addJsonParameter(eventExecution)
+                        .addParameter(eventExecution.getName())
+                        .addParameter(eventExecution.getEvent())
+                        .addParameter(eventExecution.getMessageId()).addParameter(eventExecution.getId())
+                        .executeUpdate());
+    }
+
+    private EventExecution readEventExecution(Connection connection, String eventHandlerName, String eventName,
+            String messageId, String executionId) {
+        //@formatter:off
+        String GET_EVENT_EXECUTION =
+                "SELECT json_data FROM event_execution "
+                        + "WHERE event_handler_name = ? "
+                        + "AND event_name = ? "
+                        + "AND message_id = ? "
+                        + "AND execution_id = ?";
+        //@formatter:on
+        return query(connection, GET_EVENT_EXECUTION, q ->
+                q.addParameter(eventHandlerName)
+                        .addParameter(eventName)
+                        .addParameter(messageId)
+                        .addParameter(executionId)
+                        .executeAndFetchFirst(EventExecution.class));
+    }
+
+    private void insertOrUpdatePollData(Connection connection, PollData pollData, String domain) {
+        String UPDATE_POLL_DATA =
+                "UPDATE poll_data SET json_data = ?, modified_on = CURRENT_TIMESTAMP "
+                        + "WHERE queue_name = ? AND domain = ?";
+
+        int result = query(connection, UPDATE_POLL_DATA, q ->
+                q.addJsonParameter(pollData)
+                        .addParameter(pollData.getQueueName())
+                        .addParameter(domain)
+                        .executeUpdate());
+
+        if (result == 0) {
+            String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data) VALUES (?, ?, ?)";
+            execute(connection, INSERT_POLL_DATA, q ->
+                    q.addParameter(pollData.getQueueName())
+                            .addParameter(domain)
+                            .addJsonParameter(pollData)
+                            .executeUpdate());
+        }
+    }
+
+    private PollData readPollData(Connection connection, String queueName, String domain) {
+        String GET_POLL_DATA = "SELECT json_data FROM poll_data WHERE queue_name = ? AND domain = ?";
+        return query(connection, GET_POLL_DATA, q ->
+                q.addParameter(queueName)
+                        .addParameter(domain)
+                        .executeAndFetchFirst(PollData.class));
+    }
+
+    private List<PollData> readAllPollData(String queueName) {
+        String GET_ALL_POLL_DATA = "SELECT json_data FROM poll_data WHERE queue_name = ?";
+        return queryWithTransaction(GET_ALL_POLL_DATA, q -> q.addParameter(queueName).executeAndFetch(PollData.class));
+    }
+
+    private List<String> findAllTasksInProgressInOrderOfArrival(Task task, int limit) {
+        String GET_IN_PROGRESS_TASKS_WITH_LIMIT =
+                "SELECT task_id FROM task_in_progress WHERE task_def_name = ? ORDER BY id LIMIT ?";
+
+        return queryWithTransaction(GET_IN_PROGRESS_TASKS_WITH_LIMIT, q ->
+                q.addParameter(task.getTaskDefName())
+                        .addParameter(limit)
+                        .executeScalarList(String.class));
+    }
+
+    private void validate(Task task) {
+        Preconditions.checkNotNull(task, "task object cannot be null");
+        Preconditions.checkNotNull(task.getTaskId(), "Task id cannot be null");
+        Preconditions.checkNotNull(task.getWorkflowInstanceId(), "Workflow instance id cannot be null");
+        Preconditions.checkNotNull(task.getReferenceTaskName(), "Task reference name cannot be null");
+    }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
@@ -1,19 +1,8 @@
 package com.netflix.conductor.dao.mysql;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
-import org.sql2o.Connection;
-import org.sql2o.Sql2o;
+import com.google.common.base.Preconditions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -21,249 +10,421 @@ import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.dao.MetadataDAO;
 
-class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
-	private Map<String, TaskDef> taskDefCache = new HashMap<>();
+import javax.inject.Inject;
+import javax.sql.DataSource;
 
-	@Inject
-	MySQLMetadataDAO(ObjectMapper om, Sql2o sql2o, Configuration config) {
-		super(om, sql2o);
-		refreshTaskDefs();
-		int cacheRefreshTime = config.getIntProperty("conductor.taskdef.cache.refresh.time.seconds", 60);
-		Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(this::refreshTaskDefs, cacheRefreshTime, cacheRefreshTime, TimeUnit.SECONDS);
-	}
 
-	@Override
-	public String createTaskDef(TaskDef taskDef) {
-		validate(taskDef);
-		taskDef.setCreateTime(System.currentTimeMillis());
-		return insertOrUpdateTaskDef(taskDef);
-	}
+/**
+ * @author mustafa
+ */
+public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
+    public static final String PROP_TASKDEF_CACHE_REFRESH = "conductor.taskdef.cache.refresh.time.seconds";
+    public static final int DEFAULT_TASKDEF_CACHE_REFRESH_SECONDS = 60;
+    private final ConcurrentHashMap<String, TaskDef> taskDefCache = new ConcurrentHashMap<>();
 
-	@Override
-	public String updateTaskDef(TaskDef taskDef) {
-		validate(taskDef);
-		taskDef.setUpdateTime(System.currentTimeMillis());
-		return insertOrUpdateTaskDef(taskDef);
-	}
+    @Inject
+    public MySQLMetadataDAO(ObjectMapper om, DataSource dataSource, Configuration config) {
+        super(om, dataSource);
 
-	@Override
-	public TaskDef getTaskDef(String name) {
-		Preconditions.checkNotNull(name, "TaskDef name cannot be null");
-		TaskDef taskDef = taskDefCache.get(name);
-		if (taskDef == null) {
-			taskDef = getTaskDefFromDB(name);
-		}
-		return taskDef;
-	}
+        int cacheRefreshTime = config.getIntProperty(PROP_TASKDEF_CACHE_REFRESH, DEFAULT_TASKDEF_CACHE_REFRESH_SECONDS);
+        Executors.newSingleThreadScheduledExecutor()
+                 .scheduleWithFixedDelay(this::refreshTaskDefs, cacheRefreshTime, cacheRefreshTime, TimeUnit.SECONDS);
+    }
 
-	private TaskDef getTaskDefFromDB(String name) {
-		String READ_ONE_TASKDEF_QUERY = "SELECT json_data FROM meta_task_def WHERE name = :name";
-		String taskDefJsonStr = getWithTransaction(conn -> conn.createQuery(READ_ONE_TASKDEF_QUERY).addParameter("name", name).executeScalar(String.class));
-		return taskDefJsonStr != null ? readValue(taskDefJsonStr, TaskDef.class) : null;
-	}
+    @Override
+    public String createTaskDef(TaskDef taskDef) {
+        validate(taskDef);
+        if (null == taskDef.getCreateTime() || taskDef.getCreateTime() < 1) {
+            taskDef.setCreateTime(System.currentTimeMillis());
+        }
 
-	@Override
-	public List<TaskDef> getAllTaskDefs() {
-		return getWithTransaction(this::findAllTaskDefs);
-	}
+        return insertOrUpdateTaskDef(taskDef);
+    }
 
-	@Override
-	public void removeTaskDef(String name) {
-		withTransaction(connection -> {
-			String DELETE_TASKDEF_QUERY = "DELETE FROM meta_task_def WHERE name = :name";
-			int deleted = connection.createQuery(DELETE_TASKDEF_QUERY).addParameter("name", name).executeUpdate().getResult();
-			if (deleted != 1) {
-				throw new ApplicationException(ApplicationException.Code.NOT_FOUND, "Cannot remove the task - no such task definition");
-			}
-			refreshTaskDefs(connection);
-		});
-	}
+    @Override
+    public String updateTaskDef(TaskDef taskDef) {
+        validate(taskDef);
+        taskDef.setUpdateTime(System.currentTimeMillis());
+        return insertOrUpdateTaskDef(taskDef);
+    }
 
-	@Override
-	public void create(WorkflowDef def) {
-		validate(def);
-		def.setCreateTime(System.currentTimeMillis());
-		withTransaction(connection -> {
-			if (workflowExists(connection, def)) {
-				throw new ApplicationException(ApplicationException.Code.CONFLICT, "Workflow with " + def.key() + " already exists!");
-			}
-			insertOrUpdateWorkflowDef(connection, def);
-		});
-	}
+    @Override
+    public TaskDef getTaskDef(String name) {
+        Preconditions.checkNotNull(name, "TaskDef name cannot be null");
+        TaskDef taskDef = taskDefCache.get(name);
+        if (taskDef == null) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Cache miss: {}", name);
+            }
+            taskDef = getTaskDefFromDB(name);
+        }
 
-	@Override
-	public void update(WorkflowDef def) {
-		validate(def);
-		def.setUpdateTime(System.currentTimeMillis());
-		withTransaction(connection -> insertOrUpdateWorkflowDef(connection, def));
-	}
+        return taskDef;
+    }
 
-	@Override
-	public WorkflowDef getLatest(String name) {
-		String GET_LATEST_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE NAME = :name AND version = latest_version";
-		String workflowJsonStr = getWithTransaction(conn -> conn.createQuery(GET_LATEST_WORKFLOW_DEF_QUERY).addParameter("name", name).executeScalar(String.class));
-		return (workflowJsonStr != null) ? readValue(workflowJsonStr, WorkflowDef.class) : null;
-	}
+    @Override
+    public List<TaskDef> getAllTaskDefs() {
+        return getWithTransaction(this::findAllTaskDefs);
+    }
 
-	@Override
-	public WorkflowDef get(String name, int version) {
-		String GET_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE NAME = :name AND version = :version";
-		String workflowJsonStr = getWithTransaction(conn -> conn.createQuery(GET_WORKFLOW_DEF_QUERY).addParameter("name", name).addParameter("version", version).executeScalar(String.class));
-		return (workflowJsonStr != null) ? readValue(workflowJsonStr, WorkflowDef.class) : null;
-	}
+    @Override
+    public void removeTaskDef(String name) {
+        final String DELETE_TASKDEF_QUERY = "DELETE FROM meta_task_def WHERE name = ?";
 
-	@Override
-	public List<String> findAll() {
-		String FIND_ALL_WORKFLOW_DEF_QUERY = "SELECT DISTINCT name FROM meta_workflow_def";
-		return getWithTransaction(conn -> conn.createQuery(FIND_ALL_WORKFLOW_DEF_QUERY).executeScalarList(String.class));
-	}
+        executeWithTransaction(DELETE_TASKDEF_QUERY, q -> {
+            if (!q.addParameter(name).executeDelete()) {
+                throw new ApplicationException(ApplicationException.Code.NOT_FOUND, "No such task definition");
+            }
 
-	@Override
-	public List<WorkflowDef> getAll() {
-		String GET_ALL_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def ORDER BY name, version";
-		return getWithTransaction(conn -> conn.createQuery(GET_ALL_WORKFLOW_DEF_QUERY).executeScalarList(String.class)).stream()
-				.map(jsonData -> readValue(jsonData, WorkflowDef.class))
-				.collect(Collectors.toList());
-	}
+            taskDefCache.remove(name);
+        });
+    }
 
-	@Override
-	public List<WorkflowDef> getAllLatest() {
-		String GET_ALL_LATEST_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE version = latest_version";
-		return getWithTransaction(conn -> conn.createQuery(GET_ALL_LATEST_WORKFLOW_DEF_QUERY).executeScalarList(String.class)).stream()
-				.map(jsonData -> readValue(jsonData, WorkflowDef.class))
-				.collect(Collectors.toList());
-	}
+    @Override
+    public void create(WorkflowDef def) {
+        validate(def);
+        if (null == def.getCreateTime() || def.getCreateTime() == 0) {
+            def.setCreateTime(System.currentTimeMillis());
+        }
 
-	@Override
-	public List<WorkflowDef> getAllVersions(String name) {
-		String GET_ALL_VERSIONS_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE name = :name ORDER BY version";
-		return getWithTransaction(conn -> conn.createQuery(GET_ALL_VERSIONS_WORKFLOW_DEF_QUERY).addParameter("name",name).executeScalarList(String.class)).stream()
-				.map(jsonData -> readValue(jsonData, WorkflowDef.class))
-				.collect(Collectors.toList());
-	}
+        withTransaction(tx -> {
+            if (workflowExists(tx, def)) {
+                throw new ApplicationException(ApplicationException.Code.CONFLICT,
+                                               "Workflow with " + def.key() + " already exists!");
+            }
 
-	@Override
-	public void addEventHandler(EventHandler eventHandler) {
-		Preconditions.checkNotNull(eventHandler.getName(), "EventHandler name cannot be null");
-		withTransaction(connection -> {
-			if (getEventHandler(connection, eventHandler.getName()) != null) {
-				throw new ApplicationException(ApplicationException.Code.CONFLICT, "EventHandler with name " + eventHandler.getName() + " already exists!");
-			}
-			String INSERT_EVENT_HANDLER_QUERY = "INSERT INTO meta_event_handler (name, event, active, json_data) VALUES (:name, :event, :active, :jsonData)";
-			connection.createQuery(INSERT_EVENT_HANDLER_QUERY).bind(eventHandler).addParameter("jsonData", toJson(eventHandler)).executeUpdate();
-		});
-	}
+            insertOrUpdateWorkflowDef(tx, def);
+        });
+    }
 
-	@Override
-	public void updateEventHandler(EventHandler eventHandler) {
-		Preconditions.checkNotNull(eventHandler.getName(), "EventHandler name cannot be null");
-		withTransaction(connection -> {
-			EventHandler existing = getEventHandler(connection, eventHandler.getName());
-			if (existing == null) {
-				throw new ApplicationException(ApplicationException.Code.NOT_FOUND, "EventHandler with name " + eventHandler.getName() + " not found!");
-			}
-			String UPDATE_EVENT_HANDLER_QUERY = "UPDATE meta_event_handler SET event = :event, active = :active, json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE name = :name";
-			connection.createQuery(UPDATE_EVENT_HANDLER_QUERY).bind(eventHandler).addParameter("jsonData", toJson(eventHandler)).executeUpdate();
-		});
-	}
+    @Override
+    public void update(WorkflowDef def) {
+        validate(def);
+        def.setUpdateTime(System.currentTimeMillis());
+        withTransaction(tx -> insertOrUpdateWorkflowDef(tx, def));
+    }
 
-	@Override
-	public void removeEventHandlerStatus(String name) {
-		withTransaction(connection -> {
-			EventHandler existing = getEventHandler(connection, name);
-			if (existing == null) {
-				throw new ApplicationException(ApplicationException.Code.NOT_FOUND, "EventHandler with name " + name + " not found!");
-			}
-			String DELETE_EVENT_HANDLER_QUERY = "DELETE FROM meta_event_handler WHERE name = :name";
-			connection.createQuery(DELETE_EVENT_HANDLER_QUERY).addParameter("name", name).executeUpdate();
-		});
-	}
 
-	private EventHandler getEventHandler(Connection connection, String name) {
-		String READ_ONE_EVENT_HANDLER_QUERY = "SELECT json_data FROM meta_event_handler WHERE name = :name";
-		String eventHandlerStr = connection.createQuery(READ_ONE_EVENT_HANDLER_QUERY).addParameter("name", name).executeScalar(String.class);
-		return eventHandlerStr != null ? readValue(eventHandlerStr, EventHandler.class) : null;
-	}
+    @Override
+    public WorkflowDef getLatest(String name) {
+        final String GET_LATEST_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE NAME = ? AND " +
+                                                     "version = latest_version";
 
-	@Override
-	public List<EventHandler> getEventHandlers() {
-		String READ_ALL_EVENT_HANDLER_QUERY = "SELECT json_data FROM meta_event_handler";
-		return getWithTransaction(conn -> conn.createQuery(READ_ALL_EVENT_HANDLER_QUERY).executeScalarList(String.class)).stream()
-				.map(jsonData -> readValue(jsonData, EventHandler.class))
-				.collect(Collectors.toList());
-	}
+        return queryWithTransaction(GET_LATEST_WORKFLOW_DEF_QUERY,
+                                    q -> q.addParameter(name).executeAndFetchFirst(WorkflowDef.class));
+    }
 
-	@Override
-	public List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly) {
-		String READ_ALL_EVENT_HANDLER_BY_EVENT_QUERY = "SELECT json_data FROM meta_event_handler WHERE event = :event";
-		return getWithTransaction(conn -> conn.createQuery(READ_ALL_EVENT_HANDLER_BY_EVENT_QUERY).addParameter("event", event).executeScalarList(String.class)).stream()
-				.map(jsonData -> readValue(jsonData, EventHandler.class))
-				.filter(eventHandler -> (!activeOnly || eventHandler.isActive()))
-				.collect(Collectors.toList());
-	}
+    @Override
+    public WorkflowDef get(String name, int version) {
+        final String GET_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE NAME = ? AND version = ?";
+        return queryWithTransaction(GET_WORKFLOW_DEF_QUERY, q -> q.addParameter(name)
+                                                                  .addParameter(version)
+                                                                  .executeAndFetchFirst(WorkflowDef.class));
+    }
 
-	private void refreshTaskDefs(Connection connection) {
-		Map<String, TaskDef> map = new HashMap<>();
-		findAllTaskDefs(connection).forEach(taskDef -> map.put(taskDef.getName(), taskDef));
-		this.taskDefCache = map;
-	}
+    @Override
+    public List<String> findAll() {
+        final String FIND_ALL_WORKFLOW_DEF_QUERY = "SELECT DISTINCT name FROM meta_workflow_def";
+        return queryWithTransaction(FIND_ALL_WORKFLOW_DEF_QUERY, q -> q.executeAndFetch(String.class));
+    }
 
-	private void refreshTaskDefs() {
-		withTransaction(this::refreshTaskDefs);
-	}
+    @Override
+    public List<WorkflowDef> getAll() {
+        final String GET_ALL_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def ORDER BY name, version";
 
-	private void validate(TaskDef taskDef) {
-		Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
-		Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
-	}
+        return queryWithTransaction(GET_ALL_WORKFLOW_DEF_QUERY, q -> q.executeAndFetch(WorkflowDef.class));
+    }
 
-	private void validate(WorkflowDef def) {
-		Preconditions.checkNotNull(def, "WorkflowDef object cannot be null");
-		Preconditions.checkNotNull(def.getName(), "WorkflowDef name cannot be null");
-	}
+    @Override
+    public List<WorkflowDef> getAllLatest() {
+        final String GET_ALL_LATEST_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE version = " +
+                                                         "latest_version";
 
-	private String insertOrUpdateTaskDef(TaskDef taskDef) {
-		withTransaction(connection -> {
-			String UPDATE_TASKDEF_QUERY = "UPDATE meta_task_def SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE name = :name";
-			int result = connection.createQuery(UPDATE_TASKDEF_QUERY).bind(taskDef).addParameter("jsonData", toJson(taskDef)).executeUpdate().getResult();
-			if (result == 0) {
-				String INSERT_TASKDEF_QUERY = "INSERT INTO meta_task_def (name, json_data) VALUES (:name, :jsonData)";
-				connection.createQuery(INSERT_TASKDEF_QUERY).bind(taskDef).addParameter("jsonData", toJson(taskDef)).executeUpdate();
-			}
-			refreshTaskDefs(connection);
-		});
-		return taskDef.getName();
-	}
+        return queryWithTransaction(GET_ALL_LATEST_WORKFLOW_DEF_QUERY, q -> q.executeAndFetch(WorkflowDef.class));
+    }
 
-	private void insertOrUpdateWorkflowDef(Connection connection, WorkflowDef def) {
+    @Override
+    public List<WorkflowDef> getAllVersions(String name) {
+        final String GET_ALL_VERSIONS_WORKFLOW_DEF_QUERY = "SELECT json_data FROM meta_workflow_def WHERE name = ? " +
+                                                           "ORDER BY version";
 
-		String GET_LATEST_WORKFLOW_DEF_VERSION = "SELECT max(version) AS version FROM meta_workflow_def WHERE name = :name";
-		Integer latestVersion = connection.createQuery(GET_LATEST_WORKFLOW_DEF_VERSION).bind(def).executeScalar(Integer.class);
+        return queryWithTransaction(GET_ALL_VERSIONS_WORKFLOW_DEF_QUERY,
+                                    q -> q.addParameter(name).executeAndFetch(WorkflowDef.class));
+    }
 
-		if (latestVersion == null || latestVersion < def.getVersion()) {
-			String INSERT_WORKFLOW_DEF_QUERY = "INSERT INTO meta_workflow_def (name, version, json_data) VALUES (:name, :version, :jsonData)";
-			connection.createQuery(INSERT_WORKFLOW_DEF_QUERY).bind(def).addParameter("jsonData", toJson(def)).executeUpdate();
-			latestVersion = def.getVersion();
-		} else {
-			String UPDATE_WORKFLOW_DEF_QUERY = "UPDATE meta_workflow_def SET json_data = :jsonData, modified_on = CURRENT_TIMESTAMP WHERE name = :name AND version = :version";
-			connection.createQuery(UPDATE_WORKFLOW_DEF_QUERY).bind(def).addParameter("jsonData", toJson(def)).executeUpdate();
-		}
+    @Override
+    public void addEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler.getName(), "EventHandler name cannot be null");
 
-		String UPDATE_WORKFLOW_DEF_LATEST_VERSION_QUERY = "UPDATE meta_workflow_def SET latest_version = :latest_version WHERE name = :name";
-		connection.createQuery(UPDATE_WORKFLOW_DEF_LATEST_VERSION_QUERY).bind(def).addParameter("latest_version", latestVersion).executeUpdate();
-	}
+        final String INSERT_EVENT_HANDLER_QUERY = "INSERT INTO meta_event_handler (name, event, active, json_data) " +
+                                                  "VALUES (?, ?, ?, ?)";
 
-	private Boolean workflowExists(Connection connection, WorkflowDef def) {
-		String CHECK_WORKFLOW_DEF_EXISTS_QUERY = "SELECT COUNT(*) FROM meta_workflow_def WHERE name = :name AND version = :version";
-		return connection.createQuery(CHECK_WORKFLOW_DEF_EXISTS_QUERY).bind(def).executeScalar(Boolean.class);
-	}
+        withTransaction(tx -> {
+            if (getEventHandler(tx, eventHandler.getName()) != null) {
+                throw new ApplicationException(ApplicationException.Code.CONFLICT,
+                                               "EventHandler with name " + eventHandler.getName() + " already exists!");
+            }
 
-	private List<TaskDef> findAllTaskDefs(Connection connection) {
-		String READ_ALL_TASKDEF_QUERY = "SELECT json_data FROM meta_task_def";
-		return connection.createQuery(READ_ALL_TASKDEF_QUERY).executeScalarList(String.class)
-				.stream()
-				.map(jsonData -> readValue(jsonData, TaskDef.class))
-				.collect(Collectors.toList());
-	}
+            execute(tx, INSERT_EVENT_HANDLER_QUERY, q -> q.addParameter(eventHandler.getName())
+                                                          .addParameter(eventHandler.getEvent())
+                                                          .addParameter(eventHandler.isActive())
+                                                          .addJsonParameter(eventHandler)
+                                                          .executeUpdate());
+        });
+    }
+
+    @Override
+    public void updateEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler.getName(), "EventHandler name cannot be null");
+
+        //@formatter:off
+        final String UPDATE_EVENT_HANDLER_QUERY = "UPDATE meta_event_handler SET " +
+                                                  "event = ?, active = ?, json_data = ?, " +
+                                                  "modified_on = CURRENT_TIMESTAMP WHERE name = ?";
+        //@formatter:on
+
+        withTransaction(tx -> {
+            EventHandler existing = getEventHandler(tx, eventHandler.getName());
+            if (existing == null) {
+                throw new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                                               "EventHandler with name " + eventHandler.getName() + " not found!");
+            }
+
+            execute(tx, UPDATE_EVENT_HANDLER_QUERY, q -> q.addParameter(eventHandler.getEvent())
+                                                          .addParameter(eventHandler.isActive())
+                                                          .addJsonParameter(eventHandler)
+                                                          .addParameter(eventHandler.getName())
+                                                          .executeUpdate());
+        });
+    }
+
+    @Override
+    public void removeEventHandlerStatus(String name) {
+        final String DELETE_EVENT_HANDLER_QUERY = "DELETE FROM meta_event_handler WHERE name = ?";
+
+        withTransaction(tx -> {
+            EventHandler existing = getEventHandler(tx, name);
+            if (existing == null) {
+                throw new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                                               "EventHandler with name " + name + " not found!");
+            }
+
+            execute(tx, DELETE_EVENT_HANDLER_QUERY, q -> q.addParameter(name).executeDelete());
+        });
+    }
+
+    @Override
+    public List<EventHandler> getEventHandlers() {
+        final String READ_ALL_EVENT_HANDLER_QUERY = "SELECT json_data FROM meta_event_handler";
+        return queryWithTransaction(READ_ALL_EVENT_HANDLER_QUERY, q -> q.executeAndFetch(EventHandler.class));
+    }
+
+    @Override
+    public List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly) {
+        final String READ_ALL_EVENT_HANDLER_BY_EVENT_QUERY = "SELECT json_data FROM meta_event_handler WHERE event = ?";
+        return queryWithTransaction(READ_ALL_EVENT_HANDLER_BY_EVENT_QUERY, q -> {
+            q.addParameter(event);
+            return q.executeAndFetch(rs -> {
+                List<EventHandler> handlers = new ArrayList<>();
+                while (rs.next()) {
+                    EventHandler h = readValue(rs.getString(1), EventHandler.class);
+                    if (!activeOnly || h.isActive()) {
+                        handlers.add(h);
+                    }
+                }
+
+                return handlers;
+            });
+        });
+    }
+
+    /**
+     * Use {@link Preconditions} to check for required {@link TaskDef} fields, throwing a Runtime exception
+     * if validations fail.
+     *
+     * @param taskDef The {@code TaskDef} to check.
+     */
+    private void validate(TaskDef taskDef) {
+        Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
+        Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
+    }
+
+    /**
+     * Use {@link Preconditions} to check for required {@link WorkflowDef} fields, throwing a Runtime exception
+     * if validations fail.
+     *
+     * @param def The {@code WorkflowDef} to check.
+     */
+    private void validate(WorkflowDef def) {
+        Preconditions.checkNotNull(def, "WorkflowDef object cannot be null");
+        Preconditions.checkNotNull(def.getName(), "WorkflowDef name cannot be null");
+    }
+
+    /**
+     * Retrieve a {@link EventHandler} by {@literal name}.
+     *
+     * @param connection The {@link Connection} to use for queries.
+     * @param name       The {@code EventHandler} name to look for.
+     * @return {@literal null} if nothing is found, otherwise the {@code EventHandler}.
+     */
+    private EventHandler getEventHandler(Connection connection, String name) {
+        final String READ_ONE_EVENT_HANDLER_QUERY = "SELECT json_data FROM meta_event_handler WHERE name = ?";
+
+        return query(connection, READ_ONE_EVENT_HANDLER_QUERY,
+                     q -> q.addParameter(name).executeAndFetchFirst(EventHandler.class));
+    }
+
+    /**
+     * Check if a {@link WorkflowDef} with the same {@literal name} and {@literal version} already exist.
+     *
+     * @param connection The {@link Connection} to use for queries.
+     * @param def        The {@code WorkflowDef} to check for.
+     * @return {@literal true} if a {@code WorkflowDef} already exists with the same values.
+     */
+    private Boolean workflowExists(Connection connection, WorkflowDef def) {
+        final String CHECK_WORKFLOW_DEF_EXISTS_QUERY = "SELECT COUNT(*) FROM meta_workflow_def WHERE name = ? AND " +
+                                                       "version = ?";
+
+        return query(connection, CHECK_WORKFLOW_DEF_EXISTS_QUERY,
+                     q -> q.addParameter(def.getName()).addParameter(def.getVersion()).exists());
+    }
+
+    /**
+     * Return the latest version that exists for the provided {@link WorkflowDef}.
+     *
+     * @param tx  The {@link Connection} to use for queries.
+     * @param def The {@code WorkflowDef} to check for.
+     * @return {@code Optional.empty()} if no versions exist, otherwise the max {@link WorkflowDef#version} found.
+     */
+    private Optional<Integer> getLatestVersion(Connection tx, WorkflowDef def) {
+        final String GET_LATEST_WORKFLOW_DEF_VERSION = "SELECT max(version) AS version FROM meta_workflow_def WHERE " +
+                                                       "name = ?";
+
+        Integer val = query(tx, GET_LATEST_WORKFLOW_DEF_VERSION, q -> {
+            q.addParameter(def.getName());
+            return q.executeAndFetch(rs -> {
+                if (!rs.next()) {
+                    return null;
+                }
+
+                return rs.getInt(1);
+            });
+        });
+
+        return Optional.ofNullable(val);
+    }
+
+    /**
+     * Update the latest version for the {@link WorkflowDef} to the version provided in {@literal def}.
+     *
+     * @param tx  The {@link Connection} to use for queries.
+     * @param def The {@code WorkflowDef} data to update to.
+     */
+    private void updateLatestVersion(Connection tx, WorkflowDef def) {
+        final String UPDATE_WORKFLOW_DEF_LATEST_VERSION_QUERY = "UPDATE meta_workflow_def SET latest_version = ? " +
+                                                                "WHERE name = ?";
+
+        execute(tx, UPDATE_WORKFLOW_DEF_LATEST_VERSION_QUERY,
+                q -> q.addParameter(def.getVersion()).addParameter(def.getName()).executeUpdate());
+    }
+
+    private void insertOrUpdateWorkflowDef(Connection tx, WorkflowDef def) {
+        final String INSERT_WORKFLOW_DEF_QUERY = "INSERT INTO meta_workflow_def (name, version, json_data) VALUES (?," +
+                                                 " ?, ?)";
+
+        Optional<Integer> version = getLatestVersion(tx, def);
+        if (!version.isPresent() || version.get() < def.getVersion()) {
+            execute(tx, INSERT_WORKFLOW_DEF_QUERY, q -> q.addParameter(def.getName())
+                                                         .addParameter(def.getVersion())
+                                                         .addJsonParameter(def)
+                                                         .executeUpdate());
+        } else {
+            //@formatter:off
+            final String UPDATE_WORKFLOW_DEF_QUERY =
+                "UPDATE meta_workflow_def " +
+                "SET json_data = ?, modified_on = CURRENT_TIMESTAMP " +
+                "WHERE name = ? AND version = ?";
+            //@formatter:on
+
+            execute(tx, UPDATE_WORKFLOW_DEF_QUERY, q -> q.addJsonParameter(def)
+                                                         .addParameter(def.getName())
+                                                         .addParameter(def.getVersion())
+                                                         .executeUpdate());
+        }
+
+        updateLatestVersion(tx, def);
+    }
+
+    /**
+     * Query persistence for all defined {@link TaskDef} data, and cache it in {@link #taskDefCache}.
+     */
+    private void refreshTaskDefs() {
+        withTransaction(tx -> {
+            Map<String, TaskDef> map = new HashMap<>();
+            findAllTaskDefs(tx).forEach(taskDef -> map.put(taskDef.getName(), taskDef));
+
+            synchronized (taskDefCache) {
+                taskDefCache.clear();
+                taskDefCache.putAll(map);
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("Refreshed {} TaskDefs", taskDefCache.size());
+            }
+        });
+    }
+
+    /**
+     * Query persistence for all defined {@link TaskDef} data.
+     *
+     * @param tx The {@link Connection} to use for queries.
+     * @return A new {@code List<TaskDef>} with all the {@code TaskDef} data that was retrieved.
+     */
+    private List<TaskDef> findAllTaskDefs(Connection tx) {
+        final String READ_ALL_TASKDEF_QUERY = "SELECT json_data FROM meta_task_def";
+
+        return query(tx, READ_ALL_TASKDEF_QUERY, q -> q.executeAndFetch(TaskDef.class));
+    }
+
+    /**
+     * Explicitly retrieves a {@link TaskDef} from persistence, avoiding {@link #taskDefCache}.
+     *
+     * @param name The name of the {@code TaskDef} to query for.
+     * @return {@literal null} if nothing is found, otherwise the {@code TaskDef}.
+     */
+    private TaskDef getTaskDefFromDB(String name) {
+        final String READ_ONE_TASKDEF_QUERY = "SELECT json_data FROM meta_task_def WHERE name = ?";
+
+        return queryWithTransaction(READ_ONE_TASKDEF_QUERY,
+                                    q -> q.addParameter(name).executeAndFetchFirst(TaskDef.class));
+    }
+
+    private String insertOrUpdateTaskDef(TaskDef taskDef) {
+        final String UPDATE_TASKDEF_QUERY = "UPDATE meta_task_def SET json_data = ?, modified_on = CURRENT_TIMESTAMP WHERE name = ?";
+
+        final String INSERT_TASKDEF_QUERY = "INSERT INTO meta_task_def (name, json_data) VALUES (?, ?)";
+
+        return getWithTransaction(tx -> {
+            execute(tx, UPDATE_TASKDEF_QUERY, update -> {
+                int result = update.addJsonParameter(taskDef).addParameter(taskDef.getName()).executeUpdate();
+                if (result == 0) {
+                    execute(tx, INSERT_TASKDEF_QUERY,
+                            insert -> insert.addParameter(taskDef.getName()).addJsonParameter(taskDef).executeUpdate());
+                }
+            });
+
+            taskDefCache.put(taskDef.getName(), taskDef);
+            return taskDef.getName();
+        });
+    }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLWorkflowModule.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLWorkflowModule.java
@@ -1,63 +1,66 @@
-/**
- * Copyright 2016 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.netflix.conductor.dao.mysql;
-
-import javax.inject.Singleton;
-import javax.sql.DataSource;
-
-import org.flywaydb.core.Flyway;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sql2o.Sql2o;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * @author mustafa
+ */
 public class MySQLWorkflowModule extends AbstractModule {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-	protected final Logger logger = LoggerFactory.getLogger(getClass());
+    @Provides
+    @Singleton
+    public DataSource getDataSource(Configuration config) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(config.getProperty("jdbc.url", "jdbc:mysql://localhost:3306/conductor"));
+        dataSource.setUsername(config.getProperty("jdbc.username", "conductor"));
+        dataSource.setPassword(config.getProperty("jdbc.password", "password"));
+        dataSource.setAutoCommit(false);
+        flywayMigrate(config, dataSource);
 
-	@Provides
-	@Singleton
-	public Sql2o getSql2o(Configuration config) {
-		HikariDataSource dataSource = new HikariDataSource();
-		dataSource.setJdbcUrl(config.getProperty("jdbc.url", "jdbc:mysql://localhost:3306/conductor"));
-		dataSource.setUsername(config.getProperty("jdbc.username", "conductor"));
-		dataSource.setPassword(config.getProperty("jdbc.password", "password"));
-		dataSource.setAutoCommit(false);
-		flywayMigrate(dataSource);
-		return new Sql2o(dataSource);
-	}
+        return dataSource;
+    }
 
-	@Override
-	protected void configure() {
-		bind(MetadataDAO.class).to(MySQLMetadataDAO.class);
-		bind(ExecutionDAO.class).to(MySQLExecutionDAO.class);
-		bind(QueueDAO.class).to(MySQLQueueDAO.class);
-	}
+    @Override
+    protected void configure() {
+        bind(MetadataDAO.class).to(MySQLMetadataDAO.class);
+        bind(ExecutionDAO.class).to(MySQLExecutionDAO.class);
+        bind(QueueDAO.class).to(MySQLQueueDAO.class);
+    }
 
-	private void flywayMigrate(DataSource dataSource) {
-		Flyway flyway = new Flyway();
-		flyway.setDataSource(dataSource);
-		flyway.setPlaceholderReplacement(false);
-		flyway.migrate();
-	}
+    private void flywayMigrate(Configuration config, DataSource dataSource) {
+        boolean enabled = getBool(config.getProperty("flyway.enabled", "true"), true);
+        if(!enabled) {
+            logger.debug("Flyway migrations are disabled");
+            return;
+        }
+
+        String migrationTable = config.getProperty("flyway.table", null);
+
+        Flyway flyway = new Flyway();
+        if(null != migrationTable) {
+            logger.debug("Using Flyway migration table '{}'", migrationTable);
+            flyway.setTable(migrationTable);
+        }
+
+        flyway.setDataSource(dataSource);
+        flyway.setPlaceholderReplacement(false);
+        flyway.migrate();
+    }
+
+    private boolean getBool(String value, boolean defaultValue) {
+        if(null == value || value.trim().length() == 0){ return defaultValue; }
+        return Boolean.valueOf(value.trim());
+    }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/Query.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/Query.java
@@ -1,0 +1,607 @@
+package com.netflix.conductor.dao.mysql;
+
+
+import static com.netflix.conductor.core.execution.ApplicationException.Code;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.core.execution.ApplicationException;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.sql.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang.math.NumberUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a {@link PreparedStatement} that is wrapped with convenience methods and utilities.
+ * <p/>
+ * This class simulates a parameter building pattern and all {@literal addParameter(*)} methods must be called in the
+ * proper order of their expected binding sequence.
+ *
+ * @author mustafa
+ */
+public class Query implements AutoCloseable {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * The {@link ObjectMapper} instance to use for serializing/deserializing JSON.
+     */
+    protected final ObjectMapper om;
+
+    /**
+     * The initial supplied query String that was used to prepare {@link #statement}.
+     */
+    private final String rawQuery;
+
+    /**
+     * Parameter index for the {@code ResultSet#set*(*)} methods, gets incremented every time a parameter is added to
+     * the {@code PreparedStatement} {@link #statement}.
+     */
+    private final AtomicInteger index = new AtomicInteger(1);
+
+    /**
+     * The {@link PreparedStatement} that will be managed and executed by this class.
+     */
+    private final PreparedStatement statement;
+
+    public Query(ObjectMapper objectMapper, Connection connection, String query) {
+        this.rawQuery = query;
+        this.om = objectMapper;
+
+        try {
+            this.statement = connection.prepareStatement(query);
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR,
+                    "Cannot prepare statement for query: " + ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Generate a String with {@literal count} number of '?' placeholders for {@link PreparedStatement} queries.
+     *
+     * @param count The number of '?' chars to generate.
+     * @return a comma delimited string of {@literal count} '?' binding placeholders.
+     */
+    public static String generateInBindings(int count) {
+        String[] questions = new String[count];
+        for (int i = 0; i < count; i++) {
+            questions[i] = "?";
+        }
+
+        return String.join(", ", questions);
+    }
+
+    public Query addParameter(final String value) {
+        return addParameterInternal((ps, idx) -> ps.setString(idx, value));
+    }
+
+    public Query addParameter(final int value) {
+        return addParameterInternal((ps, idx) -> ps.setInt(idx, value));
+    }
+
+    public Query addParameter(final boolean value) {
+        return addParameterInternal(((ps, idx) -> ps.setBoolean(idx, value)));
+    }
+
+    public Query addParameter(final long value) {
+        return addParameterInternal((ps, idx) -> ps.setLong(idx, value));
+    }
+
+    public Query addParameter(final double value) {
+        return addParameterInternal((ps, idx) -> ps.setDouble(idx, value));
+    }
+
+    public Query addParameter(Date date) {
+        return addParameterInternal((ps, idx) -> ps.setDate(idx, date));
+    }
+
+    public Query addParameter(Timestamp timestamp) {
+        return addParameterInternal((ps, idx) -> ps.setTimestamp(idx, timestamp));
+    }
+
+    /**
+     * Serializes {@literal value} to a JSON string for persistence.
+     *
+     * @param value The value to serialize.
+     * @return {@literal this}
+     */
+    public Query addJsonParameter(Object value) {
+        return addParameter(toJson(value));
+    }
+
+    /**
+     * Bind the given {@link java.util.Date} to the PreparedStatement as a {@link java.sql.Date}.
+     * @param date The {@literal java.util.Date} to bind.
+     * @return {@literal this}
+     */
+    public Query addDateParameter(java.util.Date date) {
+        return addParameter(new Date(date.getTime()));
+    }
+
+    /**
+     * Bind the given {@link java.util.Date} to the PreparedStatement as a {@link java.sql.Timestamp}.
+     * @param date The {@literal java.util.Date} to bind.
+     * @return {@literal this}
+     */
+    public Query addTimestampParameter(java.util.Date date) {
+        return addParameter(new Timestamp(date.getTime()));
+    }
+
+    /**
+     * Bind the given epoch millis to the PreparedStatement as a {@link java.sql.Timestamp}.
+     * @param epochMillis The epoch ms to create a new {@literal Timestamp} from.
+     * @return {@literal this}
+     */
+    public Query addTimestampParameter(long epochMillis) {
+        return addParameter(new Timestamp(epochMillis));
+    }
+
+    /**
+     * Add a collection of primitive values at once, in the order of the collection.
+     *
+     * @param values The values to bind to the prepared statement.
+     * @return {@literal this}
+     *
+     * @throws IllegalArgumentException If a non-primitive/unsupported type is encountered in the collection.
+     * @see #addParameters(Object...)
+     */
+    public Query addParameters(Collection values) {
+        return addParameters(values.toArray());
+    }
+
+    /**
+     * Add many primitive values at once.
+     *
+     * @param values The values to bind to the prepared statement.
+     * @return {@literal this}
+     *
+     * @throws IllegalArgumentException If a non-primitive/unsupported type is encountered.
+     */
+    public Query addParameters(Object... values) {
+        for (Object v : values) {
+            if (v instanceof String) {
+                addParameter((String) v);
+            } else if (v instanceof Integer) {
+                addParameter((Integer) v);
+            } else if (v instanceof Long) {
+                addParameter((Long) v);
+            } else if(v instanceof Double) {
+                addParameter((Double) v);
+            } else if (v instanceof Boolean) {
+                addParameter((Boolean) v);
+            } else if (v instanceof Date) {
+                addParameter((Date) v);
+            } else if (v instanceof Timestamp) {
+                addParameter((Timestamp) v);
+            } else {
+                throw new IllegalArgumentException(
+                        "Type " + v.getClass().getName() + " is not supported by automatic property assignment");
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Utility method for evaluating the prepared statement as a query to check the existence of a record using a
+     * numeric count or boolean return value.
+     * <p/>
+     * The {@link #rawQuery} provided must result in a {@link Number} or {@link Boolean} result.
+     *
+     * @return {@literal true} If a count query returned more than 0 or an exists query returns {@literal true}.
+     *
+     * @throws ApplicationException If an unexpected return type cannot be evaluated to a {@code Boolean} result.
+     */
+    public boolean exists() {
+        Object val = executeScalar();
+        if (null == val) {
+            return false;
+        }
+
+        if (val instanceof Number) {
+            return convertLong(val) > 0;
+        }
+
+        if (val instanceof Boolean) {
+            return (Boolean) val;
+        }
+
+        if (val instanceof String) {
+            return convertBoolean(val);
+        }
+
+        throw new ApplicationException(Code.BACKEND_ERROR,
+                "Expected a Numeric or Boolean scalar return value from the query, received " +
+                        val.getClass().getName());
+    }
+
+    /**
+     * Convenience method for executing delete statements.
+     *
+     * @return {@literal true} if the statement affected 1 or more rows.
+     *
+     * @see #executeUpdate()
+     */
+    public boolean executeDelete() {
+        int count = executeUpdate();
+        if (count > 1) {
+            logger.debug("Removed {} row(s) for query {}", count, rawQuery);
+        }
+
+        return count > 0;
+    }
+
+    /**
+     * Convenience method for executing statements that return a single numeric value,
+     * typically {@literal SELECT COUNT...} style queries.
+     *
+     * @return The result of the query as a {@literal long}.
+     */
+    public long executeCount() {
+        return executeScalar(Long.class);
+    }
+
+    /**
+     * @return The result of {@link PreparedStatement#executeUpdate()}
+     */
+    public int executeUpdate() {
+        try {
+
+            Long start = null;
+            if (logger.isTraceEnabled()) {
+                start = System.currentTimeMillis();
+            }
+
+            final int val = this.statement.executeUpdate();
+
+            if (null != start && logger.isTraceEnabled()) {
+                long end = System.currentTimeMillis();
+                logger.trace("[{}ms] {}: {}", (end - start), val, rawQuery);
+            }
+
+            return val;
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex.getMessage());
+        }
+    }
+
+    /**
+     * Execute a query from the PreparedStatement and return the ResultSet.
+     * <p />
+     *
+     * <em>NOTE:</em> The returned ResultSet must be closed/managed by the calling methods.
+     *
+     * @return {@link PreparedStatement#executeQuery()}
+     *
+     * @throws ApplicationException If any SQL errors occur.
+     */
+    public ResultSet executeQuery(){
+        Long start = null;
+        if (logger.isTraceEnabled()) {
+            start = System.currentTimeMillis();
+        }
+
+        try {
+            return this.statement.executeQuery();
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        } finally {
+            if (null != start && logger.isTraceEnabled()) {
+                long end = System.currentTimeMillis();
+                logger.trace("[{}ms] {}", (end - start), rawQuery);
+            }
+        }
+    }
+
+    /**
+     * @return The single result of the query as an Object.
+     */
+    public Object executeScalar() {
+        try (ResultSet rs = executeQuery()) {
+            if (!rs.next()) {
+                return null;
+            }
+            return rs.getObject(1);
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Execute the PreparedStatement and return a single 'primitive' value from the ResultSet.
+     *
+     * @param returnType The type to return.
+     * @return A single result from the execution of the statement, as a type of {@literal returnType}.
+     *
+     * @throws ApplicationException {@literal returnType} is unsupported, cannot be cast to from the result, or any SQL
+     * errors occur.
+     */
+    public <V> V executeScalar(Class<V> returnType) {
+        try (ResultSet rs = executeQuery()) {
+            if (!rs.next()) {
+                Object value = null;
+                if (Integer.class == returnType) {
+                    value = 0;
+                } else if (Long.class == returnType) {
+                    value = 0L;
+                } else if (Boolean.class == returnType) {
+                    value = false;
+                }
+                return returnType.cast(value);
+            } else {
+                return getScalarFromResultSet(rs, returnType);
+            }
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Execute the PreparedStatement and return a List of 'primitive' values from the ResultSet.
+     *
+     * @param returnType The type Class return a List of.
+     * @param <V> The type parameter to return a List of.
+     * @return A {@code List<returnType>}.
+     *
+     * @throws ApplicationException {@literal returnType} is unsupported, cannot be cast to from the result, or any SQL
+     * errors occur.
+     */
+    public <V> List<V> executeScalarList(Class<V> returnType) {
+        try (ResultSet rs = executeQuery()) {
+            List<V> values = new ArrayList<>();
+            while (rs.next()) {
+                values.add(getScalarFromResultSet(rs, returnType));
+            }
+            return values;
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Execute the statement and return only the first record from the result set.
+     *
+     * @param returnType The Class to return.
+     * @param <V> The type parameter.
+     * @return An instance of {@literal <V>} from the result set.
+     */
+    public <V> V executeAndFetchFirst(Class<V> returnType) {
+        Object o = executeScalar();
+        if (null == o) {
+            return null;
+        }
+        return convert(o, returnType);
+    }
+
+    /**
+     * Execute the PreparedStatement and return a List of {@literal returnType} values from the ResultSet.
+     *
+     * @param returnType The type Class return a List of.
+     * @param <V> The type parameter to return a List of.
+     * @return A {@code List<returnType>}.
+     *
+     * @throws ApplicationException {@literal returnType} is unsupported, cannot be cast to from the result, or any SQL
+     * errors occur.
+     */
+    public <V> List<V> executeAndFetch(Class<V> returnType) {
+        try (ResultSet rs = executeQuery()) {
+            List<V> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(convert(rs.getObject(1), returnType));
+            }
+            return list;
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    /**
+     * Execute the query and pass the {@link ResultSet} to the given handler.
+     *
+     * @param handler The {@link ResultSetHandler} to execute.
+     * @param <V> The return type of this method.
+     * @return The results of {@link ResultSetHandler#apply(ResultSet)}.
+     */
+    public <V> V executeAndFetch(ResultSetHandler<V> handler) {
+        try (ResultSet rs = executeQuery()) {
+            return handler.apply(rs);
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (null != statement && !statement.isClosed()) {
+                statement.close();
+            }
+        } catch (SQLException ex) {
+            logger.warn("Error closing prepared statement: {}", ex.getMessage());
+        }
+    }
+
+    protected final Query addParameterInternal(InternalParameterSetter setter) {
+        int index = getAndIncrementIndex();
+        try {
+            setter.apply(this.statement, index);
+            return this;
+        } catch (SQLException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, "Could not apply bind parameter at index " + index, ex);
+        }
+    }
+
+    protected <V> V getScalarFromResultSet(ResultSet rs, Class<V> returnType) throws SQLException {
+        Object value = null;
+
+        if (Integer.class == returnType) {
+            value = rs.getInt(1);
+        } else if (Long.class == returnType) {
+            value = rs.getLong(1);
+        } else if (String.class == returnType) {
+            value = rs.getString(1);
+        } else if (Boolean.class == returnType) {
+            value = rs.getBoolean(1);
+        } else if (Double.class == returnType) {
+            value = rs.getDouble(1);
+        } else if (Date.class == returnType) {
+            value = rs.getDate(1);
+        } else if (Timestamp.class == returnType) {
+            value = rs.getTimestamp(1);
+        } else {
+            value = rs.getObject(1);
+        }
+
+        if (null == value) {
+            throw new NullPointerException("Cannot get value from ResultSet of type " + returnType.getName());
+        }
+
+        return returnType.cast(value);
+    }
+
+    protected <V> V convert(Object value, Class<V> returnType) {
+        if (Boolean.class == returnType) {
+            return returnType.cast(convertBoolean(value));
+        } else if (Integer.class == returnType) {
+            return returnType.cast(convertInt(value));
+        } else if (Long.class == returnType) {
+            return returnType.cast(convertLong(value));
+        } else if (Double.class == returnType) {
+            return returnType.cast(convertDouble(value));
+        } else if (String.class == returnType) {
+            return returnType.cast(convertString(value));
+        } else if (value instanceof String) {
+            return fromJson((String) value, returnType);
+        }
+
+        final String vName = value.getClass().getName();
+        final String rName = returnType.getName();
+        throw new ApplicationException(Code.BACKEND_ERROR, "Cannot convert type " + vName + " to " + rName);
+    }
+
+    protected Integer convertInt(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+
+        return NumberUtils.toInt(value.toString());
+    }
+
+    protected Double convertDouble(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof Double) {
+            return (Double) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+
+        return NumberUtils.toDouble(value.toString());
+    }
+
+    protected Long convertLong(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof Long) {
+            return (Long) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return NumberUtils.toLong(value.toString());
+    }
+
+    protected String convertString(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof String) {
+            return (String) value;
+        }
+
+        return value.toString().trim();
+    }
+
+    protected Boolean convertBoolean(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+
+        String text = value.toString().trim();
+        return "Y".equalsIgnoreCase(text) || "YES".equalsIgnoreCase(text) || "TRUE".equalsIgnoreCase(text) ||
+                "T".equalsIgnoreCase(text) || "1".equalsIgnoreCase(text);
+    }
+
+
+    protected String toJson(Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        try {
+            return om.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR, ex);
+        }
+    }
+
+    protected <V> V fromJson(String value, Class<V> returnType) {
+        if (null == value) {
+            return null;
+        }
+
+        try {
+            return om.readValue(value, returnType);
+        } catch (IOException ex) {
+            throw new ApplicationException(Code.BACKEND_ERROR,
+                    "Could not convert JSON '" + value + "' to " + returnType.getName(), ex);
+        }
+    }
+
+    protected final int getIndex() {
+        return index.get();
+    }
+
+    protected final int getAndIncrementIndex() {
+        return index.getAndIncrement();
+    }
+
+    @FunctionalInterface
+    private interface InternalParameterSetter {
+
+        void apply(PreparedStatement ps, int idx) throws SQLException;
+    }
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/QueryFunction.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/QueryFunction.java
@@ -1,0 +1,12 @@
+package com.netflix.conductor.dao.mysql;
+
+import java.sql.SQLException;
+
+/**
+ * Functional interface for {@link Query} executions that return results.
+ * @author mustafa
+ */
+@FunctionalInterface
+public interface QueryFunction<R> {
+	R apply(Query query) throws SQLException;
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/ResultSetHandler.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/ResultSetHandler.java
@@ -1,0 +1,13 @@
+package com.netflix.conductor.dao.mysql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Functional interface for {@link Query#executeAndFetch(ResultSetHandler)}.
+ * @author mustafa
+ */
+@FunctionalInterface
+public interface ResultSetHandler<R> {
+	R apply(ResultSet resultSet) throws SQLException;
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/TransactionalFunction.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/TransactionalFunction.java
@@ -1,0 +1,14 @@
+package com.netflix.conductor.dao.mysql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Functional interface for operations within a transactional context.
+ *
+ * @author mustafa
+ */
+@FunctionalInterface
+public interface TransactionalFunction<R> {
+	R apply(Connection tx) throws SQLException;
+}

--- a/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `queue_message` CHANGE `created_on` `created_on` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `queue_message` CHANGE `deliver_on` `deliver_on` TIMESTAMP DEFAULT CURRENT_TIMESTAMP;

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/EmbeddedDatabase.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/EmbeddedDatabase.java
@@ -18,7 +18,7 @@ public enum EmbeddedDatabase {
 
 	private DB startEmbeddedDatabase() {
 		try {
-			DB db = DB.newEmbeddedDB(33306);
+			DB db = DB.newEmbeddedDB(33307);
 			db.start();
 			db.createDB("conductor");
 			return db;

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLBaseDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLBaseDAOTest.java
@@ -1,47 +1,106 @@
 package com.netflix.conductor.dao.mysql;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sql2o.Connection;
-import org.sql2o.Sql2o;
-
-import ch.vorburger.mariadb4j.DB;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.config.TestConfiguration;
+import com.netflix.conductor.core.config.Configuration;
+import com.zaxxer.hikari.HikariDataSource;
 
-class MySQLBaseDAOTest {
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-	protected final Logger logger = LoggerFactory.getLogger(getClass());
-	protected final Sql2o testSql2o;
-	protected final TestConfiguration testConfiguration = new TestConfiguration();
-	protected final ObjectMapper objectMapper = createObjectMapper();
-	protected final DB db = EmbeddedDatabase.INSTANCE.getDB();
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-	MySQLBaseDAOTest() {
-		testConfiguration.setProperty("jdbc.url", "jdbc:mysql://localhost:33306/conductor");
-		testConfiguration.setProperty("jdbc.username", "root");
-		testConfiguration.setProperty("jdbc.password", "");
-		testSql2o = new MySQLWorkflowModule().getSql2o(testConfiguration);
-	}
-	
-	private ObjectMapper createObjectMapper() {
-		ObjectMapper om = new ObjectMapper();
-		om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-		om.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
-		om.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
-		om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		om.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-		return om;
-	}
+import javax.sql.DataSource;
 
-	protected void resetAllData() {
-		logger.info("Resetting data for test");
-		try(Connection connection = testSql2o.open()) {
-			connection.createQuery("SHOW TABLES").executeScalarList(String.class).stream()
-					.filter(name -> !name.equalsIgnoreCase("schema_version"))
-					.forEach(table -> connection.createQuery("TRUNCATE TABLE " + table).executeUpdate());
+import ch.vorburger.mariadb4j.DB;
+
+
+@SuppressWarnings("Duplicates")
+public class MySQLBaseDAOTest {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final DataSource dataSource;
+    protected final TestConfiguration testConfiguration = new TestConfiguration();
+    protected final ObjectMapper objectMapper = createObjectMapper();
+    protected final DB db = EmbeddedDatabase.INSTANCE.getDB();
+
+    static AtomicBoolean migrated = new AtomicBoolean(false);
+
+    MySQLBaseDAOTest() {
+        testConfiguration.setProperty("jdbc.url", "jdbc:mysql://localhost:33307/conductor");
+        testConfiguration.setProperty("jdbc.username", "root");
+        testConfiguration.setProperty("jdbc.password", "");
+        this.dataSource = getDataSource(testConfiguration);
+    }
+
+    private DataSource getDataSource(Configuration config) {
+
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(config.getProperty("jdbc.url", "jdbc:mysql://localhost:33307/conductor"));
+        dataSource.setUsername(config.getProperty("jdbc.username", "conductor"));
+        dataSource.setPassword(config.getProperty("jdbc.password", "password"));
+        dataSource.setAutoCommit(false);
+
+        // Prevent DB from getting exhausted during rapid testing
+        dataSource.setMaximumPoolSize(8);
+
+        if (!migrated.get()) {
+            flywayMigrate(dataSource);
+        }
+
+        return dataSource;
+    }
+
+    private synchronized static void flywayMigrate(DataSource dataSource) {
+        if(migrated.get()) {
+            return;
+        }
+
+        synchronized (MySQLBaseDAOTest.class) {
+            Flyway flyway = new Flyway();
+            flyway.setDataSource(dataSource);
+            flyway.setPlaceholderReplacement(false);
+            flyway.migrate();
+            migrated.getAndSet(true);
+        }
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper om = new ObjectMapper();
+        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        om.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+        om.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+        om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        om.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        return om;
+    }
+
+    protected void resetAllData() {
+        logger.info("Resetting data for test");
+        try (Connection connection = dataSource.getConnection()) {
+        	try(ResultSet rs = connection.prepareStatement("SHOW TABLES").executeQuery();
+				PreparedStatement keysOn = connection.prepareStatement("SET FOREIGN_KEY_CHECKS=1")) {
+        		try(PreparedStatement keysOff = connection.prepareStatement("SET FOREIGN_KEY_CHECKS=0")){
+        			keysOff.execute();
+					while(rs.next()) {
+						String table = rs.getString(1);
+						try(PreparedStatement ps = connection.prepareStatement("TRUNCATE TABLE " + table)) {
+							ps.execute();
+						}
+					}
+				} finally {
+        			keysOn.execute();
+				}
+			}
+		} catch (SQLException ex) {
+        	logger.error(ex.getMessage(), ex);
+        	throw new RuntimeException(ex);
 		}
-	}
+    }
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAOTest.java
@@ -6,6 +6,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.netflix.conductor.common.metadata.tasks.PollData;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
+import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.dao.IndexDAO;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,21 +23,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.netflix.conductor.common.metadata.tasks.PollData;
-import com.netflix.conductor.common.metadata.tasks.Task;
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
-import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
-import com.netflix.conductor.dao.IndexDAO;
-
+@SuppressWarnings("Duplicates")
 public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 
 	private MySQLMetadataDAO metadata;
@@ -37,8 +37,8 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 
 	@Before
 	public void setup() throws Exception {
-		metadata = new MySQLMetadataDAO(objectMapper, testSql2o, testConfiguration);
-		dao = new MySQLExecutionDAO(mock(IndexDAO.class), metadata, objectMapper, testSql2o);
+		metadata = new MySQLMetadataDAO(objectMapper, dataSource, testConfiguration);
+		dao = new MySQLExecutionDAO(mock(IndexDAO.class), metadata, objectMapper, dataSource);
 		resetAllData();
 	}
 
@@ -83,12 +83,12 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 		task.setTaskId("t1");
 		task.setTaskDefName("task1");
 
-		expected.expect(NullPointerException.class);
+		expected.expect(ApplicationException.class);
 		expected.expectMessage("Workflow instance id cannot be null");
 		dao.createTasks(Collections.singletonList(task));
 
 		task.setWorkflowInstanceId("wfid");
-		expected.expect(NullPointerException.class);
+		expected.expect(ApplicationException.class);
 		expected.expectMessage("Task reference name cannot be null");
 		dao.createTasks(Collections.singletonList(task));
 	}
@@ -102,7 +102,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 		task.setTaskDefName("task1");
 		task.setWorkflowInstanceId("wfid");
 
-		expected.expect(NullPointerException.class);
+		expected.expect(ApplicationException.class);
 		expected.expectMessage("Task reference name cannot be null");
 		dao.createTasks(Collections.singletonList(task));
 	}
@@ -146,7 +146,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 			task.setRetryCount(0);
 			task.setWorkflowInstanceId(workflowId);
 			task.setTaskDefName("task" + i);
-			task.setStatus(Task.Status.IN_PROGRESS);
+			task.setStatus(Status.IN_PROGRESS);
 			tasks.add(task);
 		}
 
@@ -159,7 +159,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 		task.setRetryCount(1);
 		task.setWorkflowInstanceId(workflowId);
 		task.setTaskDefName("task" + 2);
-		task.setStatus(Task.Status.IN_PROGRESS);
+		task.setStatus(Status.IN_PROGRESS);
 		tasks.add(task);
 
 		//Duplicate task!
@@ -171,7 +171,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 		task.setRetryCount(0);
 		task.setWorkflowInstanceId(workflowId);
 		task.setTaskDefName("task" + 1);
-		task.setStatus(Task.Status.IN_PROGRESS);
+		task.setStatus(Status.IN_PROGRESS);
 		tasks.add(task);
 
 		List<Task> created = dao.createTasks(tasks);
@@ -207,7 +207,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 			task.setRetryCount(0);
 			task.setWorkflowInstanceId(workflowId);
 			task.setTaskDefName("testTaskOps" + i);
-			task.setStatus(Task.Status.IN_PROGRESS);
+			task.setStatus(Status.IN_PROGRESS);
 			tasks.add(task);
 		}
 
@@ -220,7 +220,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 			task.setRetryCount(0);
 			task.setWorkflowInstanceId("x" + workflowId);
 			task.setTaskDefName("testTaskOps" + i);
-			task.setStatus(Task.Status.IN_PROGRESS);
+			task.setStatus(Status.IN_PROGRESS);
 			dao.createTasks(Arrays.asList(task));
 		}
 
@@ -240,7 +240,7 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 			Task found = dao.getTask(workflowId + "_t" + i);
 			assertNotNull(found);
 			found.getOutputData().put("updated", true);
-			found.setStatus(Task.Status.COMPLETED);
+			found.setStatus(Status.COMPLETED);
 			update.add(found);
 		}
 		dao.updateTasks(update);
@@ -401,5 +401,4 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 		count = dao.getPendingWorkflowCount(workflowName);
 		assertEquals(0, count);
 	}
-
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
@@ -4,207 +4,209 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.core.execution.ApplicationException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-import com.netflix.conductor.common.metadata.events.EventHandler;
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.core.execution.ApplicationException;
-
+@SuppressWarnings("Duplicates")
+@RunWith(JUnit4.class)
 public class MySQLMetadataDAOTest extends MySQLBaseDAOTest {
 
-	private MySQLMetadataDAO dao;
+    private MySQLMetadataDAO dao;
 
-	@Before
-	public void setup() throws Exception {
-		dao = new MySQLMetadataDAO(objectMapper, testSql2o, testConfiguration);
-		resetAllData();
-	}
+    @Before
+    public void setup() throws Exception {
+        dao = new MySQLMetadataDAO(objectMapper, dataSource, testConfiguration);
+        resetAllData();
+    }
 
-	@Test(expected=NullPointerException.class)
-	public void testMissingName() throws Exception {
-		WorkflowDef def = new WorkflowDef();
-		dao.create(def);
-	}
+    @Test(expected=NullPointerException.class)
+    public void testMissingName() throws Exception {
+        WorkflowDef def = new WorkflowDef();
+        dao.create(def);
+    }
 
-	@Test(expected=ApplicationException.class)
-	public void testDuplicate() throws Exception {
-		WorkflowDef def = new WorkflowDef();
-		def.setName("testDuplicate");
-		def.setVersion(1);
+    @Test(expected=ApplicationException.class)
+    public void testDuplicate() throws Exception {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("testDuplicate");
+        def.setVersion(1);
 
-		dao.create(def);
-		dao.create(def);
-	}
+        dao.create(def);
+        dao.create(def);
+    }
 
-	@Test
-	public void testWorkflowDefOperations() throws Exception {
-		WorkflowDef def = new WorkflowDef();
-		def.setName("test");
-		def.setVersion(1);
-		def.setDescription("description");
-		def.setCreatedBy("unit_test");
-		def.setCreateTime(1L);
-		def.setOwnerApp("ownerApp");
-		def.setUpdatedBy("unit_test2");
-		def.setUpdateTime(2L);
+    @Test
+    public void testWorkflowDefOperations() throws Exception {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("test");
+        def.setVersion(1);
+        def.setDescription("description");
+        def.setCreatedBy("unit_test");
+        def.setCreateTime(1L);
+        def.setOwnerApp("ownerApp");
+        def.setUpdatedBy("unit_test2");
+        def.setUpdateTime(2L);
 
-		dao.create(def);
+        dao.create(def);
 
-		List<WorkflowDef> all = dao.getAll();
-		assertNotNull(all);
-		assertEquals(1, all.size());
-		assertEquals("test", all.get(0).getName());
-		assertEquals(1, all.get(0).getVersion());
+        List<WorkflowDef> all = dao.getAll();
+        assertNotNull(all);
+        assertEquals(1, all.size());
+        assertEquals("test", all.get(0).getName());
+        assertEquals(1, all.get(0).getVersion());
 
-		WorkflowDef found = dao.get("test", 1);
-		assertTrue(EqualsBuilder.reflectionEquals(def, found));
+        WorkflowDef found = dao.get("test", 1);
+        assertTrue(EqualsBuilder.reflectionEquals(def, found));
 
-		def.setVersion(2);
-		dao.create(def);
+        def.setVersion(2);
+        dao.create(def);
 
-		all = dao.getAll();
-		assertNotNull(all);
-		assertEquals(2, all.size());
-		assertEquals("test", all.get(0).getName());
-		assertEquals(1, all.get(0).getVersion());
+        all = dao.getAll();
+        assertNotNull(all);
+        assertEquals(2, all.size());
+        assertEquals("test", all.get(0).getName());
+        assertEquals(1, all.get(0).getVersion());
 
-		found = dao.getLatest(def.getName());
-		assertEquals(def.getName(), found.getName());
-		assertEquals(def.getVersion(), found.getVersion());
-		assertEquals(2, found.getVersion());
+        found = dao.getLatest(def.getName());
+        assertEquals(def.getName(), found.getName());
+        assertEquals(def.getVersion(), found.getVersion());
+        assertEquals(2, found.getVersion());
 
-		all = dao.getAllLatest();
-		assertNotNull(all);
-		assertEquals(1, all.size());
-		assertEquals("test", all.get(0).getName());
-		assertEquals(2, all.get(0).getVersion());
+        all = dao.getAllLatest();
+        assertNotNull(all);
+        assertEquals(1, all.size());
+        assertEquals("test", all.get(0).getName());
+        assertEquals(2, all.get(0).getVersion());
 
-		all = dao.getAllVersions(def.getName());
-		assertNotNull(all);
-		assertEquals(2, all.size());
-		assertEquals("test", all.get(0).getName());
-		assertEquals("test", all.get(1).getName());
-		assertEquals(1, all.get(0).getVersion());
-		assertEquals(2, all.get(1).getVersion());
+        all = dao.getAllVersions(def.getName());
+        assertNotNull(all);
+        assertEquals(2, all.size());
+        assertEquals("test", all.get(0).getName());
+        assertEquals("test", all.get(1).getName());
+        assertEquals(1, all.get(0).getVersion());
+        assertEquals(2, all.get(1).getVersion());
 
-		def.setDescription("updated");
-		dao.update(def);
-		found = dao.get(def.getName(), def.getVersion());
-		assertEquals(def.getDescription(), found.getDescription());
+        def.setDescription("updated");
+        dao.update(def);
+        found = dao.get(def.getName(), def.getVersion());
+        assertEquals(def.getDescription(), found.getDescription());
 
-		List<String> allnames = dao.findAll();
-		assertNotNull(allnames);
-		assertEquals(1, allnames.size());
-		assertEquals(def.getName(), allnames.get(0));
-	}
+        List<String> allnames = dao.findAll();
+        assertNotNull(allnames);
+        assertEquals(1, allnames.size());
+        assertEquals(def.getName(), allnames.get(0));
+    }
 
-	@Test
-	public void testTaskDefOperations() throws Exception {
-		TaskDef def = new TaskDef("taskA");
-		def.setDescription("description");
-		def.setCreatedBy("unit_test");
-		def.setCreateTime(1L);
-		def.setInputKeys(Arrays.asList("a","b","c"));
-		def.setOutputKeys(Arrays.asList("01","o2"));
-		def.setOwnerApp("ownerApp");
-		def.setRetryCount(3);
-		def.setRetryDelaySeconds(100);
-		def.setRetryLogic(TaskDef.RetryLogic.FIXED);
-		def.setTimeoutPolicy(TaskDef.TimeoutPolicy.ALERT_ONLY);
-		def.setUpdatedBy("unit_test2");
-		def.setUpdateTime(2L);
+    @Test
+    public void testTaskDefOperations() throws Exception {
+        TaskDef def = new TaskDef("taskA");
+        def.setDescription("description");
+        def.setCreatedBy("unit_test");
+        def.setCreateTime(1L);
+        def.setInputKeys(Arrays.asList("a","b","c"));
+        def.setOutputKeys(Arrays.asList("01","o2"));
+        def.setOwnerApp("ownerApp");
+        def.setRetryCount(3);
+        def.setRetryDelaySeconds(100);
+        def.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        def.setTimeoutPolicy(TaskDef.TimeoutPolicy.ALERT_ONLY);
+        def.setUpdatedBy("unit_test2");
+        def.setUpdateTime(2L);
 
-		dao.createTaskDef(def);
+        dao.createTaskDef(def);
 
-		TaskDef found = dao.getTaskDef(def.getName());
-		assertTrue(EqualsBuilder.reflectionEquals(def, found));
+        TaskDef found = dao.getTaskDef(def.getName());
+        assertTrue(EqualsBuilder.reflectionEquals(def, found));
 
-		def.setDescription("updated description");
-		dao.updateTaskDef(def);
-		found = dao.getTaskDef(def.getName());
-		assertTrue(EqualsBuilder.reflectionEquals(def, found));
-		assertEquals("updated description", found.getDescription());
+        def.setDescription("updated description");
+        dao.updateTaskDef(def);
+        found = dao.getTaskDef(def.getName());
+        assertTrue(EqualsBuilder.reflectionEquals(def, found));
+        assertEquals("updated description", found.getDescription());
 
-		for(int i = 0; i < 9; i++) {
-			TaskDef tdf = new TaskDef("taskA" + i);
-			dao.createTaskDef(tdf);
-		}
+        for(int i = 0; i < 9; i++) {
+            TaskDef tdf = new TaskDef("taskA" + i);
+            dao.createTaskDef(tdf);
+        }
 
-		List<TaskDef> all = dao.getAllTaskDefs();
-		assertNotNull(all);
-		assertEquals(10, all.size());
-		Set<String> allnames = all.stream().map(TaskDef::getName).collect(Collectors.toSet());
-		assertEquals(10, allnames.size());
-		List<String> sorted = allnames.stream().sorted().collect(Collectors.toList());
-		assertEquals(def.getName(), sorted.get(0));
+        List<TaskDef> all = dao.getAllTaskDefs();
+        assertNotNull(all);
+        assertEquals(10, all.size());
+        Set<String> allnames = all.stream().map(TaskDef::getName).collect(Collectors.toSet());
+        assertEquals(10, allnames.size());
+        List<String> sorted = allnames.stream().sorted().collect(Collectors.toList());
+        assertEquals(def.getName(), sorted.get(0));
 
-		for(int i = 0; i < 9; i++) {
-			assertEquals(def.getName() + i, sorted.get(i+1));
-		}
+        for(int i = 0; i < 9; i++) {
+            assertEquals(def.getName() + i, sorted.get(i+1));
+        }
 
-		for(int i = 0; i < 9; i++) {
-			dao.removeTaskDef(def.getName() + i);
-		}
-		all = dao.getAllTaskDefs();
-		assertNotNull(all);
-		assertEquals(1, all.size());
-		assertEquals(def.getName(), all.get(0).getName());
-	}
+        for(int i = 0; i < 9; i++) {
+            dao.removeTaskDef(def.getName() + i);
+        }
+        all = dao.getAllTaskDefs();
+        assertNotNull(all);
+        assertEquals(1, all.size());
+        assertEquals(def.getName(), all.get(0).getName());
+    }
 
-	@Test(expected=ApplicationException.class)
-	public void testRemoveTaskDef() throws Exception {
-		dao.removeTaskDef("test" + UUID.randomUUID().toString());
-	}
+    @Test(expected=ApplicationException.class)
+    public void testRemoveTaskDef() throws Exception {
+        dao.removeTaskDef("test" + UUID.randomUUID().toString());
+    }
 
-	@Test
-	public void testEventHandlers() {
-		String event1 = "SQS::arn:account090:sqstest1";
-		String event2 = "SQS::arn:account090:sqstest2";
+    @Test
+    public void testEventHandlers() {
+        String event1 = "SQS::arn:account090:sqstest1";
+        String event2 = "SQS::arn:account090:sqstest2";
 
-		EventHandler eh = new EventHandler();
-		eh.setName(UUID.randomUUID().toString());
-		eh.setActive(false);
-		EventHandler.Action action = new EventHandler.Action();
-		action.setAction(EventHandler.Action.Type.start_workflow);
-		action.setStart_workflow(new EventHandler.StartWorkflow());
-		action.getStart_workflow().setName("workflow_x");
-		eh.getActions().add(action);
-		eh.setEvent(event1);
+        EventHandler eh = new EventHandler();
+        eh.setName(UUID.randomUUID().toString());
+        eh.setActive(false);
+        EventHandler.Action action = new EventHandler.Action();
+        action.setAction(EventHandler.Action.Type.start_workflow);
+        action.setStart_workflow(new EventHandler.StartWorkflow());
+        action.getStart_workflow().setName("workflow_x");
+        eh.getActions().add(action);
+        eh.setEvent(event1);
 
-		dao.addEventHandler(eh);
-		List<EventHandler> all = dao.getEventHandlers();
-		assertNotNull(all);
-		assertEquals(1, all.size());
-		assertEquals(eh.getName(), all.get(0).getName());
-		assertEquals(eh.getEvent(), all.get(0).getEvent());
+        dao.addEventHandler(eh);
+        List<EventHandler> all = dao.getEventHandlers();
+        assertNotNull(all);
+        assertEquals(1, all.size());
+        assertEquals(eh.getName(), all.get(0).getName());
+        assertEquals(eh.getEvent(), all.get(0).getEvent());
 
-		List<EventHandler> byEvents = dao.getEventHandlersForEvent(event1, true);
-		assertNotNull(byEvents);
-		assertEquals(0, byEvents.size());		//event is marked as in-active
+        List<EventHandler> byEvents = dao.getEventHandlersForEvent(event1, true);
+        assertNotNull(byEvents);
+        assertEquals(0, byEvents.size());		//event is marked as in-active
 
-		eh.setActive(true);
-		eh.setEvent(event2);
-		dao.updateEventHandler(eh);
+        eh.setActive(true);
+        eh.setEvent(event2);
+        dao.updateEventHandler(eh);
 
-		all = dao.getEventHandlers();
-		assertNotNull(all);
-		assertEquals(1, all.size());
+        all = dao.getEventHandlers();
+        assertNotNull(all);
+        assertEquals(1, all.size());
 
-		byEvents = dao.getEventHandlersForEvent(event1, true);
-		assertNotNull(byEvents);
-		assertEquals(0, byEvents.size());
+        byEvents = dao.getEventHandlersForEvent(event1, true);
+        assertNotNull(byEvents);
+        assertEquals(0, byEvents.size());
 
-		byEvents = dao.getEventHandlersForEvent(event2, true);
-		assertNotNull(byEvents);
-		assertEquals(1, byEvents.size());
-	}
+        byEvents = dao.getEventHandlersForEvent(event2, true);
+        assertNotNull(byEvents);
+        assertEquals(1, byEvents.size());
+    }
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -1,30 +1,36 @@
 package com.netflix.conductor.dao.mysql;
 
-import com.google.common.collect.ImmutableList;
-
-import com.netflix.conductor.core.events.queue.Message;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableList;
+import com.netflix.conductor.core.events.queue.Message;
+import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.sql2o.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("Duplicates")
 public class MySQLQueueDAOTest extends MySQLBaseDAOTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MySQLQueueDAOTest.class);
 
 	private MySQLQueueDAO dao;
 
 	@Before
 	public void setup() throws Exception {
-		dao = new MySQLQueueDAO(objectMapper, testSql2o);
+		dao = new MySQLQueueDAO(objectMapper, dataSource);
 		resetAllData();
 	}
 
@@ -98,65 +104,193 @@ public class MySQLQueueDAOTest extends MySQLBaseDAOTest {
 		dao.flush(queueName);
 		size = dao.getSize(queueName);
 		assertEquals(0, size);
-
 	}
 
-    /**
-     * Test fix for https://github.com/Netflix/conductor/issues/399
-     * @since 1.8.2-rc5
-     */
-    @Test
-    public void pollMessagesTest() {
-        final List<Message> messages = new ArrayList<>();
-        final String queueName = "issue399_testQueue";
-        final int totalSize = 10;
+	/**
+	 * Test fix for https://github.com/Netflix/conductor/issues/399
+	 * @since 1.8.2-rc5
+	 */
+	@Test
+	public void pollMessagesTest() {
+		final List<Message> messages = new ArrayList<>();
+		final String queueName = "issue399_testQueue";
+		final int totalSize = 10;
 
-        for(int i = 0; i < totalSize; i++) {
-            String payload = "{\"id\": " + i + ", \"msg\":\"test " + i + "\"}";
-            messages.add(new Message("testmsg-" + i, payload, ""));
-        }
+		for(int i = 0; i < totalSize; i++) {
+			String payload = "{\"id\": " + i + ", \"msg\":\"test " + i + "\"}";
+			messages.add(new Message("testmsg-" + i, payload, ""));
+		}
 
-        // Populate the queue with our test message batch
-        dao.push(queueName, ImmutableList.copyOf(messages));
+		// Populate the queue with our test message batch
+		dao.push(queueName, ImmutableList.copyOf(messages));
 
 
-        // Assert that all messages were persisted and no extras are in there
-        assertEquals("Queue size mismatch", totalSize, dao.getSize(queueName));
+		// Assert that all messages were persisted and no extras are in there
+		assertEquals("Queue size mismatch", totalSize, dao.getSize(queueName));
 
-        final int firstPollSize = 3;
-        List<Message> firstPoll = dao.pollMessages(queueName, firstPollSize, 100);
-        assertNotNull("First poll was null", firstPoll);
-        assertFalse("First poll was empty", firstPoll.isEmpty());
-        assertEquals("First poll size mismatch", firstPollSize, firstPoll.size());
+		final int firstPollSize = 3;
+		List<Message> firstPoll = dao.pollMessages(queueName, firstPollSize, 10_000);
+		assertNotNull("First poll was null", firstPoll);
+		assertFalse("First poll was empty", firstPoll.isEmpty());
+		assertEquals("First poll size mismatch", firstPollSize, firstPoll.size());
 
-        for(int i = 0; i < firstPollSize; i++) {
-            assertEquals(messages.get(i).getId(), firstPoll.get(i).getId());
-            assertEquals(messages.get(i).getPayload(), firstPoll.get(i).getPayload());
-        }
+		final int secondPollSize = 4;
+		List<Message> secondPoll = dao.pollMessages(queueName, secondPollSize, 10_000);
+		assertNotNull("Second poll was null", secondPoll);
+		assertFalse("Second poll was empty", secondPoll.isEmpty());
+		assertEquals("Second poll size mismatch", secondPollSize, secondPoll.size());
 
-        final int secondPollSize = 4;
-        List<Message> secondPoll = dao.pollMessages(queueName, secondPollSize, 100);
-        assertNotNull("Second poll was null", secondPoll);
-        assertFalse("Second poll was empty", secondPoll.isEmpty());
-        assertEquals("Second poll size mismatch", secondPollSize, secondPoll.size());
+		// Assert that the total queue size hasn't changed
+		assertEquals("Total queue size should have remained the same", totalSize, dao.getSize(queueName));
 
-        for(int i = 0; i < secondPollSize; i++) {
-            assertEquals(messages.get(i + firstPollSize).getId(), secondPoll.get(i).getId());
-            assertEquals(messages.get(i + firstPollSize).getPayload(), secondPoll.get(i).getPayload());
-        }
+		// Assert that our un-popped messages match our expected size
+		final long expectedSize = totalSize - firstPollSize - secondPollSize;
+		try(Connection c = dataSource.getConnection()) {
+			String UNPOPPED = "SELECT COUNT(*) FROM queue_message WHERE queue_name = ? AND popped = false";
+			try(Query q = new Query(objectMapper, c, UNPOPPED)) {
+				long count = q.addParameter(queueName).executeCount();
+				assertEquals("Remaining queue size mismatch", expectedSize, count);
+			}
+		} catch (Exception ex) {
+			fail(ex.getMessage());
+		}
+	}
 
-        // Assert that the total queue size hasn't changed
-        assertEquals("Total queue size should have remained the same", totalSize, dao.getSize(queueName));
+	/**
+	 * Test fix for https://github.com/Netflix/conductor/issues/448
+	 * @since 1.8.2-rc5
+	 */
+	@Test
+	public void pollDeferredMessagesTest() throws InterruptedException {
+		final List<Message> messages = new ArrayList<>();
+		final String queueName = "issue448_testQueue";
+		final int totalSize = 10;
 
-        // Assert that our un-popped messages match our expected size
-        final int expectedSize = totalSize - firstPollSize - secondPollSize;
-        try(Connection c = testSql2o.open()) {
-            String UNPOPPED = "SELECT COUNT(*) FROM queue_message WHERE queue_name = :queueName AND popped = false";
-            int count = c.createQuery(UNPOPPED)
-                         .addParameter("queueName", queueName)
-                         .executeScalar(Integer.class);
+		for(int i = 0; i < totalSize; i++) {
+			int offset = 0;
+			if(i < 5){ offset = 0; }
+			else if(i == 6 || i == 7){
+				// Purposefully skipping id:5 to test out of order deliveries
+				// Set id:6 and id:7 for a 2s delay to be picked up in the second polling batch
+				offset = 5;
+			} else {
+				// Set all other queue messages to have enough of a delay that they won't accidentally
+				// be picked up.
+				offset = 10_000 + i;
+			}
 
-            assertEquals("Remaining queue size mismatch", expectedSize, count);
-        }
-    }
+			String payload = "{\"id\": " + i + ",\"offset_time_seconds\":" + offset + "}";
+			Message m = new Message("testmsg-" + i, payload, "");
+			messages.add(m);
+			dao.push(queueName, "testmsg-" + i, offset);
+		}
+
+		// Assert that all messages were persisted and no extras are in there
+		assertEquals("Queue size mismatch", totalSize, dao.getSize(queueName));
+
+		final int firstPollSize = 4;
+		List<Message> firstPoll = dao.pollMessages(queueName, firstPollSize, 100);
+		assertNotNull("First poll was null", firstPoll);
+		assertFalse("First poll was empty", firstPoll.isEmpty());
+		assertEquals("First poll size mismatch", firstPollSize, firstPoll.size());
+
+		List<String> firstPollMessageIds = messages.stream().map(Message::getId).collect(Collectors.toList()).subList(0, firstPollSize + 1);
+
+		for(int i = 0; i < firstPollSize; i++) {
+			String actual = firstPoll.get(i).getId();
+			assertTrue("Unexpected Id: " + actual, firstPollMessageIds.contains(actual));
+		}
+
+		final int secondPollSize = 3;
+
+		// Sleep a bit to get the next batch of messages
+		LOGGER.debug("Sleeping for second poll...");
+		Thread.sleep(5_000);
+
+		// Poll for many more messages than expected
+		List<Message> secondPoll = dao.pollMessages(queueName, secondPollSize + 10, 100);
+		assertNotNull("Second poll was null", secondPoll);
+		assertFalse("Second poll was empty", secondPoll.isEmpty());
+		assertEquals("Second poll size mismatch", secondPollSize, secondPoll.size());
+
+		List<String> expectedIds = Arrays.asList("testmsg-4","testmsg-6","testmsg-7");
+		for(int i = 0; i < secondPollSize; i++) {
+			String actual = secondPoll.get(i).getId();
+			assertTrue("Unexpected Id: " + actual, expectedIds.contains(actual));
+		}
+
+		// Assert that the total queue size hasn't changed
+		assertEquals("Total queue size should have remained the same", totalSize, dao.getSize(queueName));
+
+		// Assert that our un-popped messages match our expected size
+		final long expectedSize = totalSize - firstPollSize - secondPollSize;
+		try(Connection c = dataSource.getConnection()) {
+			String UNPOPPED = "SELECT COUNT(*) FROM queue_message WHERE queue_name = ? AND popped = false";
+			try(Query q = new Query(objectMapper, c, UNPOPPED)) {
+				long count = q.addParameter(queueName).executeCount();
+				assertEquals("Remaining queue size mismatch", expectedSize, count);
+			}
+		} catch (Exception ex) {
+			fail(ex.getMessage());
+		}
+	}
+
+	@Test
+	public void processUnacksTest() {
+		final String queueName = "process_unacks_test";
+		// Count of messages in the queue(s)
+		final int count = 10;
+		// Number of messages to process acks for
+		final int unackedCount = 4;
+		// A secondary queue to make sure we don't accidentally process other queues
+		final String otherQueueName = "process_unacks_test_other_queue";
+
+		// Create testing queue with some messages (but not all) that will be popped/acked.
+		for(int i = 0; i < count; i++) {
+			int offset = 0;
+			if(i >= unackedCount){ offset = 1_000_000; }
+
+			dao.push(queueName, "unack-" + i, offset);
+		}
+
+		// Create a second queue to make sure that unacks don't occur for it
+		for(int i = 0; i < count; i++) {
+			dao.push(otherQueueName, "other-" + i, 0);
+		}
+
+		// Poll for first batch of messages (should be equal to unackedCount)
+		List<Message> polled = dao.pollMessages(queueName, 100, 10_000);
+		assertNotNull(polled);
+		assertFalse(polled.isEmpty());
+		assertEquals(unackedCount, polled.size());
+
+		// Poll messages from the other queue so we know they don't get unacked later
+		dao.pollMessages(otherQueueName, 100, 10_000);
+
+		// Ack one of the polled messages
+		assertTrue(dao.ack(queueName, "unack-1"));
+
+		// Should have one less un-acked popped message in the queue
+		Long uacked = dao.queuesDetailVerbose().get(queueName).get("a").get("uacked");
+		assertNotNull(uacked);
+		assertEquals(uacked.longValue(), unackedCount - 1);
+
+
+		// Process unacks
+		dao.processUnacks(queueName);
+
+		// Check uacks for both queues after processing
+		Map<String, Map<String, Map<String, Long>>> details = dao.queuesDetailVerbose();
+		uacked = details.get(queueName).get("a").get("uacked");
+		assertNotNull(uacked);
+		assertEquals("There should be no unacked messages", uacked.longValue(), 0);
+
+		Long otherUacked = details.get(otherQueueName).get("a").get("uacked");
+		assertNotNull(otherUacked);
+		assertEquals("Other queue should have unacked messages", otherUacked.longValue(), count);
+
+		Long size = dao.queuesDetail().get(queueName);
+		assertNotNull(size);
+		assertEquals(size.longValue(), count - 1);
+	}
 }

--- a/mysql-persistence/src/test/resources/logback-test.xml
+++ b/mysql-persistence/src/test/resources/logback-test.xml
@@ -7,8 +7,7 @@
   <root level="info">
     <appender-ref ref="STDOUT"/>
   </root>
-
-  <logger name="org.sql2o" level="INFO"/>
+  
   <logger name="com.netflix.conductor.dao.jdbc" level="TRACE"/>
   <logger name="com.netflix.conductor.dao.mysql" level="DEBUG"/>
   <logger name="org.flywaydb" level="WARN"/>

--- a/mysql-persistence/src/test/resources/logback-test.xml
+++ b/mysql-persistence/src/test/resources/logback-test.xml
@@ -1,17 +1,18 @@
 <configuration>
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-		</encoder>
-	</appender>
-	<root level="info">
-		<appender-ref ref="STDOUT" />
-	</root>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
 
-	<logger name="org.sql2o" level="INFO" />
-	<logger name="com.netflix.conductor.dao.mysql" level="DEBUG" />
-	<logger name="org.flywaydb" level="WARN" />
-	<logger name="com.zaxxer.hikari" level="WARN" />
-	<logger name="ch.vorburger" level="WARN" />
+  <logger name="org.sql2o" level="INFO"/>
+  <logger name="com.netflix.conductor.dao.jdbc" level="TRACE"/>
+  <logger name="com.netflix.conductor.dao.mysql" level="DEBUG"/>
+  <logger name="org.flywaydb" level="WARN"/>
+  <logger name="com.zaxxer.hikari" level="WARN"/>
+  <logger name="ch.vorburger" level="WARN"/>
 
 </configuration>

--- a/mysql-persistence/src/test/resources/logback-test.xml
+++ b/mysql-persistence/src/test/resources/logback-test.xml
@@ -4,6 +4,7 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
+  
   <root level="info">
     <appender-ref ref="STDOUT"/>
   </root>

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -47,5 +47,4 @@ ext {
     revSlf4j = '1.7.25'
     revSlf4jlog4j = '1.8.0-alpha1'
     revSpectator = '0.40.0'
-    revSql2o = '1.5.4'
 }


### PR DESCRIPTION
@picaron This is a sample of the `java.sql.*` only implementation from #424 , I've included the `MetadataDAO` implementation- all the new work is in the `com.netflix.conductor.dao.jdbc` package so that it's easier to compare side by side with the existing `com.netflix.conductor.dao.mysql` package.

# Approach
Maintain the same developer flow and ergonomics that @picaron set with the usage of the Sql2o library and `MySQLBaseDAO`.

I essentially reused all existing queries, just swapping out named params for standard `PreparedStatement` bind question marks, `?`.

I created a few `@FunctionalInterface` instances for Java 8 style `Consumer` and `Function` patterns that allow for `SQLExceptions` to be handled by wrapper methods in the `JdbcBaseDAO` and `Query` classes.

## JdbcBaseDAO Class
The `jdbc.JdbcBaseDAO` mimics the `MySQLBaseDAO` conventions heavily with the `getWithTransaction` and `withTransaction` methods, but adds additional convenience wrappers as well. 

## Query Builder Class
the `jdbc.Query` class is inspired by the nice ergonomics of Sql2o, bet eschews a lot of the generic conversion and data type handling for the more simple use cases encountered in the Conductor DAOs.

**Highlights**

- Builder pattern _addParameter_ methods for quicker chaining of parameter binding.
- Primitive batch parameter addition via the `addParameters(Object...)` method
- `addJsonParameter(Object)` as a convenience method for the repeated persistence of Conductor objects as JSON strings in columns
- `SQLException` conversion to runtime `ApplicationException` exceptions to remove the massive `try/catch` boilerplate required by `PreparedStatement` and `ResultSet` interactions
- Convenience methods like `boolean exists()` and `boolean delete()` that eschew the boiler plate code of checking a `ResultSet` for affected rows or retrieving a scalar value
- Use of Java _try with resources_ for automatic management of `PreparedStatement` and `ResultSet` instances