### PR TITLE
Fixed minor inconsistencies in conductor's python api

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -107,7 +107,7 @@ class MetadataClient(BaseClient):
     def __init__(self, baseURL):
         BaseClient.__init__(self, baseURL, self.BASE_RESOURCE)
 
-    def getWorkflowDef(self, wfname, version=1):
+    def getWorkflowDef(self, wfname, version=None):
         url = self.makeUrl('workflow/{}', wfname)
         params = {}
         params['version']=version
@@ -200,7 +200,7 @@ class WorkflowClient(BaseClient):
         params['includeTasks']=includeTasks
         return self.get(url, params)
 
-    def getRunningWorkflows(self, wfName, version=1, startTime=None, endTime=None):
+    def getRunningWorkflows(self, wfName, version=None, startTime=None, endTime=None):
         url = self.makeUrl('running/{}', wfName)
         params = {}
         params['version']=version
@@ -208,7 +208,7 @@ class WorkflowClient(BaseClient):
         params['endTime']=endTime
         return self.get(url, params)
 
-    def startWorkflow(self, wfName, inputjson, version=1, correlationId=None):
+    def startWorkflow(self, wfName, inputjson, version=None, correlationId=None):
         url = self.makeUrl('{}', wfName)
         params = {}
         params['version']=version
@@ -263,7 +263,7 @@ def main():
     if command == 'start':
         if len(sys.argv) < 7:
             print('python conductor server_url start workflow_name input_json [version] [correlationId]')
-            return None;
+            return None
         wfName = sys.argv[3]
         version = sys.argv[4]
         input = json.loads(sys.argv[5])
@@ -284,8 +284,11 @@ def main():
             print('python conductor server_url terminate workflow_id')
             return None
         wfId = sys.argv[3]
-        wfjson = wfc.terminateWorkflow(wfId)
+        wfc.terminateWorkflow(wfId)
         print('OK')
         return wfId
+
+
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
-> When **GET /metadata/workflow/{name}** is called without a version, conductor returns the latest version
Line 110: Conductor python library defaults to version=1 instead

-> When **GET /workflow/running/{name}** is called without version, conductor returns all the running workflows for all versions
Line 203: Conductor python library default, only gets version=1 instead

-> When **POST /workflow** is sent an object without the 'version' key, it starts the latest version of that workflow
Line 211: Conductor python library defaults to run the version=1 instead

Line 266: unneccessary ';' at the end of line

Line 287: wfc.terminateWorkflow(wfId) returns nothing

**This commit fixes the problems stated above**