### PR TITLE
Remove unnecessary code

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -125,7 +125,6 @@ public class DeciderService {
         Map<String, Task> tasksToBeScheduled = new LinkedHashMap<>();
 
         preScheduledTasks.forEach(pst -> {
-            executedTaskRefNames.remove(pst.getReferenceTaskName());
             tasksToBeScheduled.put(pst.getReferenceTaskName(), pst);
         });
 


### PR DESCRIPTION
code1:
`
List<Task> executedTasks = tasks.stream()
                .filter(t -> !t.getStatus().equals(Status.SKIPPED) && !t.getStatus().equals(Status.READY_FOR_RERUN))
                .collect(Collectors.toList());

        List<Task> tasksToBeScheduled = new LinkedList<>();
       if (executedTasks.isEmpty()) {
            //this isSystemTask the flow that the new workflow will go through
            tasksToBeScheduled = startWorkflow(workflow, def);
            if (tasksToBeScheduled == null) {
                tasksToBeScheduled = new LinkedList<>();
            }
        }
        return decide(def, workflow, tasksToBeScheduled);
`
code2:
`     Set<String> executedTaskRefNames = workflow.getTasks()
                .stream()
                .filter(t -> !t.getStatus().equals(Status.SKIPPED) && !t.getStatus().equals(Status.READY_FOR_RERUN))
                .map(Task::getReferenceTaskName)
                .collect(Collectors.toSet());

        Map<String, Task> tasksToBeScheduled = new LinkedHashMap<>();

        preScheduledTasks.forEach(pst -> {
            executedTaskRefNames.remove(pst.getReferenceTaskName());
            tasksToBeScheduled.put(pst.getReferenceTaskName(), pst);
        });
`
in code2,when the preScheduledTasks is not empty,then wo can derive that in code1 the executedTasks is empty. when in code1 the executedTasks is empty wo can see  in code2 the executedTaskRefNames is also empty.because they all filt by workflow.gettasks by same condition. in this way wo can derive the preScheduledTasks is not empty then  executedTaskRefNames must be empty in code2