### PR TITLE
remove the unnecessary code

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -382,7 +382,6 @@ public class WorkflowExecutor {
         // If the following lines, for some reason fails, the sweep will take
         // care of this again!
         if (workflow.getParentWorkflowId() != null) {
-            Workflow parent = executionDAO.getWorkflow(workflow.getParentWorkflowId(), false);
             decide(parent.getWorkflowId());
         }
 


### PR DESCRIPTION
in WorkflowExecutor this code:
`
if (workflow.getParentWorkflowId() != null)

 {
			Workflow parent = edao.getWorkflow(workflow.getParentWorkflowId(), false);
			decide(parent.getWorkflowId());
}
`
 `Workflow parent = edao.getWorkflow(workflow.getParentWorkflowId(), false);`
is unnecessary,so remove it 