### PR TITLE
remove the unnecessary code

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -242,16 +242,6 @@ public class WorkflowExecutor {
 
             }
         }
-        ;
-        if (failedTask != null && !failedTask.getStatus().isTerminal()) {
-            throw new ApplicationException(Code.CONFLICT,
-                    "The last task is still not completed!  I can only retry the last failed task.  Use restart if you want to attempt entire workflow execution again.");
-        }
-        if (failedTask != null && failedTask.getStatus().isSuccessful()) {
-            throw new ApplicationException(Code.CONFLICT,
-                    "The last task has not failed!  I can only retry the last failed task.  Use restart if you want to attempt entire workflow execution again.");
-        }
-
         // Below is the situation where currently when the task failure causes
         // workflow to fail, the task's retried flag is not updated. This is to
         // update for these old tasks.


### PR DESCRIPTION
wo can see that the status is CANCLED,
`public enum Status {
		
		IN_PROGRESS(false, true, true), 
		CANCELED(true, false, false),
		FAILED(true, false, true),
		COMPLETED(true, true, true),
		COMPLETED_WITH_ERRORS(true, true, true),
		SCHEDULED(false, true, true), 
		TIMED_OUT(true, false, true),
		READY_FOR_RERUN(false, true, true),
		SKIPPED(true, true, false);
		
		private boolean terminal;
		
		private boolean successful;
		
		private boolean retriable;

		Status(boolean terminal, boolean successful, boolean retriable){
			this.terminal = terminal;
			this.successful = successful;
			this.retriable = retriable;
		}`
so we have know the status 's terminal is false,the status 's successful is false. in this way we don't need the code like this:
`if (failedTask != null && !failedTask.getStatus().isTerminal()) {
            throw new ApplicationException(Code.CONFLICT,
                    "The last task is still not completed!  I can only retry the last failed task.  Use restart if you want to attempt entire workflow execution again.");
        }
        if (failedTask != null && failedTask.getStatus().isSuccessful()) {
            throw new ApplicationException(Code.CONFLICT,
                    "The last task has not failed!  I can only retry the last failed task.  Use restart if you want to attempt entire workflow execution again.");
        }` 