### PR TITLE
avoid repeat task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -567,7 +567,11 @@ public class WorkflowExecutor {
             if (!tasksToBeRequeued.isEmpty()) {
                 addTaskToQueue(tasksToBeRequeued);
             }
-            workflow.getTasks().addAll(tasksToBeScheduled);
+
+            if(!workflow.getTasks().contains(tasksToBeScheduled))
+            {
+                workflow.getTasks().addAll(tasksToBeScheduled);
+            }
 
             for (Task task : tasksToBeScheduled) {
                 if (isSystemTask.and(isNonTerminalTask).test(task)) {


### PR DESCRIPTION
when i use 
fork ->wait1,wait2->join(wait1,wait2) like this:
![image](https://user-images.githubusercontent.com/9736914/39170643-d400e8ec-47ce-11e8-9335-1ff2ef05e600.png)

![image](https://user-images.githubusercontent.com/9736914/39171090-622d4592-47d0-11e8-838f-5898e6df9eab.png)

found the workflow's tasks is repeat. i found that when the wait task  is not completed, in workflowExecutor ,deciderService.decide repeat put the wait task into the tasksToBeRequeued in workflowexecutor. the result like below.
throuth the repeat task can not occur bug,but reduce performance.see the bottom picture ,
The red area could not have been executed as many times.
![image](https://user-images.githubusercontent.com/9736914/39170957-ef63a9ac-47cf-11e8-8894-768a07f9ce92.png)
 