### PR TITLE
Able to use the python sdk with python3.6.

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -44,7 +44,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
             resp = requests.post(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
@@ -58,7 +58,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
 
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
@@ -78,6 +78,11 @@ class BaseClient(object):
     def makeUrl(self, urlformat, *argv):
         url = self.baseResource + '/' + urlformat.format(*argv)
         return url
+
+    def mergeTwoDicts(self, x, y):
+        z = x.copy()
+        z.update(y)
+        return z
 
     def __print(self, resp):
         if self.printUrl:


### PR DESCRIPTION
Test code.

* cat start_workflow.py 

```
from conductor import conductor

def main():
    wfc = conductor.WorkflowClient('http://localhost:8080/api')
    wfName = 'kitchensink'
    input = { "task2Name": "task_5" }
    workflowId = wfc.startWorkflow(wfName, input, 1, None)
    print(workflowId)

if __name__ == '__main__':
    main()
```

Result.

```
yoshi4:python kakakikikeke$ python3 -V
Python 3.6.4
yoshi4:python kakakikikeke$ python3 start_workflow.py 
6b168bb0-4c67-4fa9-a7c2-ab1a6efee016
yoshi4:python kakakikikeke$ python2 -V
Python 2.7.14
yoshi4:python kakakikikeke$ python2 start_workflow.py 
7257b875-2646-458b-8ab2-8708cf9e8f0f
```