### PR TITLE
Add a method removeWorkflow into python sdk.

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -250,6 +250,13 @@ class WorkflowClient(BaseClient):
         params['reason'] = reason
         self.delete(url, params)
 
+    def removeWorkflow(self, wfId, archiveWorkflow, reason=None):
+        url = self.makeUrl('{}/remove', wfId)
+        params = {}
+        params['archiveWorkflow'] = archiveWorkflow
+        params['reason'] = reason
+        self.delete(url, params)
+
     def pauseWorkflow(self, wfId):
         url = self.makeUrl('{}/pause', wfId)
         self.put(url)

--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -44,7 +44,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
             resp = requests.post(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
@@ -58,7 +58,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
 
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
@@ -78,6 +78,11 @@ class BaseClient(object):
     def makeUrl(self, urlformat, *argv):
         url = self.baseResource + '/' + urlformat.format(*argv)
         return url
+
+    def mergeTwoDicts(self, x, y):
+        z = x.copy()
+        z.update(y)
+        return z
 
     def __print(self, resp):
         if self.printUrl:


### PR DESCRIPTION
Test code.

```
from conductor import conductor

def main():
    wfc = conductor.WorkflowClient('http://localhost:8080/api')
    wfId = '7257b875-2646-458b-8ab2-8708cf9e8f0f'
    ret = wfc.removeWorkflow(wfId, False)
    print(ret) # -> always None

if __name__ == '__main__':
    main()
```

You have to set archiveWorkflow to False every time.  
I was created this branch from https://github.com/Netflix/conductor/pull/513.