### PR TITLE
Fix a bug of unRegisterTaskDef in python SDK.

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -250,6 +250,13 @@ class WorkflowClient(BaseClient):
         params['reason'] = reason
         self.delete(url, params)
 
+    def removeWorkflow(self, wfId, archiveWorkflow, reason=None):
+        url = self.makeUrl('{}/remove', wfId)
+        params = {}
+        params['archiveWorkflow'] = archiveWorkflow
+        params['reason'] = reason
+        self.delete(url, params)
+
     def pauseWorkflow(self, wfId):
         url = self.makeUrl('{}/pause', wfId)
         self.put(url)

--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -143,9 +143,11 @@ class MetadataClient(BaseClient):
         url = self.makeUrl('taskdefs')
         self.put(url, None, taskDefObj)
 
-    def unRegisterTaskDef(self, tdName):
+    def unRegisterTaskDef(self, tdName, reason=None):
         url = self.makeUrl('taskdefs/{}', tdName)
-        self.delete(url)
+        params = {}
+        params['reason'] = reason
+        self.delete(url, params)
 
     def getAllTaskDefs(self):
         url = self.makeUrl('taskdefs')
@@ -207,9 +209,11 @@ class TaskClient(BaseClient):
         url = self.makeUrl('queue/{}', taskName)
         return self.get(url)
 
-    def removeTaskFromQueue(self, taskId):
+    def removeTaskFromQueue(self, taskId, reason=None):
         url = self.makeUrl('queue/{}', taskId)
-        self.delete(url)
+        params = {}
+        params['reason'] = reason
+        self.delete(url, params)
 
     def getTaskQueueSizes(self, listOfTaskName):
         url = self.makeUrl('queue/sizes')

--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -44,7 +44,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
             resp = requests.post(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
@@ -58,7 +58,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = self.mergeTwoDicts(self.headers, headers)
 
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
@@ -78,6 +78,11 @@ class BaseClient(object):
     def makeUrl(self, urlformat, *argv):
         url = self.baseResource + '/' + urlformat.format(*argv)
         return url
+
+    def mergeTwoDicts(self, x, y):
+        z = x.copy()
+        z.update(y)
+        return z
 
     def __print(self, resp):
         if self.printUrl:


### PR DESCRIPTION
An error Occured below as:

```
Traceback (most recent call last):
  File "delete_task.py", line 10, in <module>
    main()
  File "delete_task.py", line 6, in main
    ret = mc.unRegisterTaskDef(tdName, False)
TypeError: unRegisterTaskDef() takes 2 positional arguments but 3 were given
```

I was fixed them.  
This branch was created from #514.