### PR TITLE
Switch from "java" to "openjdk" base docker containers.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-slim
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/server/Dockerfile.build
+++ b/docker/server/Dockerfile.build
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:serverAndUI - Netflix conductor server and UI
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 


### PR DESCRIPTION
The [java](https://hub.docker.com/_/java/) images have been deprecated according to the site in favor of the [openjdk](https://hub.docker.com/_/openjdk/) images.