### PR TITLE
Move Dyno configuration from ServerModule to RedisESWorkflowModule.

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/RedisESWorkflowModule.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/RedisESWorkflowModule.java
@@ -1,17 +1,14 @@
 /**
  * Copyright 2016 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.dao;
 /**
@@ -19,21 +16,17 @@ package com.netflix.conductor.dao;
  */
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Inject;
 
 import com.netflix.conductor.core.config.Configuration;
-import com.netflix.conductor.dao.ExecutionDAO;
-import com.netflix.conductor.dao.IndexDAO;
-import com.netflix.conductor.dao.MetadataDAO;
-import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.dao.dynomite.DynoProxy;
 import com.netflix.conductor.dao.dynomite.RedisExecutionDAO;
 import com.netflix.conductor.dao.dynomite.RedisMetadataDAO;
 import com.netflix.conductor.dao.dynomite.queue.DynoQueueDAO;
 import com.netflix.conductor.dao.index.ElasticSearchDAO;
-import com.netflix.conductor.dao.index.ElasticsearchModule;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.queues.redis.DynoShardSupplier;
+
+import javax.inject.Inject;
 
 import redis.clients.jedis.JedisCommands;
 

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/RedisESWorkflowModule.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/RedisESWorkflowModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,35 +15,62 @@
  */
 package com.netflix.conductor.dao;
 /**
- * 
+ *
  */
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.dynomite.DynoProxy;
 import com.netflix.conductor.dao.dynomite.RedisExecutionDAO;
 import com.netflix.conductor.dao.dynomite.RedisMetadataDAO;
 import com.netflix.conductor.dao.dynomite.queue.DynoQueueDAO;
 import com.netflix.conductor.dao.index.ElasticSearchDAO;
 import com.netflix.conductor.dao.index.ElasticsearchModule;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.queues.redis.DynoShardSupplier;
+
+import redis.clients.jedis.JedisCommands;
 
 /**
  * @author Viren
- *
  */
 public class RedisESWorkflowModule extends AbstractModule {
+    private final Configuration config;
+    private final JedisCommands dynomiteConnection;
+    private final HostSupplier hostSupplier;
 
-	@Override
-	protected void configure() {
-		
-		install(new ElasticsearchModule());
-		bind(MetadataDAO.class).to(RedisMetadataDAO.class);
-		bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
-		bind(QueueDAO.class).to(DynoQueueDAO.class);
-		bind(IndexDAO.class).to(ElasticSearchDAO.class);
-		
-	}
+    @Inject
+    public RedisESWorkflowModule(Configuration config, JedisCommands dynomiteConnection, HostSupplier hostSupplier) {
+        this.config = config;
+        this.dynomiteConnection = dynomiteConnection;
+        this.hostSupplier = hostSupplier;
+    }
 
+    @Override
+    protected void configure() {
+
+        bind(MetadataDAO.class).to(RedisMetadataDAO.class);
+        bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
+        bind(QueueDAO.class).to(DynoQueueDAO.class);
+        bind(IndexDAO.class).to(ElasticSearchDAO.class);
+
+        bind(DynoQueueDAO.class).toInstance(createQueueDAO());
+        bind(DynoProxy.class).toInstance(new DynoProxy(dynomiteConnection));
+
+    }
+
+    private DynoQueueDAO createQueueDAO() {
+
+        String localDC = config.getAvailabilityZone();
+        localDC = localDC.replaceAll(config.getRegion(), "");
+        DynoShardSupplier ss = new DynoShardSupplier(hostSupplier, config.getRegion(), localDC);
+
+        return new DynoQueueDAO(dynomiteConnection, dynomiteConnection, ss, config);
+    }
 }

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -33,6 +33,7 @@ import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.RedisESWorkflowModule;
 import com.netflix.conductor.dao.dynomite.DynoProxy;
 import com.netflix.conductor.dao.dynomite.RedisExecutionDAO;
 import com.netflix.conductor.dao.dynomite.RedisMetadataDAO;
@@ -87,18 +88,7 @@ public class ServerModule extends AbstractModule {
 		if (db == ConductorServer.DB.mysql) {
 			install(new MySQLWorkflowModule());
 		} else {
-			String localDC = localRack;
-			localDC = localDC.replaceAll(region, "");
-			DynoShardSupplier ss = new DynoShardSupplier(hostSupplier, region, localDC);
-			DynoQueueDAO queueDao = new DynoQueueDAO(dynoConn, dynoConn, ss, conductorConfig);
-
-			bind(MetadataDAO.class).to(RedisMetadataDAO.class);
-			bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
-			bind(DynoQueueDAO.class).toInstance(queueDao);
-			bind(QueueDAO.class).to(DynoQueueDAO.class);
-
-			DynoProxy proxy = new DynoProxy(dynoConn);
-			bind(DynoProxy.class).toInstance(proxy);
+		    install(new RedisESWorkflowModule(conductorConfig, dynoConn, hostSupplier));
 		}
 
 		install(new ElasticsearchModule());


### PR DESCRIPTION
There was already some duplicated code in these two modules, but the Redis module was not actually used anywhere.  I think that this simplifies things quite a bit and makes it consistent with how we are loading the MySQL module.  Also, this seems like a better place to contain the initialization code, since it is co-located with the actual bindings and scoped to the module that actually needs them.