### PR TITLE
Bump spectator version to version 0.68.0

### DIFF
--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -26,8 +26,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -67,8 +67,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -108,8 +108,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -124,14 +124,12 @@
     },
     "findbugs": {
         "com.google.code.findbugs:findbugs": {
-            "locked": "3.0.1",
-            "requested": "3.0.1"
+            "locked": "3.0.1"
         }
     },
     "pmd": {
         "net.sourceforge.pmd:pmd-java": {
-            "locked": "5.6.1",
-            "requested": "5.6.1"
+            "locked": "5.6.1"
         }
     },
     "runtime": {
@@ -161,8 +159,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -202,8 +200,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -243,8 +241,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -296,8 +294,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -349,8 +347,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",
@@ -402,8 +400,8 @@
             "requested": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
             "locked": "1.19.4",

--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "compile": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -60,7 +60,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -107,7 +107,7 @@
     },
     "compileClasspath": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -166,7 +166,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -213,7 +213,7 @@
     },
     "default": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -272,7 +272,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -329,7 +329,7 @@
     },
     "runtime": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -388,7 +388,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -435,7 +435,7 @@
     },
     "runtimeClasspath": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -494,7 +494,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -541,7 +541,7 @@
     },
     "testCompile": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -600,7 +600,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -663,7 +663,7 @@
     },
     "testCompileClasspath": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -722,7 +722,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -785,7 +785,7 @@
     },
     "testRuntime": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -844,7 +844,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",
@@ -907,7 +907,7 @@
     },
     "testRuntimeClasspath": {
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.315",
+            "locked": "1.11.333",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -966,7 +966,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "locked": "1.19.4",

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -34,8 +34,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -87,8 +87,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -140,8 +140,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -193,8 +193,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -246,8 +246,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -299,8 +299,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -364,8 +364,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -429,8 +429,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",
@@ -494,8 +494,8 @@
             "requested": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.40.0",
-            "requested": "0.40.0"
+            "locked": "0.68.0",
+            "requested": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.2",

--- a/es5-persistence/dependencies.lock
+++ b/es5-persistence/dependencies.lock
@@ -56,7 +56,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -154,7 +154,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -252,7 +252,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -350,7 +350,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -448,7 +448,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -546,7 +546,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -652,7 +652,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -758,7 +758,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",
@@ -864,7 +864,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "commons-io:commons-io": {
             "locked": "2.4",

--- a/jersey/dependencies.lock
+++ b/jersey/dependencies.lock
@@ -55,7 +55,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -148,7 +148,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -241,7 +241,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -340,7 +340,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -433,7 +433,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -526,7 +526,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -627,7 +627,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -728,7 +728,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",
@@ -829,7 +829,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-bundle": {
             "locked": "1.19.1",

--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -56,7 +56,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -154,7 +154,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -252,7 +252,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -350,7 +350,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -448,7 +448,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -558,7 +558,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -676,7 +676,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -794,7 +794,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",
@@ -912,7 +912,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.6.3",

--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -68,7 +68,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -166,7 +166,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -264,7 +264,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -362,7 +362,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -460,7 +460,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -558,7 +558,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -668,7 +668,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -778,7 +778,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -888,7 +888,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -4,7 +4,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -107,7 +107,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -241,7 +241,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -344,7 +344,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -478,7 +478,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -581,7 +581,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -715,7 +715,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -818,7 +818,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -1012,7 +1012,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1115,7 +1115,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -1249,7 +1249,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1352,7 +1352,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -1486,7 +1486,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1589,7 +1589,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -1723,7 +1723,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1826,7 +1826,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -1968,7 +1968,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2071,7 +2071,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -2213,7 +2213,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2316,7 +2316,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -2458,7 +2458,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2561,7 +2561,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -4,13 +4,13 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -155,7 +155,7 @@
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -318,13 +318,13 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -469,7 +469,7 @@
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -632,13 +632,13 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -783,7 +783,7 @@
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [
@@ -946,13 +946,13 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.315"
+            "locked": "1.11.333"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1097,7 +1097,7 @@
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "0.40.0"
+            "locked": "0.68.0"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
             "firstLevelTransitive": [

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -48,5 +48,5 @@ ext {
     revSwaggerJersey = '1.5.0'
     revSlf4j = '1.7.25'
     revSlf4jlog4j = '1.8.0-alpha1'
-    revSpectator = '0.40.0'
+    revSpectator = '0.68.0'
 }


### PR DESCRIPTION
Bumped up spectator to version v0.68.0

Conductor was using a very old version of spectator: 0.40.0.
This works fine; however, gauges were not being passed through to underlying
registries if you wanted to integrate or collect metrics via datadog or some
other integraton framework.

However, in version 0.45.0, Spectator eventually added support to passing gauges
through to underlying registries (https://github.com/Netflix/spectator/pull/353).

This is just an attempt to upgrade the spectator version to the latest.