### PR TITLE
Use itertool's chain function to combine lists (rather than addition).

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -18,6 +18,7 @@ import requests
 import json
 import sys
 import socket
+from itertools import chain
 
 
 hostname = socket.gethostname()
@@ -44,7 +45,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = dict(chain(self.headers.items(), headers.items()))
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)
             resp = requests.post(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
@@ -58,7 +59,7 @@ class BaseClient(object):
         theUrl = "{}/{}".format(self.baseURL, resPath)
         theHeader = self.headers
         if headers is not None:
-            theHeader = dict(self.headers.items() + headers.items())
+            theHeader = dict(chain(self.headers.items(), headers.items()))
 
         if body is not None:
             jsonBody = json.dumps(body, ensure_ascii=False)


### PR DESCRIPTION
While maintaining full functionality in python 2.7, this change makes the code more forward compatible with python 3's frequent use of generators in place of lists (Note that, unlike lists, generators cannot be summed).

Example:
In python 2, using `chain`:
```
>>> dict(chain([(1,"a")],[(2,"b")]))
{1: 'a', 2: 'b'}
```

In python 3, using `chain`:
```
In [1]: dict(chain({1: "a"}.items(), {2: "b"}.items()))
Out[1]: {1: 'a', 2: 'b'}
```

In python 3, using addition:
```
In [2]: dict({1: "a"}.items() + {2: "b"}.items())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-0567e0b6f089> in <module>()
----> 1 dict({1: "a"}.items() + {2: "b"}.items())

TypeError: unsupported operand type(s) for +: 'dict_items' and 'dict_items'
```
