### PR TITLE
Fix for scheduling tasks after executing system tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -836,9 +836,6 @@ public class WorkflowExecutor {
             task.setStartTime(System.currentTimeMillis());
             if (!workflowSystemTask.isAsync()) {
                 workflowSystemTask.start(workflow, task, this);
-                if (task.getStatus().isTerminal()) {
-                    task.setExecuted(true);
-                }
                 startedSystemTasks = true;
                 executionDAO.updateTask(task);
             } else {

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowServiceTest.java
@@ -3396,63 +3396,90 @@ public class WorkflowServiceTest {
     @Test
     public void testWait() throws Exception {
 
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("test_wait");
+        workflowDef.setSchemaVersion(2);
 
-        WorkflowDef def = new WorkflowDef();
-        def.setName("test_wait");
-        def.setSchemaVersion(2);
-        WorkflowTask wait = new WorkflowTask();
-        wait.setWorkflowTaskType(Type.WAIT);
-        wait.setName("wait");
-        wait.setTaskReferenceName("wait0");
-        def.getTasks().add(wait);
-        metadataService.registerWorkflowDef(def);
+        WorkflowTask waitWorkflowTask = new WorkflowTask();
+        waitWorkflowTask.setWorkflowTaskType(Type.WAIT);
+        waitWorkflowTask.setName("wait");
+        waitWorkflowTask.setTaskReferenceName("wait0");
 
-        String id = workflowExecutor.startWorkflow(def.getName(), def.getVersion(), "", new HashMap<>());
-        Workflow workflow = workflowExecutor.getWorkflow(id, true);
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setName("junit_task_1");
+        workflowTask.setTaskReferenceName("t1");
+
+        workflowDef.getTasks().add(waitWorkflowTask);
+        workflowDef.getTasks().add(workflowTask);
+        metadataService.registerWorkflowDef(workflowDef);
+
+        String workflowId = workflowExecutor.startWorkflow(workflowDef.getName(), workflowDef.getVersion(), "", new HashMap<>());
+        Workflow workflow = workflowExecutor.getWorkflow(workflowId, true);
         assertNotNull(workflow);
         assertEquals(1, workflow.getTasks().size());
         assertEquals(WorkflowStatus.RUNNING, workflow.getStatus());
+
         Task waitTask = workflow.getTasks().get(0);
         assertEquals(WorkflowTask.Type.WAIT.name(), waitTask.getTaskType());
         waitTask.setStatus(COMPLETED);
         workflowExecutor.updateTask(new TaskResult(waitTask));
 
-        workflow = workflowExecutor.getWorkflow(id, true);
-        assertEquals(WorkflowStatus.COMPLETED, workflow.getStatus());
+        Task task = workflowExecutionService.poll("junit_task_1", "test");
+        assertNotNull(task);
+        task.setStatus(Status.COMPLETED);
+        workflowExecutionService.updateTask(task);
+
+        workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals("tasks:" + workflow.getTasks(), WorkflowStatus.COMPLETED, workflow.getStatus());
     }
 
     @Test
-    public void testEvent() throws Exception {
+    public void testEventWorkflow() throws Exception {
 
-        TaskDef td = new TaskDef();
-        td.setName("eventX");
-        td.setTimeoutSeconds(1);
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("eventX");
+        taskDef.setTimeoutSeconds(1);
 
-        metadataService.registerTaskDef(Arrays.asList(td));
+        metadataService.registerTaskDef(Collections.singletonList(taskDef));
 
-        WorkflowDef def = new WorkflowDef();
-        def.setName("test_event");
-        def.setSchemaVersion(2);
-        WorkflowTask event = new WorkflowTask();
-        event.setWorkflowTaskType(Type.EVENT);
-        event.setName("eventX");
-        event.setTaskReferenceName("wait0");
-        event.setSink("conductor");
-        def.getTasks().add(event);
-        metadataService.registerWorkflowDef(def);
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("test_event");
+        workflowDef.setSchemaVersion(2);
 
-        String id = workflowExecutor.startWorkflow(def.getName(), def.getVersion(), "", new HashMap<>());
+        WorkflowTask eventWorkflowTask = new WorkflowTask();
+        eventWorkflowTask.setWorkflowTaskType(Type.EVENT);
+        eventWorkflowTask.setName("eventX");
+        eventWorkflowTask.setTaskReferenceName("wait0");
+        eventWorkflowTask.setSink("conductor");
+
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setName("junit_task_1");
+        workflowTask.setTaskReferenceName("t1");
+
+        workflowDef.getTasks().add(eventWorkflowTask);
+        workflowDef.getTasks().add(workflowTask);
+        metadataService.registerWorkflowDef(workflowDef);
+
+        String workflowId = workflowExecutor.startWorkflow(workflowDef.getName(), workflowDef.getVersion(), "", new HashMap<>());
         Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-        Workflow workflow = workflowExecutor.getWorkflow(id, true);
+        Workflow workflow = workflowExecutor.getWorkflow(workflowId, true);
         assertNotNull(workflow);
-        assertEquals(1, workflow.getTasks().size());
 
         Task eventTask = workflow.getTasks().get(0);
-        assertEquals(WorkflowTask.Type.EVENT.name(), eventTask.getTaskType());
+        assertEquals(Type.EVENT.name(), eventTask.getTaskType());
         assertEquals(COMPLETED, eventTask.getStatus());
-        assertEquals("tasks:" + workflow.getTasks(), WorkflowStatus.COMPLETED, workflow.getStatus());
         assertTrue(!eventTask.getOutputData().isEmpty());
         assertNotNull(eventTask.getOutputData().get("event_produced"));
+
+        Task task = workflowExecutionService.poll("junit_task_1", "test");
+        assertNotNull(task);
+        task.setStatus(Status.COMPLETED);
+        workflowExecutionService.updateTask(task);
+
+        workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals("tasks:" + workflow.getTasks(), WorkflowStatus.COMPLETED, workflow.getStatus());
     }
 
 


### PR DESCRIPTION
Since tasks in progress for the workflow instance is checked every time a task is scheduled, system tasks do not need explicit handling of the `executed` flag, they will follow the same path as user defined tasks.