### PR TITLE
updated mysql test cases with two threads

### DIFF
--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAOTest.java
@@ -142,8 +142,8 @@ public class MySQLExecutionDAOTest extends MySQLBaseDAOTest {
 	}
 	
 	@Test
-    public void testWith5THreads() throws InterruptedException, ExecutionException {
-        testPollDataWithParallelThreads(5);
+    public void testWith2THreads() throws InterruptedException, ExecutionException {
+        testPollDataWithParallelThreads(2);
     }
     
     

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLPushPopQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLPushPopQueueDAOTest.java
@@ -29,8 +29,8 @@ public class MySQLPushPopQueueDAOTest extends MySQLBaseDAOTest {
     }
 
     @Test
-    public void testWith5THreads() throws Exception {
-        testPollDataWithParallelThreads(5);
+    public void testWith2THreads() throws Exception {
+        testPollDataWithParallelThreads(2);
     }
 
     private void testPollDataWithParallelThreads(final int threadCount)


### PR DESCRIPTION
@cyzhao . I see dev builds are failing because I am running some of MYSQL test cases with 5 concurrent threads. It may be related with embedded database used in the MYSQL Testcases

https://github.com/Netflix/conductor/blob/1c31b5b94ea04a07c53687709679d2f96e97c8ed/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLBaseDAOTest.java#L31

The embedded database may be failing when running with concurrent threads. I have changed two just 2 concurrent threads instead of 5.

Please review and approve the PR at your convenience.
