### PR TITLE
Adding Kafka support for eventing and event handling

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 
 	compile "io.nats:java-nats-streaming:${revNatsStreaming}"
 
+	compile "org.apache.kafka:kafka-clients:${revKafkaClient}"
+
 	provided "javax.ws.rs:jsr311-api:${revJsr311Api}"
 	provided "io.swagger:swagger-jaxrs:${revSwagger}"
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
@@ -43,7 +43,7 @@ public class KafkaModule extends AbstractModule {
   @StringMapKey("kafka")
   @Singleton
   @Named("EventQueueProviders")
-  public EventQueueProvider getNATSEventQueueProvider(Configuration configuration) {
+  public EventQueueProvider getKafkaEventQueueProvider(Configuration configuration) {
     return new KafkaEventQueueProvider(configuration);
   }
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
@@ -1,23 +1,20 @@
 /**
  * Copyright 2016 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.netflix.conductor.contribs;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.ProvidesIntoMap;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/KafkaModule.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.contribs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.ProvidesIntoMap;
+import com.google.inject.multibindings.StringMapKey;
+import com.google.inject.name.Named;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.kafka.KafkaEventQueueProvider;
+
+/**
+ * @author preeth
+ *
+ */
+public class KafkaModule extends AbstractModule {
+  private static Logger logger = LoggerFactory.getLogger(KafkaModule.class);
+
+  @Override
+  protected void configure() {
+    logger.info("Kafka module configured.");
+  }
+
+  @ProvidesIntoMap
+  @StringMapKey("kafka")
+  @Singleton
+  @Named("EventQueueProviders")
+  public EventQueueProvider getNATSEventQueueProvider(Configuration configuration) {
+    return new KafkaEventQueueProvider(configuration);
+  }
+
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -154,7 +153,8 @@ public class KafkaObservableQueue implements ObservableQueue {
     return queueName;
   }
 
-  private List<Message> receiveMessages() {
+  @VisibleForTesting() 
+  List<Message> receiveMessages() {
     List<Message> messages = new ArrayList<>();
     try {
 
@@ -178,7 +178,8 @@ public class KafkaObservableQueue implements ObservableQueue {
     return messages;
   }
 
-  private void publishMessages(List<Message> messages) {
+  @VisibleForTesting()
+  void publishMessages(List<Message> messages) {
 
     if (messages == null || messages.isEmpty()) {
       return;
@@ -205,7 +206,7 @@ public class KafkaObservableQueue implements ObservableQueue {
   }
 
   @VisibleForTesting
-  private OnSubscribe<Message> getOnSubscribe() {
+  OnSubscribe<Message> getOnSubscribe() {
     return subscriber -> {
       Observable<Long> interval = Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
       interval.flatMap((Long x) -> {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.contribs.queue.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.core.execution.ApplicationException;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+
+/**
+ * Reads the properties with prefix 'kafka.producer.', 'kafka.consumer.'
+ * and 'kafka.' from the provided configuration. Initializes a producer 
+ * and consumer based on the given value. Queue name is driven from the 
+ * workflow. 
+ * @author preeth
+ *
+ */
+public class KafkaObservableQueue implements ObservableQueue {
+
+  private static final Logger logger = LoggerFactory.getLogger(KafkaObservableQueue.class);
+
+  private static final String QUEUE_TYPE = "kafka";
+
+  private static final String KAFKA_PRODUCER_PREFIX = "kafka.producer.";
+
+  private static final String KAFKA_CONSUMER_PREFIX = "kafka.consumer.";
+
+  private static final String KAFKA_PREFIX = "kafka.";
+
+  private String queueName;
+
+  private int pollTimeInMS;
+
+  private int longPollTimeout;
+
+  private int pollCount;
+
+  private KafkaProducer<String, String> producer;
+
+  private KafkaConsumer<String, String> consumer;
+
+  @Inject
+  public KafkaObservableQueue(String queueName, Configuration config) {
+
+    this.queueName = queueName;
+    this.pollTimeInMS = config.getIntProperty("workflow.dyno.queues.pollingInterval", 100);
+    this.pollCount = config.getIntProperty("workflow.dyno.queues.pollCount", 10);
+    this.longPollTimeout = config.getIntProperty("workflow.dyno.queues.longPollTimeout", 1000);
+    // Init Kafka producer and consumer properties
+    Properties producerProps = new Properties();
+    Properties consumerProps = new Properties();
+    consumerProps.put("group.id", queueName + "_group");
+    int randomId = new Random().nextInt(100);
+    consumerProps.put("client.id", queueName + "_consumer_"+randomId);
+    producerProps.put("client.id", queueName + "_producer_"+randomId);
+    Map<String, Object> configMap = config.getAll();
+    for (Entry<String, Object> entry : configMap.entrySet()) {
+      String key = entry.getKey();
+      String value = (String) entry.getValue();
+      if (key.startsWith(KAFKA_PREFIX)) {
+        if (key.startsWith(KAFKA_PRODUCER_PREFIX)) {
+          producerProps.put(key.replaceAll(KAFKA_PRODUCER_PREFIX, ""), value);
+        } else if (key.startsWith(KAFKA_CONSUMER_PREFIX)) {
+          consumerProps.put(key.replaceAll(KAFKA_CONSUMER_PREFIX, ""), value);
+        } else {
+          producerProps.put(key.replaceAll(KAFKA_PREFIX, ""), value);
+          consumerProps.put(key.replaceAll(KAFKA_PREFIX, ""), value);
+        }
+      }
+    }
+
+    // Init Kafka producer and consumer
+    producer = new KafkaProducer<>(producerProps);
+    consumer = new KafkaConsumer<>(consumerProps);
+    consumer.subscribe(Collections.singletonList(queueName));
+    logger.info("KafkaaObservableQueue initialized for {}", queueName);
+  }
+
+  @Override
+  public Observable<Message> observe() {
+    OnSubscribe<Message> subscriber = getOnSubscribe();
+    return Observable.create(subscriber);
+  }
+
+  @Override
+  public List<String> ack(List<Message> messages) {
+    return messages.stream().map(Message::getId).collect(Collectors.toList());
+  }
+
+  public void setUnackTimeout(Message message, long unackTimeout) {
+  }
+
+  @Override
+  public void publish(List<Message> messages) {
+    publishMessages(messages);
+  }
+
+  @Override
+  public long size() {
+    return 0;
+  }
+
+  @Override
+  public String getType() {
+    return QUEUE_TYPE;
+  }
+
+  @Override
+  public String getName() {
+    return queueName;
+  }
+
+  @Override
+  public String getURI() {
+    return queueName;
+  }
+
+  private List<Message> receiveMessages() {
+    List<Message> messages = new ArrayList<>();
+    try {
+
+      ConsumerRecords<String, String> records = consumer.poll(longPollTimeout);
+      if (records.count() == 0) {
+        return messages;
+      }
+
+      logger.info("polled messages from kafka {}", records.count());
+      records.forEach(record -> {
+        logger.debug("Consumer Record: key {}, value {}, partition {}, offset {}", record.key(),
+            record.value(), record.partition(), record.offset());
+        Message message =
+            new Message(record.key() + record.partition(), String.valueOf(record.value()), "");
+        messages.add(message);
+      });
+      consumer.commitAsync();
+    } catch (KafkaException e) {
+      logger.error("kafka consumer message polling failed.", e);
+    }
+    return messages;
+  }
+
+  private void publishMessages(List<Message> messages) {
+
+    if (messages == null || messages.isEmpty()) {
+      return;
+    }
+    for (Message message : messages) {
+      final ProducerRecord<String, String> record =
+          new ProducerRecord<>(queueName, message.getId(), message.getPayload());
+
+      RecordMetadata metadata;
+      try {
+        metadata = producer.send(record).get();
+        logger.debug("Producer Record: key {}, value {}, partition {}, offset {}", record.key(),
+            record.value(), metadata.partition(), metadata.offset());
+      } catch (InterruptedException | ExecutionException e) {
+        Thread.currentThread().interrupt();
+        logger.error("Publish message to kafka topic {} failed with an error: {}", queueName,
+            e.getMessage(), e);
+        throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR,
+            "Failed to publish the event");
+      }
+    }
+    logger.info("Messages published to kafka topic {}. count {}", queueName, messages.size());
+
+  }
+
+  @VisibleForTesting
+  private OnSubscribe<Message> getOnSubscribe() {
+    return subscriber -> {
+      Observable<Long> interval = Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
+      interval.flatMap((Long x) -> {
+        List<Message> msgs = receiveMessages();
+        return Observable.from(msgs);
+      }).subscribe(subscriber::onNext, subscriber::onError);
+    };
+  }
+  @Override
+  public void close() {
+    if (producer != null) {
+      producer.flush();
+      producer.close(1000, TimeUnit.MILLISECONDS);
+    }
+    
+    if (consumer != null) {
+      consumer.unsubscribe();
+      consumer.close(1000, TimeUnit.MILLISECONDS);
+    }
+    
+  }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/kafka/KafkaObservableQueue.java
@@ -1,55 +1,57 @@
 /**
  * Copyright 2016 Netflix, Inc.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.netflix.conductor.contribs.queue.kafka;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import javax.inject.Inject;
-
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.core.execution.ApplicationException;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 
 /**
- * Reads the properties with prefix 'kafka.producer.', 'kafka.consumer.'
- * and 'kafka.' from the provided configuration. Initializes a producer 
- * and consumer based on the given value. Queue name is driven from the 
- * workflow. 
+ * Reads the properties with prefix 'kafka.producer.', 'kafka.consumer.' and 'kafka.' from the
+ * provided configuration. Initializes a producer and consumer based on the given value. Queue name
+ * is driven from the workflow. It is assumed that the queue name provided is already configured in
+ * the kafka cluster.
+ * 
  * @author preeth
  *
  */
@@ -67,31 +69,41 @@ public class KafkaObservableQueue implements ObservableQueue {
 
   private final String queueName;
 
-  private final int pollTimeInMS;
+  private final int pollIntervalInMS;
 
-  private final int longPollTimeout;
+  private final int pollTimeoutInMs;
 
-  private final int pollCount;
+  private KafkaProducer<String, String> producer;
 
-  private final KafkaProducer<String, String> producer;
-
-  private final KafkaConsumer<String, String> consumer;
+  private KafkaConsumer<String, String> consumer;
 
   @Inject
   public KafkaObservableQueue(String queueName, Configuration config) {
 
     this.queueName = queueName;
-    this.pollTimeInMS = config.getIntProperty("workflow.dyno.queues.pollingInterval", 100);
-    this.pollCount = config.getIntProperty("workflow.dyno.queues.pollCount", 10);
-    this.longPollTimeout = config.getIntProperty("workflow.dyno.queues.longPollTimeout", 1000);
+    this.pollIntervalInMS = config.getIntProperty("kafka.consumer.pollingInterval", 1000);
+    this.pollTimeoutInMs = config.getIntProperty("kafka.consumer.longPollTimeout", 1000);
     // Init Kafka producer and consumer properties
+    init(config);
+  }
+
+  /**
+   * Initializes the kafka producer with the defaults. Fails in case of any mandatory configs are
+   * missing.
+   * 
+   * @param config
+   */
+  private void init(Configuration config) {
     Properties producerProps = new Properties();
     Properties consumerProps = new Properties();
     consumerProps.put("group.id", queueName + "_group");
     String serverId = config.getServerId();
-    consumerProps.put("client.id", queueName + "_consumer_"+serverId);
-    producerProps.put("client.id", queueName + "_producer_"+serverId);
+    consumerProps.put("client.id", queueName + "_consumer_" + serverId);
+    producerProps.put("client.id", queueName + "_producer_" + serverId);
     Map<String, Object> configMap = config.getAll();
+    if (Objects.isNull(configMap)) {
+      throw new RuntimeException("Configuration missing");
+    }
     for (Entry<String, Object> entry : configMap.entrySet()) {
       String key = entry.getKey();
       String value = (String) entry.getValue();
@@ -106,12 +118,87 @@ public class KafkaObservableQueue implements ObservableQueue {
         }
       }
     }
+    checkProducerProps(producerProps);
+    checkConsumerProps(consumerProps);
+    applyConsumerDefaults(consumerProps);
+    try {
+      // Init Kafka producer and consumer
+      producer = new KafkaProducer<>(producerProps);
+      consumer = new KafkaConsumer<>(consumerProps);
+      // Assumption is that the queueName provided is already
+      // configured within the Kafka cluster.
+      consumer.subscribe(Collections.singletonList(queueName));
+      logger.info("KafkaObservableQueue initialized for {}", queueName);
 
-    // Init Kafka producer and consumer
-    producer = new KafkaProducer<>(producerProps);
-    consumer = new KafkaConsumer<>(consumerProps);
-    consumer.subscribe(Collections.singletonList(queueName));
-    logger.info("KafkaObservableQueue initialized for {}", queueName);
+    } catch (KafkaException ke) {
+      logger.error("Kafka initialization failed.", ke);
+      throw new RuntimeException(ke);
+    }
+  }
+
+  /**
+   * Apply consumer defaults, if not configured.
+   * 
+   * @param consumerProps
+   */
+  private void applyConsumerDefaults(Properties consumerProps) {
+    if (null == consumerProps.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)) {
+      consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+    }
+    if (null == consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
+      consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    }
+  }
+
+  /**
+   * Checks mandatory configs are available for kafka consumer.
+   * 
+   * @param consumerProps
+   */
+  private void checkConsumerProps(Properties consumerProps) {
+    List<String> mandatoryKeys = Arrays.asList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+    List<String> keysNotFound = hasKeyAndValue(consumerProps, mandatoryKeys);
+    if (keysNotFound != null && keysNotFound.size() > 0) {
+      logger.error("Configuration missing for Kafka consumer. {}" + keysNotFound.toString());
+      throw new RuntimeException(
+          "Configuration missing for Kafka consumer." + keysNotFound.toString());
+    }
+  }
+
+  /**
+   * Checks mandatory configurations are available for kafka producer.
+   * 
+   * @param producerProps
+   */
+  private void checkProducerProps(Properties producerProps) {
+    List<String> mandatoryKeys = Arrays.asList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG);
+    List<String> keysNotFound = hasKeyAndValue(producerProps, mandatoryKeys);
+    if (keysNotFound != null && keysNotFound.size() > 0) {
+      logger.error("Configuration missing for Kafka producer. {}" + keysNotFound.toString());
+      throw new RuntimeException(
+          "Configuration missing for Kafka producer." + keysNotFound.toString());
+    }
+  }
+
+  /**
+   * Validates whether the property has given keys.
+   * 
+   * @param prop
+   * @param keys
+   * @return
+   */
+  private List<String> hasKeyAndValue(Properties prop, List<String> keys) {
+    List<String> keysNotFound = new ArrayList<>();
+    for (String key : keys) {
+      if (!prop.containsKey(key) || Objects.isNull(prop.get(key))) {
+        keysNotFound.add(key);
+      }
+    }
+    return keysNotFound;
+
   }
 
   @Override
@@ -122,11 +209,23 @@ public class KafkaObservableQueue implements ObservableQueue {
 
   @Override
   public List<String> ack(List<Message> messages) {
-    return messages.stream().map(Message::getId).collect(Collectors.toList());
+    Map<TopicPartition, OffsetAndMetadata> currentOffsets = new HashMap<>();
+    messages.forEach(message -> {
+      String[] idParts = message.getId().split(":");
+
+      currentOffsets.put(new TopicPartition(idParts[1], Integer.valueOf(idParts[2])),
+          new OffsetAndMetadata(Integer.valueOf(idParts[3]) + 1, "no metadata"));
+    });
+    try {
+      consumer.commitSync(currentOffsets);
+    } catch (KafkaException ke) {
+      logger.error("kafka consumer selective commit failed.", ke);
+      return messages.stream().map(message -> message.getId()).collect(Collectors.toList());
+    }
+    return Collections.emptyList();
   }
 
-  public void setUnackTimeout(Message message, long unackTimeout) {
-  }
+  public void setUnackTimeout(Message message, long unackTimeout) {}
 
   @Override
   public void publish(List<Message> messages) {
@@ -153,31 +252,43 @@ public class KafkaObservableQueue implements ObservableQueue {
     return queueName;
   }
 
-  @VisibleForTesting() 
+  /**
+   * Polls the topics and retrieve the messages.
+   * 
+   * @return List of messages
+   */
+  @VisibleForTesting()
   List<Message> receiveMessages() {
     List<Message> messages = new ArrayList<>();
     try {
 
-      ConsumerRecords<String, String> records = consumer.poll(longPollTimeout);
+      ConsumerRecords<String, String> records = consumer.poll(pollTimeoutInMs);
+
       if (records.count() == 0) {
         return messages;
       }
 
       logger.info("polled {} messages from kafka topic.", records.count());
       records.forEach(record -> {
-        logger.debug("Consumer Record: key: {}, value: {}, partition: {}, offset: {}", record.key(),
-            record.value(), record.partition(), record.offset());
-        Message message =
-            new Message(record.key() +":"+ record.partition(), String.valueOf(record.value()), "");
+        logger.debug(
+            "Consumer Record: " + "key: {}, " + "value: {}, " + "partition: {}, " + "offset: {}",
+            record.key(), record.value(), record.partition(), record.offset());
+        String id =
+            record.key() + ":" + record.topic() + ":" + record.partition() + ":" + record.offset();
+        Message message = new Message(id, String.valueOf(record.value()), "");
         messages.add(message);
       });
-      consumer.commitAsync();
     } catch (KafkaException e) {
       logger.error("kafka consumer message polling failed.", e);
     }
     return messages;
   }
 
+  /**
+   * Publish the messages to the given topic.
+   * 
+   * @param messages
+   */
   @VisibleForTesting()
   void publishMessages(List<Message> messages) {
 
@@ -193,8 +304,11 @@ public class KafkaObservableQueue implements ObservableQueue {
         metadata = producer.send(record).get();
         logger.debug("Producer Record: key {}, value {}, partition {}, offset {}", record.key(),
             record.value(), metadata.partition(), metadata.offset());
-      } catch (InterruptedException | ExecutionException e) {
+      } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        logger.error("Publish message to kafka topic {} failed with an error: {}", queueName,
+            e.getMessage(), e);
+      } catch (ExecutionException e) {
         logger.error("Publish message to kafka topic {} failed with an error: {}", queueName,
             e.getMessage(), e);
         throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR,
@@ -208,24 +322,25 @@ public class KafkaObservableQueue implements ObservableQueue {
   @VisibleForTesting
   OnSubscribe<Message> getOnSubscribe() {
     return subscriber -> {
-      Observable<Long> interval = Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
+      Observable<Long> interval = Observable.interval(pollIntervalInMS, TimeUnit.MILLISECONDS);
       interval.flatMap((Long x) -> {
         List<Message> msgs = receiveMessages();
         return Observable.from(msgs);
       }).subscribe(subscriber::onNext, subscriber::onError);
     };
   }
+
   @Override
   public void close() {
     if (producer != null) {
       producer.flush();
       producer.close(1000, TimeUnit.MILLISECONDS);
     }
-    
+
     if (consumer != null) {
       consumer.unsubscribe();
       consumer.close(1000, TimeUnit.MILLISECONDS);
     }
-    
+
   }
 }

--- a/contribs/src/main/java/com/netflix/conductor/core/events/kafka/KafkaEventQueueProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/core/events/kafka/KafkaEventQueueProvider.java
@@ -1,29 +1,24 @@
 /**
  * Copyright 2017 Netflix, Inc.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.netflix.conductor.core.events.kafka;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.netflix.conductor.contribs.queue.kafka.KafkaObservableQueue;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.EventQueueProvider;

--- a/contribs/src/main/java/com/netflix/conductor/core/events/kafka/KafkaEventQueueProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/core/events/kafka/KafkaEventQueueProvider.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.events.kafka;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.contribs.queue.kafka.KafkaObservableQueue;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+
+/**
+ * @author preeth
+ */
+@Singleton
+public class KafkaEventQueueProvider implements EventQueueProvider {
+  private static Logger logger = LoggerFactory.getLogger(KafkaEventQueueProvider.class);
+  protected Map<String, KafkaObservableQueue> queues = new ConcurrentHashMap<>();
+  private Configuration config;
+
+  @Inject
+  public KafkaEventQueueProvider(Configuration config) {
+    this.config = config;
+    logger.info("Kafka Event Queue Provider initialized.");
+  }
+
+  @Override
+  public ObservableQueue getQueue(String queueURI) {
+    return queues.computeIfAbsent(queueURI, q -> new KafkaObservableQueue(queueURI, config));
+  }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/kafka/TestKafkaObservableQueue.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/kafka/TestKafkaObservableQueue.java
@@ -1,0 +1,82 @@
+package com.netflix.conductor.contribs.queue.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.core.execution.ApplicationException;
+
+import rx.Observable;
+
+public class TestKafkaObservableQueue {
+	@Test
+	public void testSubscribe() {
+
+		List<Message> messages = new LinkedList<>();
+		Observable.range(0, 10)
+				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+		assertEquals(10, messages.size());
+
+		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);
+
+		Answer<?> answer = (Answer<List<Message>>) invocation -> Collections.emptyList();
+		when(queue.receiveMessages()).thenReturn(messages).thenAnswer(answer);
+		when(queue.getOnSubscribe()).thenCallRealMethod();
+		when(queue.observe()).thenCallRealMethod();
+		List<Message> found = new LinkedList<>();
+		Observable<Message> observable = queue.observe();
+		assertNotNull(observable);
+		observable.subscribe(found::add);
+
+		Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+
+		assertEquals(messages.size(), found.size());
+		assertEquals(messages, found);
+
+	}
+	
+	@Test(expected = Test.None.class /* no exception expected */)
+	public void testPublish() {
+		
+		List<Message> messages = new LinkedList<>();
+		Observable.range(0, 10)
+				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+		assertEquals(10, messages.size());
+
+		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);		
+		Answer<?> answer = (invocation) -> {return null;};
+		doAnswer(answer).when(queue).publishMessages(messages);
+		doCallRealMethod().when(queue).publish(messages);
+		queue.publish(messages);
+		
+	}
+	
+	@Test(expected = ApplicationException.class)
+	public void testPublishWithException() {
+		
+		List<Message> messages = new LinkedList<>();
+		Observable.range(0, 10)
+				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+		assertEquals(10, messages.size());
+		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);		
+		doThrow(ApplicationException.class).when(queue).publishMessages(messages);
+		doCallRealMethod().when(queue).publish(messages);
+		queue.publish(messages);
+		
+	}
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/kafka/TestKafkaObservableQueue.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/kafka/TestKafkaObservableQueue.java
@@ -9,15 +9,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.execution.ApplicationException;
 
@@ -29,7 +31,8 @@ public class TestKafkaObservableQueue {
 
 		List<Message> messages = new LinkedList<>();
 		Observable.range(0, 10)
-				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+				.forEach((Integer x) -> messages.add(
+						new Message("testTopic:01:" + x, "payload: " + x, null)));
 		assertEquals(10, messages.size());
 
 		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);
@@ -49,34 +52,75 @@ public class TestKafkaObservableQueue {
 		assertEquals(messages, found);
 
 	}
-	
+
 	@Test(expected = Test.None.class /* no exception expected */)
 	public void testPublish() {
-		
+
 		List<Message> messages = new LinkedList<>();
 		Observable.range(0, 10)
-				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+				.forEach((Integer x) -> messages.add(
+						new Message("testTopic:01:" + x, "payload: " + x, null)));
 		assertEquals(10, messages.size());
 
-		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);		
-		Answer<?> answer = (invocation) -> {return null;};
+		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);
+		Answer<?> answer = (invocation) -> {
+			return null;
+		};
 		doAnswer(answer).when(queue).publishMessages(messages);
 		doCallRealMethod().when(queue).publish(messages);
 		queue.publish(messages);
-		
+
 	}
-	
+
 	@Test(expected = ApplicationException.class)
 	public void testPublishWithException() {
-		
+
 		List<Message> messages = new LinkedList<>();
 		Observable.range(0, 10)
-				.forEach((Integer x) -> messages.add(new Message("testTopic:01:" + x, "payload: " + x, null)));
+				.forEach((Integer x) -> messages.add(
+						new Message("testTopic:01:" + x, "payload: " + x, null)));
 		assertEquals(10, messages.size());
-		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);		
+		KafkaObservableQueue queue = mock(KafkaObservableQueue.class);
 		doThrow(ApplicationException.class).when(queue).publishMessages(messages);
 		doCallRealMethod().when(queue).publish(messages);
 		queue.publish(messages);
-		
+
 	}
+
+	@Test(expected = RuntimeException.class)
+	public void testInitializationWithoutConfig() {
+		Configuration config = mock(Configuration.class);
+		KafkaObservableQueue queue = new KafkaObservableQueue(
+				"kafka:testTopi02", config);
+
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testInitializationWithoutConsumerConfig() {
+		Configuration config = mock(Configuration.class);
+		Map<String, Object> configMap = new HashMap<>();
+		configMap.put("kafka.bootstrap.servers", "locahost:9999");
+		configMap.put("kafka.producer.key.serializer",
+				"org.apache.kafka.common.serialization.StringSerializer.class");
+		configMap.put("kafka.producer.value.serializer",
+				"org.apache.kafka.common.serialization.StringSerializer.class");
+		when(config.getAll()).thenReturn(configMap);
+		KafkaObservableQueue queue = new KafkaObservableQueue("kafka:testTopi02", config);
+
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testInitializationWithoutProducerConfig() {
+		Configuration config = mock(Configuration.class);
+		Map<String, Object> configMap = new HashMap<>();
+		configMap.put("kafka.bootstrap.servers", "locahost:9999");
+		configMap.put("kafka.consumer.key.deserializer",
+				"org.apache.kafka.common.serialization.StringDeSerializer.class");
+		configMap.put("kafka.consumer.value.deserializer",
+				"org.apache.kafka.common.serialization.StringDeSerializer.class");
+		when(config.getAll()).thenReturn(configMap);
+		KafkaObservableQueue queue = new KafkaObservableQueue("kafka:testTopi02", config);
+
+	}
+
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -714,6 +714,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
                     q -> q.addParameter(eventExecution.getName()).addParameter(eventExecution.getEvent())
                             .addParameter(eventExecution.getMessageId()).addParameter(eventExecution.getId())
                             .addJsonParameter(eventExecution).executeUpdate());
+            return true;
         }
         return false;
     }

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -41,3 +41,17 @@ workflow.elasticsearch.version=2
 
 # For a single node dynomite or redis server, make sure the value below is set to same as rack specified in the "workflow.dynomite.cluster.hosts" property.
 EC2_AVAILABILITY_ZONE=us-east-1c
+
+#uncomment to enable kafka based event features.
+#conductor.additional.modules=com.netflix.conductor.contribs.KafkaModule
+
+#all kafka properties are suffixed "kafka."
+#kafka.bootstrap.servers=localhost:9092
+
+#all kafka producer properties are suffixed "kafka.producer."
+#kafka.producer.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+#kafka.producer.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+#all kafka consumer properties are suffixed "kafka.consumer."
+#kafka.consumer.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+#kafka.consumer.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -50,4 +50,5 @@ ext {
     revSlf4j = '1.7.25'
     revSlf4jlog4j = '1.8.0-alpha1'
     revSpectator = '0.68.0'
+    revKafkaClient = '1.1.0'
 }


### PR DESCRIPTION
Two changes:
1. Minor correction in the event handling logic when using MySQL persistence.
2. Adding Kafka support in the contribs module.

kafka configuration for provider and consumer can be added with the below prefixes for general, producer and consumer configuration respectively.
'kafka.' , 'kafka.provider.' and 'kafka.consumer.'

request for review

related enhancement discussed in #414 