### PR TITLE
Elasticsearch property decoupling from db

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -166,5 +166,4 @@ public interface Configuration {
     enum DB {
         REDIS, DYNOMITE, MEMORY, REDIS_CLUSTER, MYSQL
     }
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -27,9 +27,6 @@ public interface Configuration {
     String DB_PROPERTY_NAME = "db";
     String DB_DEFAULT_VALUE = "memory";
 
-    String ELASTICSEARCH_PROPERTY_NAME = "elasticsearch";
-    String ELASTICSEARCH_DEFAULT_VALUE = "memory";
-
     String SWEEP_FREQUENCY_PROPERTY_NAME = "decider.sweep.frequency.seconds";
     int SWEEP_FREQUENCY_DEFAULT_VALUE = 30;
 
@@ -67,14 +64,6 @@ public interface Configuration {
 
     default String getDBString() {
         return getProperty(DB_PROPERTY_NAME, DB_DEFAULT_VALUE).toUpperCase();
-    }
-
-    default ELASTICSEARCH getElasticSearchType() {
-        return ELASTICSEARCH.valueOf(getElasticSearchString());
-    }
-
-    default String getElasticSearchString() {
-        return getProperty(ELASTICSEARCH_PROPERTY_NAME, ELASTICSEARCH_DEFAULT_VALUE).toUpperCase();
     }
 
     /**
@@ -178,7 +167,4 @@ public interface Configuration {
         REDIS, DYNOMITE, MEMORY, REDIS_CLUSTER, MYSQL
     }
 
-    enum ELASTICSEARCH {
-        MEMORY, EXTERNAL
-    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -27,6 +27,9 @@ public interface Configuration {
     String DB_PROPERTY_NAME = "db";
     String DB_DEFAULT_VALUE = "memory";
 
+    String ELASTICSEARCH_PROPERTY_NAME = "elasticsearch";
+    String ELASTICSEARCH_DEFAULT_VALUE = "memory";
+
     String SWEEP_FREQUENCY_PROPERTY_NAME = "decider.sweep.frequency.seconds";
     int SWEEP_FREQUENCY_DEFAULT_VALUE = 30;
 
@@ -64,6 +67,14 @@ public interface Configuration {
 
     default String getDBString() {
         return getProperty(DB_PROPERTY_NAME, DB_DEFAULT_VALUE).toUpperCase();
+    }
+
+    default ELASTICSEARCH getElasticSearchType() {
+        return ELASTICSEARCH.valueOf(getElasticSearchString());
+    }
+
+    default String getElasticSearchString() {
+        return getProperty(ELASTICSEARCH_PROPERTY_NAME, ELASTICSEARCH_DEFAULT_VALUE).toUpperCase();
     }
 
     /**
@@ -165,5 +176,9 @@ public interface Configuration {
 
     enum DB {
         REDIS, DYNOMITE, MEMORY, REDIS_CLUSTER, MYSQL
+    }
+
+    enum ELASTICSEARCH {
+        MEMORY, EXTERNAL
     }
 }

--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -11,14 +11,6 @@ conductor.grpc.server.enabled=false
 
 db=memory
 
-# Elastic search instance. Possible values are memory and external.
-# If not specified, the instance will be embedded in memory
-#
-# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
-# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
-#           the server dies. Useful for more stable environments like staging or production.
-elasticsearch=external
-
 # Dynomite Cluster details.
 # format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=dyno1:8102:us-east-1c
@@ -37,6 +29,13 @@ queues.dynomite.threads=10
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
 queues.dynomite.nonQuorum.port=22122
 
+# Elastic search instance type. Possible values are memory and external.
+# If not specified, the instance type will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+workflow.elasticsearch.instanceType=external
 
 # Transport address to elasticsearch
 workflow.elasticsearch.url=localhost:9300

--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -11,6 +11,14 @@ conductor.grpc.server.enabled=false
 
 db=memory
 
+# Elastic search instance. Possible values are memory and external.
+# If not specified, the instance will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+elasticsearch=external
+
 # Dynomite Cluster details.
 # format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=dyno1:8102:us-east-1c

--- a/docker/server/config/config-mysql-grpc.properties
+++ b/docker/server/config/config-mysql-grpc.properties
@@ -11,6 +11,14 @@ conductor.grpc.server.enabled=true
 
 db=mysql
 
+# Elastic search instance. Possible values are memory and external.
+# If not specified, the instance will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+elasticsearch=external
+
 jdbc.url=jdbc:mysql://mysql:3306/conductor
 # Transport address to elasticsearch
 workflow.elasticsearch.url=elasticsearch:9300

--- a/docker/server/config/config-mysql-grpc.properties
+++ b/docker/server/config/config-mysql-grpc.properties
@@ -11,15 +11,16 @@ conductor.grpc.server.enabled=true
 
 db=mysql
 
-# Elastic search instance. Possible values are memory and external.
-# If not specified, the instance will be embedded in memory
+jdbc.url=jdbc:mysql://mysql:3306/conductor
+
+# Elastic search instance type. Possible values are memory and external.
+# If not specified, the instance type will be embedded in memory
 #
 # memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
 # external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
 #           the server dies. Useful for more stable environments like staging or production.
-elasticsearch=external
+workflow.elasticsearch.instanceType=external
 
-jdbc.url=jdbc:mysql://mysql:3306/conductor
 # Transport address to elasticsearch
 workflow.elasticsearch.url=elasticsearch:9300
 

--- a/docker/server/config/config-mysql.properties
+++ b/docker/server/config/config-mysql.properties
@@ -11,15 +11,16 @@ conductor.grpc.server.enabled=false
 
 db=mysql
 
-# Elastic search instance. Possible values are memory and external.
-# If not specified, the instance will be embedded in memory
+jdbc.url=jdbc:mysql://mysql:3306/conductor
+
+# Elastic search instance type. Possible values are memory and external.
+# If not specified, the instance type will be embedded in memory
 #
 # memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
 # external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
 #           the server dies. Useful for more stable environments like staging or production.
-elasticsearch=external
+workflow.elasticsearch.instanceType=external
 
-jdbc.url=jdbc:mysql://mysql:3306/conductor
 # Transport address to elasticsearch
 workflow.elasticsearch.url=elasticsearch:9300
 

--- a/docker/server/config/config-mysql.properties
+++ b/docker/server/config/config-mysql.properties
@@ -11,6 +11,14 @@ conductor.grpc.server.enabled=false
 
 db=mysql
 
+# Elastic search instance. Possible values are memory and external.
+# If not specified, the instance will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+elasticsearch=external
+
 jdbc.url=jdbc:mysql://mysql:3306/conductor
 # Transport address to elasticsearch
 workflow.elasticsearch.url=elasticsearch:9300

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -11,6 +11,14 @@ conductor.grpc.server.enabled=false
 
 db=dynomite
 
+# Elastic search instance. Possible values are memory and external.
+# If not specified, the instance will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+elasticsearch=external
+
 # Dynomite Cluster details.
 # format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=dyno1:8102:us-east-1c

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -11,14 +11,6 @@ conductor.grpc.server.enabled=false
 
 db=dynomite
 
-# Elastic search instance. Possible values are memory and external.
-# If not specified, the instance will be embedded in memory
-#
-# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
-# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
-#           the server dies. Useful for more stable environments like staging or production.
-elasticsearch=external
-
 # Dynomite Cluster details.
 # format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=dyno1:8102:us-east-1c
@@ -40,6 +32,13 @@ queues.dynomite.threads=10
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
 queues.dynomite.nonQuorum.port=22122
 
+# Elastic search instance type. Possible values are memory and external.
+# If not specified, the instance type will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+workflow.elasticsearch.instanceType=external
 
 # Transport address to elasticsearch
 workflow.elasticsearch.url=es:9300

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -9,6 +9,9 @@ import java.util.stream.Collectors;
 
 public interface ElasticSearchConfiguration extends Configuration {
 
+    String ELASTICSEARCH_PROPERTY_NAME = "workflow.elasticsearch.instanceType";
+    ElasticSearchInstanceType ELASTICSEARCH_INSTANCE_TYPE_DEFAULT_VALUE = ElasticSearchInstanceType.MEMORY;
+
     String ELASTIC_SEARCH_URL_PROPERTY_NAME = "workflow.elasticsearch.url";
     String ELASTIC_SEARCH_URL_DEFAULT_VALUE = "localhost:9300";
 
@@ -75,4 +78,15 @@ public interface ElasticSearchConfiguration extends Configuration {
     default String getEmbeddedSettingsFile() {
         return getProperty(EMBEDDED_SETTINGS_FILE_PROPERTY_NAME, EMBEDDED_SETTINGS_FILE_DEFAULT_VALUE);
     }
+
+    default ElasticSearchInstanceType getElasticSearchInstanceType() {
+        return ElasticSearchInstanceType.valueOf(
+                getProperty(ELASTICSEARCH_PROPERTY_NAME, ELASTICSEARCH_INSTANCE_TYPE_DEFAULT_VALUE.name()).toUpperCase()
+        );
+    }
+
+    enum ElasticSearchInstanceType {
+        MEMORY, EXTERNAL
+    }
+
 }

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -1,5 +1,6 @@
 package com.netflix.conductor.elasticsearch;
 
+import com.google.common.base.Strings;
 import com.netflix.conductor.core.config.Configuration;
 
 import java.net.URI;
@@ -80,9 +81,12 @@ public interface ElasticSearchConfiguration extends Configuration {
     }
 
     default ElasticSearchInstanceType getElasticSearchInstanceType() {
-        return ElasticSearchInstanceType.valueOf(
-                getProperty(ELASTICSEARCH_PROPERTY_NAME, ELASTICSEARCH_INSTANCE_TYPE_DEFAULT_VALUE.name()).toUpperCase()
-        );
+        ElasticSearchInstanceType elasticSearchInstanceType = ELASTICSEARCH_INSTANCE_TYPE_DEFAULT_VALUE;
+        String instanceTypeConfig = getProperty(ELASTICSEARCH_PROPERTY_NAME, "");
+        if (!Strings.isNullOrEmpty(instanceTypeConfig)) {
+            elasticSearchInstanceType = ElasticSearchInstanceType.valueOf(instanceTypeConfig.toUpperCase());
+        }
+        return elasticSearchInstanceType;
     }
 
     enum ElasticSearchInstanceType {

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/es5/EmbeddedElasticSearchV5Provider.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/es5/EmbeddedElasticSearchV5Provider.java
@@ -29,6 +29,6 @@ public class EmbeddedElasticSearchV5Provider implements EmbeddedElasticSearchPro
     }
 
     private boolean isEmbedded() {
-        return configuration.getDB().equals(Configuration.DB.MEMORY);
+        return configuration.getElasticSearchType().equals(Configuration.ELASTICSEARCH.MEMORY);
     }
 }

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/es5/EmbeddedElasticSearchV5Provider.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/es5/EmbeddedElasticSearchV5Provider.java
@@ -1,13 +1,11 @@
 package com.netflix.conductor.elasticsearch.es5;
 
-import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.elasticsearch.ElasticSearchConfiguration;
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearch;
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearchProvider;
 
-import java.util.Optional;
-
 import javax.inject.Inject;
+import java.util.Optional;
 
 public class EmbeddedElasticSearchV5Provider implements EmbeddedElasticSearchProvider {
     private final ElasticSearchConfiguration configuration;
@@ -29,6 +27,6 @@ public class EmbeddedElasticSearchV5Provider implements EmbeddedElasticSearchPro
     }
 
     private boolean isEmbedded() {
-        return configuration.getElasticSearchType().equals(Configuration.ELASTICSEARCH.MEMORY);
+        return configuration.getElasticSearchInstanceType().equals(ElasticSearchConfiguration.ElasticSearchInstanceType.MEMORY);
     }
 }


### PR DESCRIPTION
Currently, the property `db` determines how we run the storage (redis, mysql...) and the indexing(elastic search). The main disadvantage of this approach is the lack of flexibility: we cannot run an `in-memory db` and `external elastic search` or viceversa.

This PR adds a property `workflow.elasticsearch.instanceType` so we are able to run an external or in-memory instance regardless of the option chosen for db.
In addition to that, this may benefit also how tests are run on the CI tool as we could have a in memory db with an external hosted elastic search instance.
