### PR TITLE
Updated ElasticSearchConfiguration to contain TaskLog Index Name property

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -28,12 +28,12 @@ import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.RetryUtil;
-import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.core.execution.ApplicationException.Code;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.es5.index.query.parser.Expression;
+import com.netflix.conductor.elasticsearch.ElasticSearchConfiguration;
 import com.netflix.conductor.elasticsearch.query.parser.ParserException;
 import com.netflix.conductor.metrics.Monitors;
 import org.apache.commons.io.IOUtils;
@@ -135,21 +135,11 @@ public class ElasticSearchDAOV5 implements IndexDAO {
     }
 
     @Inject
-    public ElasticSearchDAOV5(Client elasticSearchClient, Configuration config, ObjectMapper objectMapper) {
+    public ElasticSearchDAOV5(Client elasticSearchClient, ElasticSearchConfiguration config, ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         this.elasticSearchClient = elasticSearchClient;
-        this.indexName = config.getProperty("workflow.elasticsearch.index.name", null);
-        this.logIndexPrefix = config.getProperty("workflow.elasticsearch.tasklog.index.name", "task_log");
-
-        try {
-
-            initIndex();
-            updateIndexName();
-            Executors.newScheduledThreadPool(1).scheduleAtFixedRate(() -> updateIndexName(), 0, 1, TimeUnit.HOURS);
-
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+        this.indexName = config.getIndexName();
+        this.logIndexPrefix = config.getTasklogIndexName();
 
         int corePoolSize = 6;
         int maximumPoolSize = 12;

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -19,6 +19,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_INDEX_NAME_PROPERTY_NAME = "workflow.elasticsearch.index.name";
     String ELASTIC_SEARCH_INDEX_NAME_DEFAULT_VALUE = "conductor";
 
+    String TASK_LOG_INDEX_NAME_PROPERTY_NAME = "workflow.elasticsearch.tasklog.index.name";
+    String TASK_LOG_INDEX__NAME_DEFAULT_VALUE = "task_log";
+
     String EMBEDDED_DATA_PATH_PROPERTY_NAME = "workflow.elasticsearch.embedded.data.path";
     String EMBEDDED_DATA_PATH_DEFAULT_VALUE = "path.data";
 
@@ -54,6 +57,10 @@ public interface ElasticSearchConfiguration extends Configuration {
 
     default String getIndexName() {
         return getProperty(ELASTIC_SEARCH_INDEX_NAME_PROPERTY_NAME, ELASTIC_SEARCH_INDEX_NAME_DEFAULT_VALUE);
+    }
+
+    default String getTasklogIndexName() {
+        return getProperty(TASK_LOG_INDEX_NAME_PROPERTY_NAME, TASK_LOG_INDEX__NAME_DEFAULT_VALUE);
     }
 
     default String getEmbeddedDataPath() {


### PR DESCRIPTION
- Updated ES Dao v5 as well, so creation of metadata only happens during the setup and not during the constructor