### PR TITLE
store large payloads in external storage - part 1

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
+++ b/client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.client.config;
+
+public interface ConductorClientConfiguration {
+
+    /**
+     * @return the workflow input payload threshold in KB,
+     * beyond which the payload will be processed based on {@link ConductorClientConfiguration#isExternalPayloadStorageEnabled()}.
+     */
+    int getWorkflowInputPayloadThresholdKB();
+
+    /**
+     * @return the task output payload threshold in KB,
+     * beyond which the payload will be processed based on {@link ConductorClientConfiguration#isExternalPayloadStorageEnabled()}.
+     */
+    int getTaskOutputPayloadThresholdKB();
+
+    /**
+     * @return the flag which controls the use of external storage for storing workflow/task
+     * input and output JSON payloads with size greater than threshold.
+     * If it is set to true, the payload is stored in external location.
+     * If it is set to false, the payload is rejected and the task/workflow execution fails.
+     */
+    boolean isExternalPayloadStorageEnabled();
+}

--- a/client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
+++ b/client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
@@ -19,16 +19,28 @@ package com.netflix.conductor.client.config;
 public interface ConductorClientConfiguration {
 
     /**
-     * @return the workflow input payload threshold in KB,
+     * @return the workflow input payload size threshold in KB,
      * beyond which the payload will be processed based on {@link ConductorClientConfiguration#isExternalPayloadStorageEnabled()}.
      */
     int getWorkflowInputPayloadThresholdKB();
 
     /**
-     * @return the task output payload threshold in KB,
+     * @return the max value of workflow input payload size threshold in KB,
+     * beyond which the payload will be rejected regardless external payload storage is enabled.
+     */
+    int getWorkflowInputMaxPayloadThresholdKB();
+
+    /**
+     * @return the task output payload size threshold in KB,
      * beyond which the payload will be processed based on {@link ConductorClientConfiguration#isExternalPayloadStorageEnabled()}.
      */
     int getTaskOutputPayloadThresholdKB();
+
+    /**
+     * @return the max value of task output payload size threshold in KB,
+     * beyond which the payload will be rejected regardless external payload storage is enabled.
+     */
+    int getTaskOutputMaxPayloadThresholdKB();
 
     /**
      * @return the flag which controls the use of external storage for storing workflow/task

--- a/client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
+++ b/client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
@@ -28,8 +28,18 @@ public class DefaultConductorClientConfiguration implements ConductorClientConfi
     }
 
     @Override
+    public int getWorkflowInputMaxPayloadThresholdKB() {
+        return 10240;
+    }
+
+    @Override
     public int getTaskOutputPayloadThresholdKB() {
         return 3072;
+    }
+
+    @Override
+    public int getTaskOutputMaxPayloadThresholdKB() {
+        return 10240;
     }
 
     @Override

--- a/client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
+++ b/client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.client.config;
+
+/**
+ * A default implementation of {@link ConductorClientConfiguration}
+ * where external payload storage is disabled.
+ */
+public class DefaultConductorClientConfiguration implements ConductorClientConfiguration {
+
+    @Override
+    public int getWorkflowInputPayloadThresholdKB() {
+        return 5120;
+    }
+
+    @Override
+    public int getTaskOutputPayloadThresholdKB() {
+        return 3072;
+    }
+
+    @Override
+    public boolean isExternalPayloadStorageEnabled() {
+        return false;
+    }
+}

--- a/client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
@@ -18,16 +18,16 @@ package com.netflix.conductor.client.http;
 
 import com.google.common.base.Preconditions;
 import com.netflix.conductor.client.config.ConductorClientConfiguration;
+import com.netflix.conductor.client.config.DefaultConductorClientConfiguration;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.sun.jersey.api.client.ClientHandler;
 import com.sun.jersey.api.client.GenericType;
 import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.client.filter.ClientFilter;
 import org.apache.commons.lang.StringUtils;
 
-import javax.ws.rs.QueryParam;
-import java.util.Arrays;
 import java.util.List;
 
 public class MetadataClient extends ClientBase {
@@ -42,14 +42,14 @@ public class MetadataClient extends ClientBase {
      * Creates a default metadata client
      */
     public MetadataClient() {
-        super();
+        this(new DefaultClientConfig(), new DefaultConductorClientConfiguration(), null);
     }
 
     /**
      * @param clientConfig REST Client configuration
      */
     public MetadataClient(ClientConfig clientConfig) {
-        super(clientConfig);
+        this(clientConfig, new DefaultConductorClientConfiguration(), null);
     }
 
     /**
@@ -57,7 +57,7 @@ public class MetadataClient extends ClientBase {
      * @param clientHandler Jersey client handler. Useful when plugging in various http client interaction modules (e.g. ribbon)
      */
     public MetadataClient(ClientConfig clientConfig, ClientHandler clientHandler) {
-        super(clientConfig, clientHandler);
+        this(clientConfig, new DefaultConductorClientConfiguration(), clientHandler);
     }
 
     /**
@@ -66,18 +66,14 @@ public class MetadataClient extends ClientBase {
      * @param filters Chain of client side filters to be applied per request
      */
     public MetadataClient(ClientConfig config, ClientHandler handler, ClientFilter... filters) {
-        super(config, handler);
-        for (ClientFilter filter : filters) {
-            super.client.addFilter(filter);
-        }
+        this(config, new DefaultConductorClientConfiguration(), handler, filters);
     }
 
     /**
-     *
-     * @param config REST Client configuration
+     * @param config              REST Client configuration
      * @param clientConfiguration Specific properties configured for the client, see {@link ConductorClientConfiguration}
-     * @param handler Jersey client handler. Useful when plugging in various http client interaction modules (e.g. ribbon)
-     * @param filters Chain of client side filters to be applied per request
+     * @param handler             Jersey client handler. Useful when plugging in various http client interaction modules (e.g. ribbon)
+     * @param filters             Chain of client side filters to be applied per request
      */
     public MetadataClient(ClientConfig config, ConductorClientConfiguration clientConfiguration, ClientHandler handler, ClientFilter... filters) {
         super(config, clientConfiguration, handler);
@@ -96,7 +92,7 @@ public class MetadataClient extends ClientBase {
      */
     public void registerWorkflowDef(WorkflowDef workflowDef) {
         Preconditions.checkNotNull(workflowDef, "Worfklow definition cannot be null");
-        postForEntity("metadata/workflow", workflowDef);
+        postForEntityWithRequestOnly("metadata/workflow", workflowDef);
     }
 
     /**
@@ -134,13 +130,13 @@ public class MetadataClient extends ClientBase {
      * Removes the workflow definition of a workflow from the conductor server.
      * It does not remove associated workflows. Use with caution.
      *
-     * @param name Name of the workflow to be unregistered.
+     * @param name    Name of the workflow to be unregistered.
      * @param version Version of the workflow definition to be unregistered.
      */
     public void unregisterWorkflowDef(String name, Integer version) {
         Preconditions.checkArgument(StringUtils.isNotBlank(name), "Workflow name cannot be blank");
         Preconditions.checkNotNull(version, "Version cannot be null");
-        delete("metadata/workflow/{name}/{version}",  name, version);
+        delete("metadata/workflow/{name}/{version}", name, version);
     }
 
     // Task Metadata Operations
@@ -152,7 +148,7 @@ public class MetadataClient extends ClientBase {
      */
     public void registerTaskDefs(List<TaskDef> taskDefs) {
         Preconditions.checkNotNull(taskDefs, "Task defs list cannot be null");
-        postForEntity("metadata/taskdefs", taskDefs);
+        postForEntityWithRequestOnly("metadata/taskdefs", taskDefs);
     }
 
     /**

--- a/client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
@@ -17,6 +17,7 @@
 package com.netflix.conductor.client.http;
 
 import com.google.common.base.Preconditions;
+import com.netflix.conductor.client.config.ConductorClientConfiguration;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.sun.jersey.api.client.ClientHandler;
@@ -66,6 +67,20 @@ public class MetadataClient extends ClientBase {
      */
     public MetadataClient(ClientConfig config, ClientHandler handler, ClientFilter... filters) {
         super(config, handler);
+        for (ClientFilter filter : filters) {
+            super.client.addFilter(filter);
+        }
+    }
+
+    /**
+     *
+     * @param config REST Client configuration
+     * @param clientConfiguration Specific properties configured for the client, see {@link ConductorClientConfiguration}
+     * @param handler Jersey client handler. Useful when plugging in various http client interaction modules (e.g. ribbon)
+     * @param filters Chain of client side filters to be applied per request
+     */
+    public MetadataClient(ClientConfig config, ConductorClientConfiguration clientConfiguration, ClientHandler handler, ClientFilter... filters) {
+        super(config, clientConfiguration, handler);
         for (ClientFilter filter : filters) {
             super.client.addFilter(filter);
         }

--- a/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
@@ -242,6 +242,8 @@ public class TaskClient extends ClientBase {
 
     /**
      * Updates the result of a task execution.
+     * If the size of the task output payload is bigger than {@link ConductorClientConfiguration#getTaskOutputPayloadThresholdKB()},
+     * it is uploaded to {@link ExternalPayloadStorage}, if enabled, else the task is marked as FAILED_WITH_TERMINAL_ERROR.
      *
      * @param taskResult the {@link TaskResult} of the executed task to be updated.
      * @param taskType   the type of the task
@@ -259,7 +261,7 @@ public class TaskClient extends ClientBase {
             long payloadSizeThreshold = conductorClientConfiguration.getTaskOutputPayloadThresholdKB() * 1024;
             if (taskResultSize > payloadSizeThreshold) {
                 if (!conductorClientConfiguration.isExternalPayloadStorageEnabled()
-                        || taskResultSize > (conductorClientConfiguration.getTaskOutputMaxPayloadThresholdKB() * 1024)) {
+                        || taskResultSize > conductorClientConfiguration.getTaskOutputMaxPayloadThresholdKB() * 1024) {
                     taskResult.setReasonForIncompletion(String.format("The TaskResult payload size: %d is greater than the permissible %d MB", taskResultSize, payloadSizeThreshold));
                     taskResult.setStatus(TaskResult.Status.FAILED_WITH_TERMINAL_ERROR);
                     taskResult.setOutputData(null);

--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
@@ -273,15 +273,15 @@ public class WorkflowTaskCoordinator {
 		});
 	}
 
-    	public void shutdown() {
-        	this.scheduledExecutorService.shutdown();
-        	this.executorService.shutdown();
+	public void shutdown() {
+		this.scheduledExecutorService.shutdown();
+		this.executorService.shutdown();
 
-        	shutdownExecutorService(this.scheduledExecutorService, SHUTDOWN_WAIT_TIME_IN_SEC);
-        	shutdownExecutorService(this.executorService, SHUTDOWN_WAIT_TIME_IN_SEC);
-    	}
+		shutdownExecutorService(this.scheduledExecutorService, SHUTDOWN_WAIT_TIME_IN_SEC);
+		shutdownExecutorService(this.executorService, SHUTDOWN_WAIT_TIME_IN_SEC);
+	}
 
-    	private void shutdownExecutorService(ExecutorService executorService, long timeout) {
+	private void shutdownExecutorService(ExecutorService executorService, long timeout) {
 		try {
 			if (executorService.awaitTermination(timeout, TimeUnit.SECONDS)) {
 				logger.debug("tasks completed, shutting down");

--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
@@ -379,6 +379,7 @@ public class WorkflowTaskCoordinator {
 		TaskResult result = null;
 		try {
 			logger.debug("Executing task {} in worker {} at {}", task, worker.getClass().getSimpleName(), worker.getIdentity());
+			// TODO
 			result = worker.execute(task);
 			result.setWorkflowInstanceId(task.getWorkflowInstanceId());
 			result.setTaskId(task.getTaskId());

--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -379,7 +379,6 @@ public class WorkflowTaskCoordinator {
 		TaskResult result = null;
 		try {
 			logger.debug("Executing task {} in worker {} at {}", task, worker.getClass().getSimpleName(), worker.getIdentity());
-			// TODO
 			result = worker.execute(task);
 			result.setWorkflowInstanceId(task.getWorkflowInstanceId());
 			result.setTaskId(task.getTaskId());

--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskMetrics.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskMetrics.java
@@ -42,6 +42,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class WorkflowTaskMetrics {
 
 	private static final String TASK_TYPE = "taskType";
+	private static final String WORFLOW_TYPE = "workflowType";
+	private static final String WORKFLOW_VERSION = "version";
 	private static final String EXCEPTION = "exception";
 
 	private static final String TASK_EXECUTION_QUEUE_FULL = "task_execution_queue_full";
@@ -54,7 +56,9 @@ public class WorkflowTaskMetrics {
 	private static final String TASK_POLL_COUNTER = "task_poll_counter";
 	private static final String TASK_EXECUTE_TIME = "task_execute_time";
 	private static final String TASK_POLL_TIME = "task_poll_time";
-	public static final String TASK_RESULT_SIZE = "task_result_size";
+	private static final String TASK_RESULT_SIZE = "task_result_size";
+	private static final String WORKFLOW_INPUT_SIZE = "workflow_input_size";
+
 
 
 	private static Registry registry = Spectator.globalRegistry();
@@ -158,5 +162,7 @@ public class WorkflowTaskMetrics {
 		getCounter(TASK_POLL_COUNTER, TASK_TYPE, taskType).increment(taskCount);
 	}
 
-
+	public static void recordWorkflowInputPayloadSize(String workflowType, String version, long payloadSize) {
+		getGauge(WORKFLOW_INPUT_SIZE, WORFLOW_TYPE, workflowType, WORKFLOW_VERSION, version).getAndSet(payloadSize);
+	}
 }

--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskMetrics.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskMetrics.java
@@ -45,6 +45,9 @@ public class WorkflowTaskMetrics {
 	private static final String WORFLOW_TYPE = "workflowType";
 	private static final String WORKFLOW_VERSION = "version";
 	private static final String EXCEPTION = "exception";
+	private static final String NAME = "name";
+	private static final String OPERATION = "operation";
+	private static final String PAYLOAD_TYPE = "payload_type";
 
 	private static final String TASK_EXECUTION_QUEUE_FULL = "task_execution_queue_full";
 	private static final String TASK_POLL_ERROR = "task_poll_error";
@@ -58,7 +61,7 @@ public class WorkflowTaskMetrics {
 	private static final String TASK_POLL_TIME = "task_poll_time";
 	private static final String TASK_RESULT_SIZE = "task_result_size";
 	private static final String WORKFLOW_INPUT_SIZE = "workflow_input_size";
-
+	private static final String EXTERNAL_PAYLOAD_USED = "external_payload_used";
 
 
 	private static Registry registry = Spectator.globalRegistry();
@@ -164,5 +167,9 @@ public class WorkflowTaskMetrics {
 
 	public static void recordWorkflowInputPayloadSize(String workflowType, String version, long payloadSize) {
 		getGauge(WORKFLOW_INPUT_SIZE, WORFLOW_TYPE, workflowType, WORKFLOW_VERSION, version).getAndSet(payloadSize);
+	}
+
+	public static void incrementExternalPayloadUsedCount(String name, String operation, String payloadType) {
+		incrementCount(EXTERNAL_PAYLOAD_USED, NAME, name, OPERATION, operation, PAYLOAD_TYPE, payloadType);
 	}
 }

--- a/client/src/main/java/com/netflix/conductor/client/util/PayloadStorage.java
+++ b/client/src/main/java/com/netflix/conductor/client/util/PayloadStorage.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.client.util;
+
+import com.netflix.conductor.client.exceptions.ConductorClientException;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * An implementation of {@link ExternalPayloadStorage} for storing large JSON payload data.
+ */
+public class PayloadStorage implements ExternalPayloadStorage {
+    private static final Logger logger = LoggerFactory.getLogger(PayloadStorage.class);
+
+    /**
+     * This method is not intended to be used in the client.
+     * The client makes a request to the server to get the {@link ExternalStorageLocation}
+     */
+    @Override
+    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Uploads the payload to the uri specified.
+     *
+     * @param path        the location to which the object is to be uploaded
+     * @param payload     an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     * @throws ConductorClientException if the upload fails due to an invalid path or an error from external storage
+     */
+    @Override
+    public void upload(String path, InputStream payload, long payloadSize) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URI(path).toURL();
+
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("PUT");
+
+            try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(connection.getOutputStream())) {
+                int length;
+                while ((length = payload.read()) != -1) {
+                    bufferedOutputStream.write(length);
+                }
+
+                // Check the HTTP response code
+                int responseCode = connection.getResponseCode();
+                logger.debug("Upload completed with HTTP response code: {}", responseCode);
+            }
+        } catch (URISyntaxException | MalformedURLException e) {
+            String errorMsg = String.format("Invalid path specified: %s", path);
+            logger.error(errorMsg, e);
+            throw new ConductorClientException(errorMsg, e);
+        } catch (IOException e) {
+            String errorMsg = String.format("Error uploading to path: %s", path);
+            logger.error(errorMsg, e);
+            throw new ConductorClientException(errorMsg, e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /**
+     * Downloads the payload from the given uri.
+     *
+     * @param path the location from where the object is to be downloaded
+     * @return an inputstream of the payload in the external storage
+     * @throws ConductorClientException if the download fails due to an invalid path or an error from external storage
+     */
+    @Override
+    public InputStream download(String path) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URI(path).toURL();
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(false);
+
+            // Check the HTTP response code
+            int responseCode = connection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                logger.debug("Download completed with HTTP response code: {}", connection.getResponseCode());
+                return connection.getInputStream();
+            }
+            logger.info("No file to download. Response code: {}", responseCode);
+            return null;
+        } catch (URISyntaxException | MalformedURLException e) {
+            String errorMsg = String.format("Invalid path specified: %s", path);
+            logger.error(errorMsg, e);
+            throw new ConductorClientException(errorMsg, e);
+        } catch (IOException e) {
+            String errorMsg = String.format("Error downloading from path: %s", path);
+            logger.error(errorMsg, e);
+            throw new ConductorClientException(errorMsg, e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/client/src/test/java/com/netflix/conductor/client/worker/TestPropertyFactory.java
+++ b/client/src/test/java/com/netflix/conductor/client/worker/TestPropertyFactory.java
@@ -13,63 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * 
- */
+
 package com.netflix.conductor.client.worker;
+
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
-import com.netflix.conductor.common.metadata.tasks.Task;
-import com.netflix.conductor.common.metadata.tasks.TaskResult;
 
 /**
  * @author Viren
  *
  */
 public class TestPropertyFactory {
-	
+
 	@Test
 	public void testIdentity(){
-		Worker worker = Worker.create("Test2", (Task task)->{
-			return new TaskResult(task);
-		});
+		Worker worker = Worker.create("Test2", TaskResult::new);
 		assertNotNull(worker.getIdentity());
 		boolean paused = worker.paused();
 		assertFalse("Paused? " + paused, paused);
 	}
-	
+
 	@Test
 	public void test() {
-		
-		int val = PropertyFactory.getInteger("workerB", "pollingInterval", 100).intValue();
+
+		int val = PropertyFactory.getInteger("workerB", "pollingInterval", 100);
 		assertEquals("got: " + val, 2, val);
 		assertEquals(100, PropertyFactory.getInteger("workerB", "propWithoutValue", 100).intValue());
-		
+
 		assertFalse(PropertyFactory.getBoolean("workerB", "paused", true));		//Global value set to 'false'
 		assertTrue(PropertyFactory.getBoolean("workerA", "paused", false));		//WorkerA value set to 'true'
-		
-		
+
+
 		assertEquals(42, PropertyFactory.getInteger("workerA", "batchSize", 42).intValue());	//No global value set, so will return the default value supplied
 		assertEquals(84, PropertyFactory.getInteger("workerB", "batchSize", 42).intValue());	//WorkerB's value set to 84
 
-		assertEquals("domainA", PropertyFactory.getString("workerA", "domain", null));	
-		assertEquals("domainB", PropertyFactory.getString("workerB", "domain", null));	
-		assertEquals(null, PropertyFactory.getString("workerC", "domain", null));	// Non Existent
+		assertEquals("domainA", PropertyFactory.getString("workerA", "domain", null));
+		assertEquals("domainB", PropertyFactory.getString("workerB", "domain", null));
+		assertNull(PropertyFactory.getString("workerC", "domain", null));	// Non Existent
 	}
-	
+
 	@Test
 	public void testProperty() {
-		Worker worker = Worker.create("Test", (Task task)->{
-			return new TaskResult(task);
-		});
+		Worker worker = Worker.create("Test", TaskResult::new);
 		boolean paused = worker.paused();
 		assertTrue("Paused? " + paused, paused);
 	}
-	
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -438,7 +438,8 @@ public class Task {
 
 
     /**
-     * @param workflowType workflow type
+     * @param workflowType the name of the workflow
+     * @return the task object with the workflow type set
      */
     public Task setWorkflowType(String workflowType) {
         this.workflowType = workflowType;

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -132,8 +132,11 @@ public class Task {
 
     private int rateLimitFrequencyInSeconds;
 
-    public Task() {
+    private String externalInputPayloadStoragePath;
 
+    private String externalOutputPayloadStoragePath;
+
+    public Task() {
     }
 
     /**
@@ -560,8 +563,35 @@ public class Task {
         this.rateLimitFrequencyInSeconds = rateLimitFrequencyInSeconds;
     }
 
-    public Task copy() {
+    /**
+     * @return the external storage path for the task input payload
+     */
+    public String getExternalInputPayloadStoragePath() {
+        return externalInputPayloadStoragePath;
+    }
 
+    /**
+     * @param externalInputPayloadStoragePath the external storage path where the task input payload is stored
+     */
+    public void setExternalInputPayloadStoragePath(String externalInputPayloadStoragePath) {
+        this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
+    }
+
+    /**
+     * @return the external storage path for the task output payload
+     */
+    public String getExternalOutputPayloadStoragePath() {
+        return externalOutputPayloadStoragePath;
+    }
+
+    /**
+     * @param externalOutputPayloadStoragePath the external storage path where the task output payload is stored
+     */
+    public void setExternalOutputPayloadStoragePath(String externalOutputPayloadStoragePath) {
+        this.externalOutputPayloadStoragePath = externalOutputPayloadStoragePath;
+    }
+
+    public Task copy() {
         Task copy = new Task();
         copy.setCallbackAfterSeconds(callbackAfterSeconds);
         copy.setCallbackFromWorker(callbackFromWorker);
@@ -584,6 +614,7 @@ public class Task {
         copy.setDomain(domain);
         copy.setRateLimitPerFrequency(rateLimitPerFrequency);
         copy.setRateLimitFrequencyInSeconds(rateLimitFrequencyInSeconds);
+        copy.setExternalInputPayloadStoragePath(externalInputPayloadStoragePath);
         return copy;
     }
 
@@ -607,11 +638,11 @@ public class Task {
                 ", startDelayInSeconds=" + startDelayInSeconds +
                 ", retriedTaskId='" + retriedTaskId + '\'' +
                 ", retried=" + retried +
+                ", executed=" + executed +
                 ", callbackFromWorker=" + callbackFromWorker +
-                ", rateLimitFrequencyInSeconds=" + rateLimitFrequencyInSeconds +
-                ", rateLimitPerFrequency=" + rateLimitPerFrequency +
                 ", responseTimeoutSeconds=" + responseTimeoutSeconds +
                 ", workflowInstanceId='" + workflowInstanceId + '\'' +
+                ", workflowType='" + workflowType + '\'' +
                 ", taskId='" + taskId + '\'' +
                 ", reasonForIncompletion='" + reasonForIncompletion + '\'' +
                 ", callbackAfterSeconds=" + callbackAfterSeconds +
@@ -619,6 +650,10 @@ public class Task {
                 ", outputData=" + outputData +
                 ", workflowTask=" + workflowTask +
                 ", domain='" + domain + '\'' +
+                ", rateLimitPerFrequency=" + rateLimitPerFrequency +
+                ", rateLimitFrequencyInSeconds=" + rateLimitFrequencyInSeconds +
+                ", externalInputPayloadStoragePath='" + externalInputPayloadStoragePath + '\'' +
+                ", externalOutputPayloadStoragePath='" + externalOutputPayloadStoragePath + '\'' +
                 '}';
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -615,6 +615,7 @@ public class Task {
         copy.setRateLimitPerFrequency(rateLimitPerFrequency);
         copy.setRateLimitFrequencyInSeconds(rateLimitFrequencyInSeconds);
         copy.setExternalInputPayloadStoragePath(externalInputPayloadStoragePath);
+        copy.setExternalOutputPayloadStoragePath(externalOutputPayloadStoragePath);
         return copy;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -48,7 +48,7 @@ public class TaskResult {
 
     private List<TaskExecLog> logs = new CopyOnWriteArrayList<>();
 
-    private String externalPayloadStoragePath;
+    private String externalOutputPayloadStoragePath;
 
     public TaskResult(Task task) {
         this.workflowInstanceId = task.getWorkflowInstanceId();
@@ -58,6 +58,7 @@ public class TaskResult {
         this.status = Status.valueOf(task.getStatus().name());
         this.workerId = task.getWorkerId();
         this.outputData = task.getOutputData();
+        this.externalOutputPayloadStoragePath = task.getExternalOutputPayloadStoragePath();
     }
 
     public TaskResult() {
@@ -195,16 +196,16 @@ public class TaskResult {
      *
      * @return the path where the task output is stored in external storage
      */
-    public String getExternalPayloadStoragePath() {
-        return externalPayloadStoragePath;
+    public String getExternalOutputPayloadStoragePath() {
+        return externalOutputPayloadStoragePath;
     }
 
     /**
      *
-     * @param externalPayloadStoragePath path in the external storage where the task output is stored
+     * @param externalOutputPayloadStoragePath path in the external storage where the task output is stored
      */
-    public void setExternalPayloadStoragePath(String externalPayloadStoragePath) {
-        this.externalPayloadStoragePath = externalPayloadStoragePath;
+    public void setExternalOutputPayloadStoragePath(String externalOutputPayloadStoragePath) {
+        this.externalOutputPayloadStoragePath = externalOutputPayloadStoragePath;
     }
 
     @Override
@@ -218,7 +219,7 @@ public class TaskResult {
                 ", status=" + status +
                 ", outputData=" + outputData +
                 ", logs=" + logs +
-                ", externalPayloadStoragePath='" + externalPayloadStoragePath + '\'' +
+                ", externalOutputPayloadStoragePath='" + externalOutputPayloadStoragePath + '\'' +
                 '}';
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- */
+
 package com.netflix.conductor.common.metadata.tasks;
 
 import java.util.HashMap;
@@ -49,6 +47,8 @@ public class TaskResult {
     private Map<String, Object> outputData = new HashMap<>();
 
     private List<TaskExecLog> logs = new CopyOnWriteArrayList<>();
+
+    private String externalPayloadStoragePath;
 
     public TaskResult(Task task) {
         this.workflowInstanceId = task.getWorkflowInstanceId();
@@ -191,6 +191,22 @@ public class TaskResult {
         return this;
     }
 
+    /**
+     *
+     * @return the path where the task output is stored in external storage
+     */
+    public String getExternalPayloadStoragePath() {
+        return externalPayloadStoragePath;
+    }
+
+    /**
+     *
+     * @param externalPayloadStoragePath path in the external storage where the task output is stored
+     */
+    public void setExternalPayloadStoragePath(String externalPayloadStoragePath) {
+        this.externalPayloadStoragePath = externalPayloadStoragePath;
+    }
+
     @Override
     public String toString() {
         return "TaskResult{" +
@@ -202,6 +218,7 @@ public class TaskResult {
                 ", status=" + status +
                 ", outputData=" + outputData +
                 ", logs=" + logs +
+                ", externalPayloadStoragePath='" + externalPayloadStoragePath + '\'' +
                 '}';
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
@@ -7,6 +7,7 @@ public class StartWorkflowRequest {
 	private String name;
 	private Integer version;
 	private String correlationId;
+	private String externalStoragePath;
 	private Map<String, Object> input = new HashMap<>();
 	private Map<String, String> taskToDomain = new HashMap<>();
 	
@@ -19,7 +20,8 @@ public class StartWorkflowRequest {
 	public StartWorkflowRequest withName(String name) {
 		this.name = name;
 		return this;
-	}	
+	}
+
 	public Integer getVersion() {
 		return version;
 	}
@@ -30,6 +32,7 @@ public class StartWorkflowRequest {
 		this.version = version;
 		return this;
 	}
+
 	public String getCorrelationId() {
 		return correlationId;
 	}
@@ -40,6 +43,15 @@ public class StartWorkflowRequest {
 		this.correlationId = correlationId;
 		return this;
 	}
+
+	public String getExternalStoragePath() {
+		return externalStoragePath;
+	}
+
+	public void setExternalStoragePath(String externalStoragePath) {
+		this.externalStoragePath = externalStoragePath;
+	}
+
 	public Map<String, Object> getInput() {
 		return input;
 	}
@@ -50,6 +62,7 @@ public class StartWorkflowRequest {
 		this.input = input;
 		return this;
 	}
+
 	public Map<String, String> getTaskToDomain() {
 		return taskToDomain;
 	}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
@@ -7,7 +7,7 @@ public class StartWorkflowRequest {
 	private String name;
 	private Integer version;
 	private String correlationId;
-	private String externalStoragePath;
+	private String externalInputPayloadStoragePath;
 	private Map<String, Object> input = new HashMap<>();
 	private Map<String, String> taskToDomain = new HashMap<>();
 	
@@ -44,12 +44,12 @@ public class StartWorkflowRequest {
 		return this;
 	}
 
-	public String getExternalStoragePath() {
-		return externalStoragePath;
+	public String getExternalInputPayloadStoragePath() {
+		return externalInputPayloadStoragePath;
 	}
 
-	public void setExternalStoragePath(String externalStoragePath) {
-		this.externalStoragePath = externalStoragePath;
+	public void setExternalInputPayloadStoragePath(String externalInputPayloadStoragePath) {
+		this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
 	}
 
 	public Map<String, Object> getInput() {

--- a/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
@@ -16,10 +16,18 @@
 
 package com.netflix.conductor.common.run;
 
+/**
+ * Describes the location where the JSON payload is stored in external storage.
+ * <li>
+ * The location is described using the following fields:
+ * <ul>uri: The uri of the json file in external storage</ul>
+ * <ul>path: The relative path of the file in external storage</ul>
+ * </li>
+ */
 public class ExternalStorageLocation {
 
-    public String uri;
-    public String path;
+    private String uri;
+    private String path;
 
     public String getUri() {
         return uri;

--- a/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
@@ -18,11 +18,12 @@ package com.netflix.conductor.common.run;
 
 /**
  * Describes the location where the JSON payload is stored in external storage.
+ * <ul>
  * <li>
  * The location is described using the following fields:
- * <ul>uri: The uri of the json file in external storage</ul>
- * <ul>path: The relative path of the file in external storage</ul>
- * </li>
+ * <li>uri: The uri of the json file in external storage</li>
+ * <li>path: The relative path of the file in external storage</li>
+ * </ul>
  */
 public class ExternalStorageLocation {
 

--- a/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.common.run;
+
+public class ExternalStorageLocation {
+
+    public String uri;
+    public String path;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalStorageLocation{" +
+                "uri='" + uri + '\'' +
+                ", path='" + path + '\'' +
+                '}';
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -15,76 +15,81 @@
  */
 package com.netflix.conductor.common.run;
 
+import com.netflix.conductor.common.metadata.Auditable;
+import com.netflix.conductor.common.metadata.tasks.Task;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.netflix.conductor.common.metadata.Auditable;
-import com.netflix.conductor.common.metadata.tasks.Task;
+import java.util.stream.Collectors;
 
 
 public class Workflow extends Auditable{
-	
+
 	public enum  WorkflowStatus {
 		RUNNING(false, false), COMPLETED(true, true), FAILED(true, false), TIMED_OUT(true, false), TERMINATED(true, false), PAUSED(false, true);
-		
+
 		private boolean terminal;
-		
+
 		private boolean successful;
-		
+
 		WorkflowStatus(boolean terminal, boolean successful){
 			this.terminal = terminal;
 			this.successful = successful;
 		}
-		
+
 		public boolean isTerminal(){
 			return terminal;
 		}
-		
+
 		public boolean isSuccessful(){
 			return successful;
 		}
 	}
-	
+
 	private WorkflowStatus status = WorkflowStatus.RUNNING;
-	
+
 	private long endTime;
 
 	private String workflowId;
-	
+
 	private String parentWorkflowId;
 
 	private String parentWorkflowTaskId;
 
 	private List<Task> tasks = new LinkedList<>();
-	
+
 	private Map<String, Object> input = new HashMap<>();
-	
+
 	private Map<String, Object> output = new HashMap<>();;
-	
+
 	private String workflowType;
-	
+
 	private int version;
-	
+
 	private String correlationId;
-	
+
 	private String reRunFromWorkflowId;
-	
+
 	private String reasonForIncompletion;
-	
+
 	private int schemaVersion;
-	
+
 	private String event;
 
 	private Map<String, String> taskToDomain = new HashMap<>();
 
 	private Set<String> failedReferenceTaskNames = new HashSet<>();
 
+	private String externalInputPayloadStoragePath;
+
+	private String externalOutputPayloadStoragePath;
+
 	public Workflow(){
-		
+
 	}
 	/**
 	 * @return the status
@@ -152,7 +157,7 @@ public class Workflow extends Auditable{
 	public void setTasks(List<Task> tasks) {
 		this.tasks = tasks;
 	}
-	
+
 	/**
 	 * @return the input
 	 */
@@ -189,40 +194,40 @@ public class Workflow extends Auditable{
 	public void setOutput(Map<String, Object> output) {
 		this.output = output;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return The correlation id used when starting the workflow
 	 */
 	public String getCorrelationId() {
 		return correlationId;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param correlationId the correlation id
 	 */
 	public void setCorrelationId(String correlationId) {
 		this.correlationId = correlationId;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return Workflow Type / Definition
 	 */
 	public String getWorkflowType() {
 		return workflowType;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param workflowType Workflow type
 	 */
 	public void setWorkflowType(String workflowType) {
 		this.workflowType = workflowType;
 	}
-	
-	
+
+
 	/**
 	 * @return the version
 	 */
@@ -235,23 +240,23 @@ public class Workflow extends Auditable{
 	public void setVersion(int version) {
 		this.version = version;
 	}
-	
+
 	public String getReRunFromWorkflowId() {
 		return reRunFromWorkflowId;
 	}
-	
+
 	public void setReRunFromWorkflowId(String reRunFromWorkflowId) {
 		this.reRunFromWorkflowId = reRunFromWorkflowId;
 	}
-	
+
 	public String getReasonForIncompletion() {
 		return reasonForIncompletion;
 	}
-	
+
 	public void setReasonForIncompletion(String reasonForIncompletion) {
 		this.reasonForIncompletion = reasonForIncompletion;
 	}
-	
+
 	/**
 	 * @return the parentWorkflowId
 	 */
@@ -264,7 +269,7 @@ public class Workflow extends Auditable{
 	public void setParentWorkflowId(String parentWorkflowId) {
 		this.parentWorkflowId = parentWorkflowId;
 	}
-	
+
 	/**
 	 * @return the parentWorkflowTaskId
 	 */
@@ -289,17 +294,17 @@ public class Workflow extends Auditable{
 	public void setSchemaVersion(int schemaVersion) {
 		this.schemaVersion = schemaVersion;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return Name of the event that started the workflow
 	 */
 	public String getEvent() {
 		return event;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param event Name of the event that started the workflow
 	 */
 	public void setEvent(String event) {
@@ -314,16 +319,39 @@ public class Workflow extends Auditable{
 		this.failedReferenceTaskNames = failedReferenceTaskNames;
 	}
 
-	@Override
-	public String toString() {
-		return workflowType + "." + version + "/" + workflowId + "." + status; 
+	/**
+	 * @return the external storage path of the workflow input payload
+	 */
+	public String getExternalInputPayloadStoragePath() {
+		return externalInputPayloadStoragePath;
 	}
-	
+
+	/**
+	 * @param externalInputPayloadStoragePath the external storage path where the workflow input payload is stored
+	 */
+	public void setExternalInputPayloadStoragePath(String externalInputPayloadStoragePath) {
+		this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
+	}
+
+	/**
+	 * @return the external storage path of the workflow output payload
+	 */
+	public String getExternalOutputPayloadStoragePath() {
+		return externalOutputPayloadStoragePath;
+	}
+
+	/**
+	 * @param externalOutputPayloadStoragePath the external storage path where the workflow output payload is stored
+	 */
+	public void setExternalOutputPayloadStoragePath(String externalOutputPayloadStoragePath) {
+		this.externalOutputPayloadStoragePath = externalOutputPayloadStoragePath;
+	}
+
 	public Task getTaskByRefName(String refName) {
 		if (refName == null) {
 			throw new RuntimeException("refName passed is null.  Check the workflow execution.  For dynamic tasks, make sure referenceTaskName is set to a not null value");
 		}
-		LinkedList<Task> found = new LinkedList<Task>();
+		LinkedList<Task> found = new LinkedList<>();
 		for (Task t : tasks) {
 			if (t.getReferenceTaskName() == null) {
 				throw new RuntimeException("Task " + t.getTaskDefName() + ", seq=" + t.getSeq() + " does not have reference name specified.");
@@ -337,5 +365,41 @@ public class Workflow extends Auditable{
 		}
 		return found.getLast();
 	}
-	
+
+	/**
+	 * @return a deep copy of the workflow instance
+	 * Note: This does not copy the following fields:
+	 * <ul>
+	 * <li>endTime</li>
+	 * <li>taskToDomain</li>
+	 * <li>failedReferenceTaskNames</li>
+	 * <li>externalInputPayloadStoragePath</li>
+	 * <li>externalOutputPayloadStoragePath</li>
+	 * </ul>
+	 */
+	public Workflow copy() {
+		Workflow copy = new Workflow();
+		copy.setInput(input);
+		copy.setOutput(output);
+		copy.setStatus(status);
+		copy.setWorkflowId(workflowId);
+		copy.setParentWorkflowId(parentWorkflowId);
+		copy.setParentWorkflowTaskId(parentWorkflowTaskId);
+		copy.setReRunFromWorkflowId(reRunFromWorkflowId);
+		copy.setWorkflowType(workflowType);
+		copy.setVersion(version);
+		copy.setCorrelationId(correlationId);
+		copy.setEvent(event);
+		copy.setReasonForIncompletion(reasonForIncompletion);
+		copy.setSchemaVersion(schemaVersion);
+		copy.setTasks(tasks.stream()
+				.map(Task::copy)
+				.collect(Collectors.toList()));
+		return copy;
+	}
+
+	@Override
+	public String toString() {
+		return workflowType + "." + version + "/" + workflowId + "." + status;
+	}
 }

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 
 public class Workflow extends Auditable{
 

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -34,9 +34,11 @@ public interface ExternalPayloadStorage {
      *
      * @param operation   the type of {@link Operation} to be performed with the uri
      * @param payloadType the {@link PayloadType} that is being accessed at the uri
+     * @param path (optional) the relative path for which the external storage location object is to be populated.
+     *             If path is not specified, it will be computed and populated.
      * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the json payload
      */
-    ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType);
+    ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
     /**
      * Upload a json payload to the specified external storage location.

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.common.utils;
+
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+
+import java.io.InputStream;
+
+/**
+ * Interface used to externalize the storage of large JSON payloads in workflow and task input/output
+ */
+public interface ExternalPayloadStorage {
+
+    enum Operation {READ, WRITE}
+
+    enum PayloadType {WORKFLOW_INPUT, WORKFLOW_OUTPUT, TASK_INPUT, TASK_OUTPUT}
+
+    /**
+     * Obtain a uri used to store/access a json payload in external storage.
+     *
+     * @param operation   the type of {@link Operation} to be performed with the uri
+     * @param payloadType the {@link PayloadType} that is being accessed at the uri
+     * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the json payload
+     */
+    ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType);
+
+    /**
+     * Upload a json payload to the specified external storage location.
+     *
+     * @param path        the location to which the object is to be uploaded
+     * @param payload     an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     */
+    void upload(String path, InputStream payload, long payloadSize);
+
+    /**
+     * Download the json payload from the specified external storage location.
+     *
+     * @param path the location from where the object is to be downloaded
+     * @return an {@link InputStream} of the json payload at the specified location
+     */
+    InputStream download(String path);
+}

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -36,7 +36,7 @@ public interface ExternalPayloadStorage {
      * @param payloadType the {@link PayloadType} that is being accessed at the uri
      * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the json payload
      */
-    ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType);
+    ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType);
 
     /**
      * Upload a json payload to the specified external storage location.

--- a/common/src/test/java/com/netflix/conductor/common/workflow/TestWorkflowDef.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/TestWorkflowDef.java
@@ -18,20 +18,20 @@
  */
 package com.netflix.conductor.common.workflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Viren
@@ -47,7 +47,7 @@ public class TestWorkflowDef {
 	}
 	
 	@Test
-	public void test() throws Exception {
+	public void test() {
 
 		String COND_TASK_WF = "COND_TASK_WF";
 		List<WorkflowTask> wfts = new ArrayList<WorkflowTask>(10);
@@ -78,7 +78,7 @@ public class TestWorkflowDef {
 		caseTask.setTaskReferenceName("case");
 		Map<String, List<WorkflowTask>> dc = new HashMap<>();
 		dc.put("c1", Arrays.asList(wfts.get(0), subCaseTask, wfts.get(1)));
-		dc.put("c2", Arrays.asList(wfts.get(3)));
+		dc.put("c2", Collections.singletonList(wfts.get(3)));
 		caseTask.setDecisionCases(dc);
 		
 		WorkflowTask finalTask = new WorkflowTask();

--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -1,7 +1,13 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -112,8 +118,14 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -224,8 +236,14 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -346,8 +364,14 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -458,8 +482,14 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -570,8 +600,14 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -698,8 +734,14 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -826,8 +868,14 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -954,8 +1002,14 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.380",
+            "locked": "1.11.389",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -160,9 +160,7 @@ public class HttpTask extends WorkflowSystemTask {
 		if(input.body != null) {
 			builder.entity(input.body);
 		}
-		input.headers.entrySet().forEach(e -> {
-			builder.header(e.getKey(), e.getValue());
-		});
+		input.headers.forEach(builder::header);
 		
 		HttpResponse response = new HttpResponse();
 		try {

--- a/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
 import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.contribs.http.HttpTask.Input;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.DeciderService;
@@ -53,7 +54,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
@@ -131,7 +131,7 @@ public class TestHttpTask {
 	}
 	
 	@Test
-	public void testPost() throws Exception {
+	public void testPost() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -158,7 +158,7 @@ public class TestHttpTask {
 	
 
 	@Test
-	public void testPostNoContent() throws Exception {
+	public void testPostNoContent() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -179,7 +179,7 @@ public class TestHttpTask {
 	}
 	
 	@Test
-	public void testFailure() throws Exception {
+	public void testFailure() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -199,7 +199,7 @@ public class TestHttpTask {
 	}
 	
 	@Test
-	public void testTextGET() throws Exception {
+	public void testTextGET() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -215,7 +215,7 @@ public class TestHttpTask {
 	}
 	
 	@Test
-	public void testNumberGET() throws Exception {
+	public void testNumberGET() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -250,7 +250,7 @@ public class TestHttpTask {
 	}
 
 	@Test
-	public void testExecute() throws Exception {
+	public void testExecute() {
 
 		Task task = new Task();
 		Input input = new Input();
@@ -261,11 +261,10 @@ public class TestHttpTask {
 		task.setScheduledTime(0);
 		boolean executed = httpTask.execute(workflow, task, executor);
 		assertFalse(executed);
-
 	}
 	
 	@Test
-	public void testOptional() throws Exception {
+	public void testOptional() {
  		Task task = new Task();
  		Input input = new Input();
  		input.setUri("http://localhost:7009/failure");
@@ -297,7 +296,8 @@ public class TestHttpTask {
 		def.getTasks().add(wft);
  		MetadataDAO metadataDAO = mock(MetadataDAO.class);
 		QueueDAO queueDAO = mock(QueueDAO.class);
-		ParametersUtils parametersUtils = new ParametersUtils();
+		ExternalPayloadStorage externalPayloadStorage = mock(ExternalPayloadStorage.class);
+		ParametersUtils parametersUtils = mock(ParametersUtils.class);
 		Map<String, TaskMapper> taskMappers = new HashMap<>();
 		taskMappers.put("DECISION", new DecisionTaskMapper());
 		taskMappers.put("DYNAMIC", new DynamicTaskMapper(parametersUtils, metadataDAO));
@@ -309,14 +309,14 @@ public class TestHttpTask {
 		taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
 		taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
 		taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
- 		new DeciderService(metadataDAO, queueDAO, taskMappers).decide(workflow, def);
+ 		new DeciderService(metadataDAO, parametersUtils, queueDAO, externalPayloadStorage, taskMappers).decide(workflow, def);
  		
  		System.out.println(workflow.getTasks());
  		System.out.println(workflow.getStatus());
  	}
 
  	@Test
-	public void testOAuth() throws Exception {
+	public void testOAuth() {
 		Task task = new Task();
 		Input input = new Input();
 		input.setUri("http://localhost:7009/oauth");
@@ -346,7 +346,7 @@ public class TestHttpTask {
 		
 		@Override
 		public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-				throws IOException, ServletException {
+				throws IOException {
 			if(request.getMethod().equals("GET") && request.getRequestURI().equals("/text")) {
 				PrintWriter writer = response.getWriter();
 				writer.print(TEXT_RESPONSE);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,13 +8,13 @@ dependencies {
 
     compile "com.netflix.servo:servo-core:${revServo}"
     compile "com.netflix.spectator:spectator-api:${revSpectator}"
+
     compile "com.fasterxml.jackson.core:jackson-databind:${revJacksonDatabind}"
     compile "com.fasterxml.jackson.core:jackson-core:${revJacksonCore}"
     compile "com.jayway.jsonpath:json-path:${revJsonPath}"
-
     compile "org.apache.commons:commons-lang3:${revCommonsLang3}"
-
     compile "com.spotify:completable-futures:${revSpotifyCompletableFutures}"
+    compile "com.amazonaws:aws-java-sdk-s3:${revAwsSdk}"
 
     testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"
 }

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -1,5 +1,9 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -57,6 +61,10 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -114,6 +122,10 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -171,6 +183,10 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -228,6 +244,10 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -285,6 +305,10 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -354,6 +378,10 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -423,6 +451,10 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"
@@ -492,6 +524,10 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "locked": "1.11.86",
+            "requested": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.7.5",
             "requested": "2.7.5"

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * 
- */
+
 package com.netflix.conductor.core.config;
 
 import com.google.inject.AbstractModule;
@@ -84,6 +82,54 @@ public interface Configuration {
 	 * @return Availability zone / rack.  for AWS deployments, the value is something like us-east-1a, etc.
 	 */
 	String getAvailabilityZone();
+
+	/**
+	 *
+	 * @return The threshold of the workflow input payload size in KB beyond which the payload will be stored in {@link com.netflix.conductor.common.utils.ExternalPayloadStorage}
+	 */
+	Long getWorkflowInputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The maximum threshold of the workflow input payload size in KB beyond which input will be rejected and the workflow will be marked as FAILED
+	 */
+	Long getMaxWorkflowInputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The threshold of the workflow output payload size in KB beyond which the payload will be stored in {@link com.netflix.conductor.common.utils.ExternalPayloadStorage}
+	 */
+	Long getWorkflowOutputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The maximum threshold of the workflow output payload size in KB beyond which output will be rejected and the workflow will be marked as FAILED
+	 */
+	Long getMaxWorkflowOutputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The threshold of the task input payload size in KB beyond which the payload will be stored in {@link com.netflix.conductor.common.utils.ExternalPayloadStorage}
+	 */
+	Long getTaskInputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The maximum threshold of the task input payload size in KB beyond which the task input will be rejected and the task will be marked as FAILED_WITH_TERMINAL_ERROR
+	 */
+	Long getMaxTaskInputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The threshold of the task output payload size in KB beyond which the payload will be stored in {@link com.netflix.conductor.common.utils.ExternalPayloadStorage}
+	 */
+	Long getTaskOutputPayloadSizeThresholdKB();
+
+	/**
+	 *
+	 * @return The maximum threshold of the task output payload size in KB beyond which the task input will be rejected and the task will be marked as FAILED_WITH_TERMINAL_ERROR
+	 */
+	Long getMaxTaskOutputPayloadSizeThresholdKB();
 
 	/**
 	 * 

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -18,10 +18,10 @@
  */
 package com.netflix.conductor.core.config;
 
+import com.google.inject.AbstractModule;
+
 import java.util.List;
 import java.util.Map;
-
-import com.google.inject.AbstractModule;
 
 /**
  * @author Viren
@@ -33,13 +33,13 @@ public interface Configuration {
 	 * 
 	 * @return time frequency in seconds, at which the workflow sweeper should run to evaluate running workflows. 
 	 */
-	public int getSweepFrequency();
+	int getSweepFrequency();
 	
 	/**
 	 * 
 	 * @return when set to true, the sweep is disabled
 	 */
-	public boolean disableSweep();
+	boolean disableSweep();
 	
 	
 	/**
@@ -47,43 +47,43 @@ public interface Configuration {
 	 * @return when set to true, the background task workers executing async system tasks (eg HTTP) are disabled
 	 * 
 	 */
-	public boolean disableAsyncWorkers();
+	boolean disableAsyncWorkers();
 	
 	/**
 	 * 
 	 * @return ID of the server.  Can be host name, IP address or any other meaningful identifier.  Used for logging
 	 */
-	public String getServerId();
+	String getServerId();
 
 	/**
 	 * 
 	 * @return Current environment. e.g. test, prod
 	 */
-	public String getEnvironment();
+	String getEnvironment();
 
 	/**
 	 * 
 	 * @return name of the stack under which the app is running.  e.g. devint, testintg, staging, prod etc. 
 	 */
-	public String getStack();
+	String getStack();
 
 	/**
 	 * 
 	 * @return APP ID.  Used for logging
 	 */
-	public String getAppId();
+	String getAppId();
 
 	/**
 	 * 
 	 * @return Data center region.  if hosting on Amazon the value is something like us-east-1, us-west-2 etc.
 	 */
-	public String getRegion();
+	String getRegion();
 
 	/**
 	 * 
 	 * @return Availability zone / rack.  for AWS deployments, the value is something like us-east-1a, etc.
 	 */
-	public String getAvailabilityZone();
+	String getAvailabilityZone();
 
 	/**
 	 * 
@@ -91,7 +91,7 @@ public interface Configuration {
 	 * @param defaultValue  Default value when not specified
 	 * @return User defined integer property. 
 	 */
-	public int getIntProperty(String name, int defaultValue);
+	int getIntProperty(String name, int defaultValue);
 
 
 	/**
@@ -100,7 +100,7 @@ public interface Configuration {
 	 * @param defaultValue  Default value when not specified
 	 * @return User defined Long property.
 	 */
-	public long getLongProperty(String name, long defaultValue);
+	long getLongProperty(String name, long defaultValue);
 	
 	/**
 	 * 
@@ -108,14 +108,14 @@ public interface Configuration {
 	 * @param defaultValue  Default value when not specified
 	 * @return User defined string property. 
 	 */
-	public String getProperty(String name, String defaultValue);
+	String getProperty(String name, String defaultValue);
 	
 	
 	/**
 	 * 
 	 * @return Returns all the configurations in a map.
 	 */
-	public Map<String, Object> getAll();
+	Map<String, Object> getAll();
 	
 	/**
 	 * 
@@ -123,7 +123,7 @@ public interface Configuration {
 	 * Use this to inject additional modules that should be loaded as part of the Conductor server initialization
 	 * If you are creating custom tasks (com.netflix.conductor.core.execution.tasks.WorkflowSystemTask) then initialize them as part of the custom modules.
 	 */
-	public default List<AbstractModule> getAdditionalModules() {
+	default List<AbstractModule> getAdditionalModules() {
 		return null;
 	}
 

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,6 @@ import com.google.inject.name.Named;
 import com.netflix.conductor.core.events.ActionProcessor;
 import com.netflix.conductor.core.events.EventProcessor;
 import com.netflix.conductor.core.events.EventQueueProvider;
-import com.netflix.conductor.core.events.EventQueues;
 import com.netflix.conductor.core.events.queue.dyno.DynoEventQueueProvider;
 import com.netflix.conductor.core.execution.ParametersUtils;
 import com.netflix.conductor.core.execution.mapper.DecisionTaskMapper;
@@ -50,7 +49,6 @@ import com.netflix.conductor.core.execution.tasks.Wait;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 
-
 /**
  * @author Viren
  */
@@ -59,7 +57,6 @@ public class CoreModule extends AbstractModule {
     @Override
     protected void configure() {
         install(MultibindingsScanner.asModule());
-        requestStaticInjection(EventQueues.class);
         bind(ActionProcessor.class).asEagerSingleton();
         bind(EventProcessor.class).asEagerSingleton();
         bind(SystemTaskWorkerCoordinator.class).asEagerSingleton();
@@ -73,7 +70,6 @@ public class CoreModule extends AbstractModule {
     public ParametersUtils getParameterUtils() {
         return new ParametersUtils();
     }
-
 
     @ProvidesIntoMap
     @StringMapKey("conductor")
@@ -106,7 +102,6 @@ public class CoreModule extends AbstractModule {
     public TaskMapper getJoinTaskMapper() {
         return new JoinTaskMapper();
     }
-
 
 
     @ProvidesIntoMap
@@ -164,6 +159,4 @@ public class CoreModule extends AbstractModule {
     public TaskMapper getSimpleTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
         return new SimpleTaskMapper(parametersUtils, metadataDAO);
     }
-
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
@@ -50,13 +50,15 @@ public class ActionProcessor {
 
     private final WorkflowExecutor executor;
     private final MetadataService metadataService;
-    private final ParametersUtils parametersUtils = new ParametersUtils();
+    private final ParametersUtils parametersUtils;
+
     private final JsonUtils jsonUtils = new JsonUtils();
 
     @Inject
-    public ActionProcessor(WorkflowExecutor executor, MetadataService metadataService) {
+    public ActionProcessor(WorkflowExecutor executor, MetadataService metadataService, ParametersUtils parametersUtils) {
         this.executor = executor;
         this.metadataService = metadataService;
+        this.parametersUtils = parametersUtils;
     }
 
     public Map<String, Object> execute(Action action, Object payloadObject, String event, String messageId) {

--- a/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
@@ -143,7 +143,7 @@ public class EventProcessor {
         queue.observe().subscribe((Message msg) -> handle(queue, msg));
     }
 
-    @SuppressWarnings({"unchecked", "ToArrayCallWithZeroLengthArrayArgument"})
+    @SuppressWarnings({"unchecked"})
     private void handle(ObservableQueue queue, Message msg) {
         try {
             executionService.addMessage(queue.getName(), msg);

--- a/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/EventProcessor.java
@@ -70,6 +70,7 @@ public class EventProcessor {
     private final MetadataService metadataService;
     private final ExecutionService executionService;
     private final ActionProcessor actionProcessor;
+    private final EventQueues eventQueues;
 
     private ExecutorService executorService;
     private final Map<String, ObservableQueue> eventToQueueMap = new ConcurrentHashMap<>();
@@ -78,10 +79,11 @@ public class EventProcessor {
 
     @Inject
     public EventProcessor(ExecutionService executionService, MetadataService metadataService,
-                          ActionProcessor actionProcessor, Configuration config) {
+                          ActionProcessor actionProcessor, EventQueues eventQueues, Configuration config) {
         this.executionService = executionService;
         this.metadataService = metadataService;
         this.actionProcessor = actionProcessor;
+        this.eventQueues = eventQueues;
 
         int executorThreadCount = config.getIntProperty("workflow.event.processor.thread.count", 2);
         if (executorThreadCount > 0) {
@@ -120,7 +122,7 @@ public class EventProcessor {
 
             List<ObservableQueue> createdQueues = new LinkedList<>();
             events.forEach(event -> eventToQueueMap.computeIfAbsent(event, s -> {
-                        ObservableQueue q = EventQueues.getQueue(event);
+                        ObservableQueue q = eventQueues.getQueue(event);
                         createdQueues.add(q);
                         return q;
                     }

--- a/core/src/main/java/com/netflix/conductor/core/events/EventQueues.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/EventQueues.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.core.events;
 
@@ -25,34 +25,37 @@ import com.netflix.conductor.core.execution.ParametersUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * @author Viren
- * Static holders for internal event queues
+ * Holders for internal event queues
  */
+@Singleton
 public class EventQueues {
-	
-	private static Logger logger = LoggerFactory.getLogger(EventQueues.class);
 
-	private static ParametersUtils parametersUtils = new ParametersUtils();
+	private static final Logger logger = LoggerFactory.getLogger(EventQueues.class);
+
+	private final ParametersUtils parametersUtils;
+
+	private final Map<String, EventQueueProvider> providers;
 
 	@Inject
-	@Named("EventQueueProviders")
-	public static Map<String, EventQueueProvider> providers; //TODO this is a leaky abstraction, when the static injection is moved to singleton this will be fixed
-
-	private EventQueues() {
+	public EventQueues(@Named("EventQueueProviders") Map<String, EventQueueProvider> providers, ParametersUtils parametersUtils) {
+	    this.providers = providers;
+	    this.parametersUtils = parametersUtils;
 	}
 
-	public static List<String> providers() {
+	public List<String> getProviders() {
 		return providers.values().stream()
 				.map(p -> p.getClass().getName())
 				.collect(Collectors.toList());
 	}
 
-	public static ObservableQueue getQueue(String eventType) {
+	public ObservableQueue getQueue(String eventType) {
 		String event = parametersUtils.replace(eventType).toString();
 		int index = event.indexOf(':');
 		if (index == -1) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/Code.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/Code.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.core.execution;
 
 import java.util.HashMap;

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -151,7 +151,7 @@ public class DeciderService {
             TaskDef taskDefinition = metadataDAO.getTaskDef(pendingTask.getTaskDefName());
             if (taskDefinition != null) {
                 checkForTimeout(taskDefinition, pendingTask);
-                // If the task has not been updated for "responseTimeout" then mark task as TIMED_OUT
+                // If the task has not been updated for "responseTimeoutSeconds" then mark task as TIMED_OUT
                 if (isResponseTimedOut(taskDefinition, pendingTask)) {
                     timeoutTask(pendingTask);
                 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,13 +36,11 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 /**
- *
- *
- *
+ * Used to parse and resolve the JSONPath bindings in the workflow and task definitions.
  */
 public class ParametersUtils {
 
-    private ObjectMapper om = new ObjectMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private TypeReference<Map<String, Object>> map = new TypeReference<Map<String, Object>>() {
     };
@@ -54,7 +52,6 @@ public class ParametersUtils {
     }
 
     public ParametersUtils() {
-
     }
 
     public Map<String, Object> getTaskInput(Map<String, Object> inputParams, Workflow workflow,
@@ -80,69 +77,68 @@ public class ParametersUtils {
 
         Map<String, Map<String, Object>> inputMap = new HashMap<>();
 
-        Map<String, Object> wf = new HashMap<>();
-        wf.put("input", workflow.getInput());
-        wf.put("output", workflow.getOutput());
-        wf.put("status", workflow.getStatus());
-        wf.put("workflowId", workflow.getWorkflowId());
-        wf.put("parentWorkflowId", workflow.getParentWorkflowId());
-        wf.put("parentWorkflowTaskId", workflow.getParentWorkflowTaskId());
-        wf.put("workflowType", workflow.getWorkflowType());
-        wf.put("version", workflow.getVersion());
-        wf.put("correlationId", workflow.getCorrelationId());
-        wf.put("reasonForIncompletion", workflow.getReasonForIncompletion());
-        wf.put("schemaVersion", workflow.getSchemaVersion());
+        Map<String, Object> workflowParams = new HashMap<>();
+        workflowParams.put("input", workflow.getInput());
+        workflowParams.put("output", workflow.getOutput());
+        workflowParams.put("status", workflow.getStatus());
+        workflowParams.put("workflowId", workflow.getWorkflowId());
+        workflowParams.put("parentWorkflowId", workflow.getParentWorkflowId());
+        workflowParams.put("parentWorkflowTaskId", workflow.getParentWorkflowTaskId());
+        workflowParams.put("workflowType", workflow.getWorkflowType());
+        workflowParams.put("version", workflow.getVersion());
+        workflowParams.put("correlationId", workflow.getCorrelationId());
+        workflowParams.put("reasonForIncompletion", workflow.getReasonForIncompletion());
+        workflowParams.put("schemaVersion", workflow.getSchemaVersion());
 
-        inputMap.put("workflow", wf);
-        //For new work flow being started the list of tasks will be empty
+        inputMap.put("workflow", workflowParams);
+
+        //For new workflow being started the list of tasks will be empty
         workflow.getTasks().stream()
                 .map(Task::getReferenceTaskName)
-                .map(taskRefName -> workflow.getTaskByRefName(taskRefName))
+                .map(workflow::getTaskByRefName)
                 .forEach(task -> {
-                    Map<String, Object> taskIO = new HashMap<>();
-                    taskIO.put("input", task.getInputData());
-                    taskIO.put("output", task.getOutputData());
-                    taskIO.put("taskType", task.getTaskType());
+                    Map<String, Object> taskParams = new HashMap<>();
+                    taskParams.put("input", task.getInputData());
+                    taskParams.put("output", task.getOutputData());
+                    taskParams.put("taskType", task.getTaskType());
                     if (task.getStatus() != null) {
-                        taskIO.put("status", task.getStatus().toString());
+                        taskParams.put("status", task.getStatus().toString());
                     }
-                    taskIO.put("referenceTaskName", task.getReferenceTaskName());
-                    taskIO.put("retryCount", task.getRetryCount());
-                    taskIO.put("correlationId", task.getCorrelationId());
-                    taskIO.put("pollCount", task.getPollCount());
-                    taskIO.put("taskDefName", task.getTaskDefName());
-                    taskIO.put("scheduledTime", task.getScheduledTime());
-                    taskIO.put("startTime", task.getStartTime());
-                    taskIO.put("endTime", task.getEndTime());
-                    taskIO.put("workflowInstanceId", task.getWorkflowInstanceId());
-                    taskIO.put("taskId", task.getTaskId());
-                    taskIO.put("reasonForIncompletion", task.getReasonForIncompletion());
-                    taskIO.put("callbackAfterSeconds", task.getCallbackAfterSeconds());
-                    taskIO.put("workerId", task.getWorkerId());
-                    inputMap.put(task.getReferenceTaskName(), taskIO);
+                    taskParams.put("referenceTaskName", task.getReferenceTaskName());
+                    taskParams.put("retryCount", task.getRetryCount());
+                    taskParams.put("correlationId", task.getCorrelationId());
+                    taskParams.put("pollCount", task.getPollCount());
+                    taskParams.put("taskDefName", task.getTaskDefName());
+                    taskParams.put("scheduledTime", task.getScheduledTime());
+                    taskParams.put("startTime", task.getStartTime());
+                    taskParams.put("endTime", task.getEndTime());
+                    taskParams.put("workflowInstanceId", task.getWorkflowInstanceId());
+                    taskParams.put("taskId", task.getTaskId());
+                    taskParams.put("reasonForIncompletion", task.getReasonForIncompletion());
+                    taskParams.put("callbackAfterSeconds", task.getCallbackAfterSeconds());
+                    taskParams.put("workerId", task.getWorkerId());
+                    inputMap.put(task.getReferenceTaskName(), taskParams);
                 });
 
         Configuration option = Configuration.defaultConfiguration()
                 .addOptions(Option.SUPPRESS_EXCEPTIONS);
         DocumentContext documentContext = JsonPath.parse(inputMap, option);
-        Map<String, Object> replaced = replace(inputParams, documentContext, taskId);
-        return replaced;
+        return replace(inputParams, documentContext, taskId);
     }
 
     //deep clone using json - POJO
     private Map<String, Object> clone(Map<String, Object> inputTemplate) {
         try {
 
-            byte[] bytes = om.writeValueAsBytes(inputTemplate);
-            Map<String, Object> cloned = om.readValue(bytes, map);
-            return cloned;
+            byte[] bytes = objectMapper.writeValueAsBytes(inputTemplate);
+            return objectMapper.readValue(bytes, map);
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new RuntimeException("Unable to clone input params", e);
         }
     }
 
     public Map<String, Object> replace(Map<String, Object> input, Object json) {
-        Object doc = null;
+        Object doc;
         if (json instanceof String) {
             doc = JsonPath.parse(json.toString());
         } else {
@@ -293,6 +289,4 @@ public class ParametersUtils {
         });
         return input;
     }
-
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/TerminateWorkflowException.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/TerminateWorkflowException.java
@@ -44,5 +44,4 @@ public class TerminateWorkflowException extends RuntimeException {
         this.workflowStatus = workflowStatus;
         this.task = task;
     }
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -34,6 +34,7 @@ import com.netflix.conductor.core.WorkflowContext;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException.Code;
 import com.netflix.conductor.core.execution.DeciderService.DeciderOutcome;
+import com.netflix.conductor.core.execution.tasks.SubWorkflow;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.QueueUtils;
@@ -82,18 +83,17 @@ public class WorkflowExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutor.class);
 
-    private MetadataDAO metadataDAO;
+    private final MetadataDAO metadataDAO;
 
-    private ExecutionDAO executionDAO;
+    private final ExecutionDAO executionDAO;
 
-    private QueueDAO queueDAO;
+    private final QueueDAO queueDAO;
 
-    private DeciderService deciderService;
+    private final DeciderService deciderService;
 
-    private Configuration config;
+    private final Configuration config;
 
-
-    private ParametersUtils parametersUtils = new ParametersUtils();
+    private final ParametersUtils parametersUtils;
 
     public static final String deciderQueue = "_deciderQueue";
 
@@ -101,12 +101,13 @@ public class WorkflowExecutor {
 
     @Inject
     public WorkflowExecutor(DeciderService deciderService, MetadataDAO metadataDAO, ExecutionDAO executionDAO,
-                            QueueDAO queueDAO, Configuration config) {
+                            QueueDAO queueDAO, ParametersUtils parametersUtils, Configuration config) {
         this.deciderService = deciderService;
         this.metadataDAO = metadataDAO;
         this.executionDAO = executionDAO;
         this.queueDAO = queueDAO;
         this.config = config;
+        this.parametersUtils = parametersUtils;
 
         activeWorkerLastPollnSecs = config.getIntProperty("tasks.active.worker.lastpoll", 10);
     }
@@ -119,12 +120,12 @@ public class WorkflowExecutor {
         return startWorkflow(name, version, input, correlationId, null, null, event);
     }
 
-    public String startWorkflow(String name, int version, String correlationId, Map<String, Object> input, String event, Map<String, String> taskToDomain) {
-        return startWorkflow(name, version, input, correlationId, null, null, event, taskToDomain);
+    public String startWorkflow(String name, int version, String correlationId, Map<String, Object> input, String externalInputPayloadStoragePath, String event, Map<String, String> taskToDomain) {
+        return startWorkflow(name, version, input, externalInputPayloadStoragePath, correlationId, null, null, event, taskToDomain);
     }
 
     public String startWorkflow(String name, int version, Map<String, Object> input, String correlationId, String parentWorkflowId, String parentWorkflowTaskId, String event) {
-        return startWorkflow(name, version, input, correlationId, parentWorkflowId, parentWorkflowTaskId, event, null);
+        return startWorkflow(name, version, input, null, correlationId, parentWorkflowId, parentWorkflowTaskId, event, null);
     }
 
     private final Predicate<PollData> validateLastPolledTime = pd -> pd.getLastPollTime() > System.currentTimeMillis() - (activeWorkerLastPollnSecs * 1000);
@@ -134,17 +135,47 @@ public class WorkflowExecutor {
     private final Predicate<Task> isNonTerminalTask = task -> !task.getStatus().isTerminal();
 
     public String startWorkflow(String workflowName, int workflowVersion, Map<String, Object> workflowInput,
-                                String correlationId, String parentWorkflowId, String parentWorkflowTaskId,
-                                String event, Map<String, String> taskToDomain) {
+                                String externalInputPayloadStoragePath, String correlationId, String parentWorkflowId,
+                                String parentWorkflowTaskId, String event, Map<String, String> taskToDomain) {
 
+        // perform validations
+        validateWorkflow(workflowName, workflowVersion, workflowInput, externalInputPayloadStoragePath);
 
+        //A random UUID is assigned to the work flow instance
+        String workflowId = IDGenerator.generate();
+
+        // Persist the Workflow
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowId(workflowId);
+        workflow.setCorrelationId(correlationId);
+        workflow.setWorkflowType(workflowName);
+        workflow.setVersion(workflowVersion);
+        workflow.setInput(workflowInput);
+        workflow.setExternalInputPayloadStoragePath(externalInputPayloadStoragePath);
+        workflow.setStatus(WorkflowStatus.RUNNING);
+        workflow.setParentWorkflowId(parentWorkflowId);
+        workflow.setParentWorkflowTaskId(parentWorkflowTaskId);
+        workflow.setOwnerApp(WorkflowContext.get().getClientApp());
+        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setUpdatedBy(null);
+        workflow.setUpdateTime(null);
+        workflow.setEvent(event);
+        workflow.setTaskToDomain(taskToDomain);
+        executionDAO.createWorkflow(workflow);
+        logger.info("A new instance of workflow {} created with workflow id {}", workflowName, workflowId);
+        //then decide to see if anything needs to be done as part of the workflow
+        decide(workflowId);
+
+        return workflowId;
+    }
+
+    /**
+     * Performs validations for starting a workflow
+     *
+     * @throws ApplicationException if the validation fails
+     */
+    private void validateWorkflow(String workflowName, int workflowVersion, Map<String, Object> workflowInput, String externalStoragePath) {
         try {
-            //Check if the input to the workflow is not null
-            if (workflowInput == null) {
-                logger.error("The input for the workflow {} cannot be NULL", workflowName);
-                throw new ApplicationException(INVALID_INPUT, "NULL input passed when starting workflow");
-            }
-
             //Check if the workflow definition is valid
             WorkflowDef workflowDefinition = metadataDAO.get(workflowName, workflowVersion);
             if (workflowDefinition == null) {
@@ -163,32 +194,12 @@ public class WorkflowExecutor {
                 logger.error("Cannot find the task definitions for the following tasks used in workflow: {}", missingTaskDefs);
                 throw new ApplicationException(INVALID_INPUT, "Cannot find the task definitions for the following tasks used in workflow: " + missingTaskDefs);
             }
-            //A random UUID is assigned to the work flow instance
-            String workflowId = IDGenerator.generate();
 
-            // Persist the Workflow
-            Workflow workflow = new Workflow();
-            workflow.setWorkflowId(workflowId);
-            workflow.setCorrelationId(correlationId);
-            workflow.setWorkflowType(workflowName);
-            workflow.setVersion(workflowVersion);
-            workflow.setInput(workflowInput);
-            workflow.setStatus(WorkflowStatus.RUNNING);
-            workflow.setParentWorkflowId(parentWorkflowId);
-            workflow.setParentWorkflowTaskId(parentWorkflowTaskId);
-            workflow.setOwnerApp(WorkflowContext.get().getClientApp());
-            workflow.setCreateTime(System.currentTimeMillis());
-            workflow.setUpdatedBy(null);
-            workflow.setUpdateTime(null);
-            workflow.setEvent(event);
-            workflow.setTaskToDomain(taskToDomain);
-            executionDAO.createWorkflow(workflow);
-            logger.info("A new instance of workflow {} created with workflow id {}", workflowName, workflowId);
-            //then decide to see if anything needs to be done as part of the workflow
-            decide(workflowId);
-
-            return workflowId;
-
+            //Check if the input to the workflow is not null
+            if (workflowInput == null && StringUtils.isBlank(externalStoragePath)) {
+                logger.error("The input for the workflow {} cannot be NULL", workflowName);
+                throw new ApplicationException(INVALID_INPUT, "NULL input passed when starting workflow");
+            }
         } catch (Exception e) {
             Monitors.recordWorkflowStartError(workflowName, WorkflowContext.get().getClientApp());
             throw e;
@@ -212,7 +223,6 @@ public class WorkflowExecutor {
                 }
             }
         }
-        ;
         return workflowId;
     }
 
@@ -427,7 +437,7 @@ public class WorkflowExecutor {
 
             try {
                 WorkflowDef latestFailureWorkflow = metadataDAO.getLatest(failureWorkflow);
-                String failureWFId = startWorkflow(failureWorkflow, latestFailureWorkflow.getVersion(), input, workflowId, null, null, null);
+                String failureWFId = startWorkflow(failureWorkflow, latestFailureWorkflow.getVersion(), workflowId, input);
                 workflow.getOutput().put("conductor.failure_workflow", failureWFId);
             } catch (Exception e) {
                 logger.error("Failed to start error workflow", e);
@@ -488,6 +498,7 @@ public class WorkflowExecutor {
 
         task.setStatus(valueOf(taskResult.getStatus().name()));
         task.setOutputData(taskResult.getOutputData());
+        task.setExternalOutputPayloadStoragePath(taskResult.getExternalOutputPayloadStoragePath());
         task.setReasonForIncompletion(taskResult.getReasonForIncompletion());
         task.setWorkerId(taskResult.getWorkerId());
         task.setCallbackAfterSeconds(taskResult.getCallbackAfterSeconds());
@@ -581,16 +592,16 @@ public class WorkflowExecutor {
 
     /**
      * @param workflowId ID of the workflow to evaluate the state for
-     * @return true if the workflow has completed (success or failed), false otherwise.
+     * @return true if the workflow is in terminal state, false otherwise.
      */
     public boolean decide(String workflowId) {
 
-        //If it is a new workflow the tasks will be still empty even though include tasks is true
+        // If it is a new workflow, the tasks will be still empty even though include tasks is true
         Workflow workflow = executionDAO.getWorkflow(workflowId, true);
-        WorkflowDef def = metadataDAO.get(workflow.getWorkflowType(), workflow.getVersion());
+        WorkflowDef workflowDef = metadataDAO.get(workflow.getWorkflowType(), workflow.getVersion());
 
         try {
-            DeciderOutcome outcome = deciderService.decide(workflow, def);
+            DeciderOutcome outcome = deciderService.decide(workflow, workflowDef);
             if (outcome.isComplete) {
                 completeWorkflow(workflow);
                 return true;
@@ -629,9 +640,9 @@ public class WorkflowExecutor {
                 decide(workflowId);
             }
 
-        } catch (TerminateWorkflowException tw) {
-            logger.debug(tw.getMessage(), tw);
-            terminate(def, workflow, tw);
+        } catch (TerminateWorkflowException twe) {
+            logger.info("Execution terminated of workflow: {} of type: {}", workflowId, workflowDef.getName(), twe);
+            terminate(workflowDef, workflow, twe);
             return true;
         } catch (RuntimeException e) {
             logger.error("Error deciding workflow: {}", workflowId, e);
@@ -791,7 +802,7 @@ public class WorkflowExecutor {
         }
     }
 
-    public void setTaskDomains(List<Task> tasks, Workflow wf) {
+    private void setTaskDomains(List<Task> tasks, Workflow wf) {
         Map<String, String> taskToDomain = wf.getTaskToDomain();
         if (taskToDomain != null) {
             // Check if all tasks have the same domain "*"
@@ -950,8 +961,8 @@ public class WorkflowExecutor {
                 break;
             } else {
                 // If not found look into sub workflows
-                if (task.getTaskType().equalsIgnoreCase("SUB_WORKFLOW")) {
-                    String subWorkflowId = task.getInputData().get("subWorkflowId").toString();
+                if (task.getTaskType().equalsIgnoreCase(SubWorkflow.NAME)) {
+                    String subWorkflowId = task.getInputData().get(SubWorkflow.SUB_WORKFLOW_ID).toString();
                     if (rerunWF(subWorkflowId, taskId, taskInput, null, null)) {
                         rerunFromTask = task;
                         break;
@@ -960,7 +971,6 @@ public class WorkflowExecutor {
             }
         }
 
-
         if (rerunFromTask != null) {
             // Remove all tasks after the "rerunFromTask"
             for (Task task : workflow.getTasks()) {
@@ -968,20 +978,20 @@ public class WorkflowExecutor {
                     executionDAO.removeTask(task.getTaskId());
                 }
             }
-            if (rerunFromTask.getTaskType().equalsIgnoreCase("SUB_WORKFLOW")) {
+            if (rerunFromTask.getTaskType().equalsIgnoreCase(SubWorkflow.NAME)) {
                 // if task is sub workflow set task as IN_PROGRESS
                 rerunFromTask.setStatus(IN_PROGRESS);
-                executionDAO.updateTask(rerunFromTask);
             } else {
-                // Set the task to rerun
+                // Set the task to rerun as SCHEDULED
                 rerunFromTask.setStatus(SCHEDULED);
                 if (taskInput != null) {
                     rerunFromTask.setInputData(taskInput);
                 }
-                rerunFromTask.setExecuted(false);
-                executionDAO.updateTask(rerunFromTask);
                 addTaskToQueue(rerunFromTask);
             }
+            rerunFromTask.setExecuted(false);
+            executionDAO.updateTask(rerunFromTask);
+
             // and set workflow as RUNNING
             workflow.setStatus(WorkflowStatus.RUNNING);
             if (correlationId != null) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- */
+
 package com.netflix.conductor.core.execution;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -366,6 +364,7 @@ public class WorkflowExecutor {
 
         workflow.setStatus(WorkflowStatus.COMPLETED);
         workflow.setOutput(wf.getOutput());
+        workflow.setExternalOutputPayloadStoragePath(wf.getExternalOutputPayloadStoragePath());
         executionDAO.updateWorkflow(workflow);
         logger.debug("Completed workflow execution for {}", wf.getWorkflowId());
         executionDAO.updateTasks(wf.getTasks());
@@ -524,11 +523,7 @@ public class WorkflowExecutor {
                 taskByRefName.setWorkerId(task.getWorkerId());
                 taskByRefName.setCallbackAfterSeconds(task.getCallbackAfterSeconds());
                 WorkflowDef workflowDef = metadataDAO.get(workflowInstance.getWorkflowType(), workflowInstance.getVersion());
-                Map<String, Object> outputData = task.getOutputData();
-                if (!workflowDef.getOutputParameters().isEmpty()) {
-                    outputData = parametersUtils.getTaskInput(workflowDef.getOutputParameters(), workflowInstance, null, null);
-                }
-                workflowInstance.setOutput(outputData);
+                deciderService.updateOutput(workflowDef, workflowInstance, task);
             }
             executionDAO.updateWorkflow(workflowInstance);
             logger.debug("Task: {} has a {} status and the Workflow has been updated with failed task reference", task, task.getStatus());

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -362,6 +362,7 @@ public class WorkflowExecutor {
             throw new ApplicationException(CONFLICT, msg);
         }
 
+        deciderService.updateWorkflowOutput(wf, null);
         workflow.setStatus(WorkflowStatus.COMPLETED);
         workflow.setOutput(wf.getOutput());
         workflow.setExternalOutputPayloadStoragePath(wf.getExternalOutputPayloadStoragePath());
@@ -401,6 +402,8 @@ public class WorkflowExecutor {
         if (!workflow.getStatus().isTerminal()) {
             workflow.setStatus(WorkflowStatus.TERMINATED);
         }
+
+        deciderService.updateWorkflowOutput(workflow, null);
 
         String workflowId = workflow.getWorkflowId();
         workflow.setReasonForIncompletion(reason);
@@ -522,8 +525,8 @@ public class WorkflowExecutor {
                 taskByRefName.setReasonForIncompletion(task.getReasonForIncompletion());
                 taskByRefName.setWorkerId(task.getWorkerId());
                 taskByRefName.setCallbackAfterSeconds(task.getCallbackAfterSeconds());
-                WorkflowDef workflowDef = metadataDAO.get(workflowInstance.getWorkflowType(), workflowInstance.getVersion());
-                deciderService.updateOutput(workflowDef, workflowInstance, task);
+                //WorkflowDef workflowDef = metadataDAO.get(workflowInstance.getWorkflowType(), workflowInstance.getVersion());
+                deciderService.updateWorkflowOutput(workflowInstance, task);
             }
             executionDAO.updateWorkflow(workflowInstance);
             logger.debug("Task: {} has a {} status and the Workflow has been updated with failed task reference", task, task.getStatus());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.script.ScriptException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ public class DecisionTaskMapper implements TaskMapper {
         decisionTask.setScheduledTime(System.currentTimeMillis());
         decisionTask.setEndTime(System.currentTimeMillis());
         decisionTask.getInputData().put("case", caseValue);
-        decisionTask.getOutputData().put("caseOutput", Arrays.asList(caseValue));
+        decisionTask.getOutputData().put("caseOutput", Collections.singletonList(caseValue));
         decisionTask.setTaskId(taskId);
         decisionTask.setStatus(Task.Status.IN_PROGRESS);
         decisionTask.setWorkflowTask(taskToSchedule);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -225,6 +225,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * @throws TerminateWorkflowException : In case of input parameters of the dynamic fork tasks not represented as {@link Map}
      * @return: a {@link Pair} representing the list of dynamic fork tasks in {@link Pair#getLeft()} and the input for the dynamic fork tasks in {@link Pair#getRight()}
      */
+    @SuppressWarnings("unchecked")
     @VisibleForTesting
     Pair<List<WorkflowTask>, Map<String, Map<String, Object>>> getDynamicForkTasksAndInput(WorkflowTask taskToSchedule, Workflow workflowInstance,
                                                                                            String dynamicForkTaskParam) throws TerminateWorkflowException {

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -28,7 +28,7 @@ import com.netflix.conductor.dao.MetadataDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +49,6 @@ public class SimpleTaskMapper implements TaskMapper {
         this.parametersUtils = parametersUtils;
         this.metadataDAO = metadataDAO;
     }
-
 
     /**
      * This method maps a {@link WorkflowTask} of type {@link WorkflowTask.Type#SIMPLE}
@@ -93,6 +92,6 @@ public class SimpleTaskMapper implements TaskMapper {
         simpleTask.setResponseTimeoutSeconds(taskDefinition.getResponseTimeoutSeconds());
         simpleTask.setWorkflowTask(taskToSchedule);
         simpleTask.setRetriedTaskId(retriedTaskId);
-        return Arrays.asList(simpleTask);
+        return Collections.singletonList(simpleTask);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,6 @@ public class WaitTaskMapper implements TaskMapper {
         waitTask.setTaskId(taskId);
         waitTask.setStatus(Task.Status.IN_PROGRESS);
         waitTask.setWorkflowTask(taskToSchedule);
-        return Arrays.asList(waitTask);
+        return Collections.singletonList(waitTask);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -37,6 +37,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 
 	private static final Logger logger = LoggerFactory.getLogger(SubWorkflow.class);
 	public static final String NAME = "SUB_WORKFLOW";
+	public static final String SUB_WORKFLOW_ID = "subWorkflowId";
 
 	public SubWorkflow() {
 		super(NAME);
@@ -56,9 +57,9 @@ public class SubWorkflow extends WorkflowSystemTask {
 		String correlationId = workflow.getCorrelationId();
 		
 		try {
-			String subWorkflowId = provider.startWorkflow(name, version, wfInput, correlationId, workflow.getWorkflowId(), task.getTaskId(), null, workflow.getTaskToDomain());
-			task.getOutputData().put("subWorkflowId", subWorkflowId);
-			task.getInputData().put("subWorkflowId", subWorkflowId);
+			String subWorkflowId = provider.startWorkflow(name, version, wfInput, null, correlationId, workflow.getWorkflowId(), task.getTaskId(), null, workflow.getTaskToDomain());
+			task.getOutputData().put(SUB_WORKFLOW_ID, subWorkflowId);
+			task.getInputData().put(SUB_WORKFLOW_ID, subWorkflowId);
 			task.setStatus(Status.IN_PROGRESS);
 		} catch (Exception e) {
 			task.setStatus(Status.FAILED);
@@ -69,9 +70,9 @@ public class SubWorkflow extends WorkflowSystemTask {
 	
 	@Override
 	public boolean execute(Workflow workflow, Task task, WorkflowExecutor provider) {
-		String workflowId = (String) task.getOutputData().get("subWorkflowId");
+		String workflowId = (String) task.getOutputData().get(SUB_WORKFLOW_ID);
 		if (workflowId == null) {
-			workflowId = (String) task.getInputData().get("subWorkflowId");	//Backward compatibility
+			workflowId = (String) task.getInputData().get(SUB_WORKFLOW_ID);	//Backward compatibility
 		}
 		
 		if(StringUtils.isEmpty(workflowId)) {
@@ -94,9 +95,9 @@ public class SubWorkflow extends WorkflowSystemTask {
 	
 	@Override
 	public void cancel(Workflow workflow, Task task, WorkflowExecutor provider) {
-		String workflowId = (String) task.getOutputData().get("subWorkflowId");
+		String workflowId = (String) task.getOutputData().get(SUB_WORKFLOW_ID);
 		if(workflowId == null) {
-			workflowId = (String) task.getInputData().get("subWorkflowId");	//Backward compatibility
+			workflowId = (String) task.getInputData().get(SUB_WORKFLOW_ID);	//Backward compatibility
 		}
 		
 		if(StringUtils.isEmpty(workflowId)) {

--- a/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
 public class DummyPayloadStorage implements ExternalPayloadStorage {
 
     @Override
-    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType) {
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path) {
         return null;
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.core.utils;
+
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+
+import java.io.InputStream;
+
+/**
+ *
+ */
+public class DummyPayloadStorage implements ExternalPayloadStorage {
+
+    @Override
+    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+        return null;
+    }
+
+    @Override
+    public void upload(String path, InputStream payload, long payloadSize) {
+    }
+
+    @Override
+    public InputStream download(String path) {
+        return null;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/DummyPayloadStorage.java
@@ -22,12 +22,12 @@ import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import java.io.InputStream;
 
 /**
- *
+ * A dummy implementation of {@link ExternalPayloadStorage} used when no external payload is configured
  */
 public class DummyPayloadStorage implements ExternalPayloadStorage {
 
     @Override
-    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType) {
         return null;
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.utils;
+
+import com.amazonaws.util.IOUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage.PayloadType;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides utility functions to upload and download payloads to {@link ExternalPayloadStorage}
+ */
+public class ExternalPayloadStorageUtils {
+    private static final Logger logger = LoggerFactory.getLogger(ExternalPayloadStorageUtils.class);
+
+    private final ExternalPayloadStorage externalPayloadStorage;
+    private final Configuration configuration;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    public ExternalPayloadStorageUtils(ExternalPayloadStorage externalPayloadStorage, Configuration configuration) {
+        this.externalPayloadStorage = externalPayloadStorage;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Download the payload from the given path
+     *
+     * @param path the relative path of the payload in the {@link ExternalPayloadStorage}
+     * @return the payload object
+     * @throws ApplicationException in case of JSON parsing errors or download errors
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> downloadPayload(String path) {
+        try (InputStream inputStream = externalPayloadStorage.download(path)) {
+            return objectMapper.readValue(IOUtils.toString(inputStream), Map.class);
+        } catch (IOException e) {
+            logger.error("Unable to download payload from external storage path: {}", path, e);
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, e);
+        }
+    }
+
+    /**
+     * Verify the payload size and upload to external storage if necessary.
+     *
+     * @param entity      the task or workflow for which the payload is to be verified and uploaded
+     * @param payloadType the {@link PayloadType} of the payload
+     * @param <T>         {@link Task} or {@link Workflow}
+     * @throws ApplicationException       in case of JSON parsing errors or upload errors
+     * @throws TerminateWorkflowException if the payload size is bigger than permissible limit as per {@link Configuration}
+     */
+    public <T> void verifyAndUpload(T entity, PayloadType payloadType) {
+        long threshold = 0L;
+        long maxThreshold = 0L;
+        Map<String, Object> payload = new HashMap<>();
+        String workflowId = "";
+        switch (payloadType) {
+            case TASK_INPUT:
+                threshold = configuration.getTaskInputPayloadSizeThresholdKB();
+                maxThreshold = configuration.getMaxTaskInputPayloadSizeThresholdKB();
+                payload = ((Task) entity).getInputData();
+                workflowId = ((Task) entity).getWorkflowInstanceId();
+                break;
+            case TASK_OUTPUT:
+                threshold = configuration.getTaskOutputPayloadSizeThresholdKB();
+                maxThreshold = configuration.getMaxTaskOutputPayloadSizeThresholdKB();
+                payload = ((Task) entity).getOutputData();
+                workflowId = ((Task) entity).getWorkflowInstanceId();
+                break;
+            case WORKFLOW_INPUT:
+                threshold = configuration.getWorkflowInputPayloadSizeThresholdKB();
+                maxThreshold = configuration.getMaxWorkflowInputPayloadSizeThresholdKB();
+                payload = ((Workflow) entity).getInput();
+                workflowId = ((Workflow) entity).getWorkflowId();
+                break;
+            case WORKFLOW_OUTPUT:
+                threshold = configuration.getWorkflowOutputPayloadSizeThresholdKB();
+                maxThreshold = configuration.getMaxWorkflowOutputPayloadSizeThresholdKB();
+                payload = ((Workflow) entity).getOutput();
+                workflowId = ((Workflow) entity).getWorkflowId();
+                break;
+        }
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            objectMapper.writeValue(byteArrayOutputStream, payload);
+            byte[] payloadBytes = byteArrayOutputStream.toByteArray();
+            long payloadSize = payloadBytes.length / 1024;
+            if (payloadSize > threshold) {
+                if (payloadSize > maxThreshold) {
+                    if (entity instanceof Task) {
+                        String errorMsg = String.format("The payload size: %dKB of task: %s in workflow: %s  is greater than the permissible limit: %dKB", payloadSize, ((Task) entity).getTaskId(), ((Task) entity).getWorkflowInstanceId(), maxThreshold);
+                        failTask(((Task) entity), payloadType, errorMsg);
+                    } else {
+                        String errorMsg = String.format("The output payload size: %dKB of workflow: %s is greater than the permissible limit: %dKB", payloadSize, ((Workflow) entity).getWorkflowId(), maxThreshold);
+                        failWorkflow(errorMsg);
+                    }
+                }
+
+                switch (payloadType) {
+                    case TASK_INPUT:
+                        ((Task) entity).setInputData(null);
+                        ((Task) entity).setExternalInputPayloadStoragePath(uploadHelper(payloadBytes, payloadSize, PayloadType.TASK_INPUT));
+                        break;
+                    case TASK_OUTPUT:
+                        ((Task) entity).setOutputData(null);
+                        ((Task) entity).setExternalOutputPayloadStoragePath(uploadHelper(payloadBytes, payloadSize, PayloadType.TASK_OUTPUT));
+                        break;
+                    case WORKFLOW_INPUT:
+                        ((Workflow) entity).setInput(null);
+                        ((Workflow) entity).setExternalInputPayloadStoragePath(uploadHelper(payloadBytes, payloadSize, PayloadType.WORKFLOW_INPUT));
+                        break;
+                    case WORKFLOW_OUTPUT:
+                        ((Workflow) entity).setOutput(null);
+                        ((Workflow) entity).setExternalOutputPayloadStoragePath(uploadHelper(payloadBytes, payloadSize, PayloadType.WORKFLOW_OUTPUT));
+                        break;
+                }
+            }
+        } catch (IOException e) {
+            logger.error("Unable to upload payload to external storage for workflow: {}", workflowId, e);
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, e);
+        }
+    }
+
+    @VisibleForTesting
+    String uploadHelper(byte[] payloadBytes, long payloadSize, ExternalPayloadStorage.PayloadType payloadType) {
+        ExternalStorageLocation location = externalPayloadStorage.getLocation(ExternalPayloadStorage.Operation.WRITE, payloadType, "");
+        externalPayloadStorage.upload(location.getPath(), new ByteArrayInputStream(payloadBytes), payloadSize);
+        return location.getPath();
+    }
+
+    @VisibleForTesting
+    void failTask(Task task, PayloadType payloadType, String errorMsg) {
+        logger.error(errorMsg);
+        task.setReasonForIncompletion(errorMsg);
+        task.setStatus(Task.Status.FAILED_WITH_TERMINAL_ERROR);
+        if (payloadType == PayloadType.TASK_INPUT) {
+            task.setInputData(null);
+        } else {
+            task.setOutputData(null);
+        }
+        throw new TerminateWorkflowException(errorMsg, Workflow.WorkflowStatus.FAILED, task);
+    }
+
+    private void failWorkflow(String errorMsg) {
+        logger.error(errorMsg);
+        throw new TerminateWorkflowException(errorMsg);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/utils/JsonUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/JsonUtils.java
@@ -91,7 +91,7 @@ public class JsonUtils {
         try {
             return objectMapper.readValue(jsonAsString, Object.class);
         } catch (Exception e) {
-            logger.error("Error parsing json string: {}", jsonAsString, e);
+            logger.info("Unable to parse (json?) string: {}", jsonAsString, e);
             return jsonAsString;
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
@@ -29,6 +29,7 @@ import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
      * @return a {@link ExternalStorageLocation} object which contains the pre-signed URL and the s3 object key for the json payload
      */
     @Override
-    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType) {
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path) {
         try {
             ExternalStorageLocation externalStorageLocation = new ExternalStorageLocation();
 
@@ -78,7 +79,12 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
                 httpMethod = HttpMethod.PUT;
             }
 
-            String objectKey = getObjectKey(payloadType);
+            String objectKey;
+            if (StringUtils.isNotBlank(path)) {
+                objectKey = path;
+            } else {
+                objectKey = getObjectKey(payloadType);
+            }
             externalStorageLocation.setPath(objectKey);
 
             GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, objectKey)

--- a/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.core.utils;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.ApplicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.Date;
+
+/**
+ * An implementation of {@link ExternalPayloadStorage} using AWS S3 for storing large JSON payload data.
+ * The S3 client assumes that access to S3 is configured on the instance.
+ * see <a href="https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/index.html?com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html">DefaultAWSCredentialsProviderChain</a>
+ */
+@Singleton
+public class S3PayloadStorage implements ExternalPayloadStorage {
+    private static final Logger logger = LoggerFactory.getLogger(S3PayloadStorage.class);
+    private static final String CONTENT_TYPE = "application/json";
+
+    private final AmazonS3 s3Client;
+    private final String bucketName;
+    private final int expirationSec;
+
+    @Inject
+    public S3PayloadStorage(Configuration config) {
+        s3Client = AmazonS3ClientBuilder.standard().withRegion("us-east-1").build();
+        bucketName = config.getProperty("s3bucket", "");
+        expirationSec = config.getIntProperty("s3signedurlexpirationseconds", 3600);
+    }
+
+    /**
+     * @param operation   the type of {@link Operation} to be performed
+     * @param payloadType the {@link PayloadType} that is being accessed
+     * @return a {@link ExternalStorageLocation} object which contains the pre-signed URL and the s3 object key for the json payload
+     */
+    @Override
+    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+        try {
+            ExternalStorageLocation externalStorageLocation = new ExternalStorageLocation();
+
+            Date expiration = new Date();
+            long expTimeMillis = expiration.getTime() + 1000 * expirationSec;
+            expiration.setTime(expTimeMillis);
+
+            HttpMethod httpMethod = HttpMethod.GET;
+            if (operation == Operation.WRITE) {
+                httpMethod = HttpMethod.PUT;
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (payloadType == PayloadType.WORKFLOW_INPUT) {
+                stringBuilder.append("workflow/input/");
+            } else if (payloadType == PayloadType.WORKFLOW_OUTPUT) {
+                stringBuilder.append("workflow/output/");
+            } else if (payloadType == PayloadType.TASK_INPUT) {
+                stringBuilder.append("task/input/");
+            } else {
+                stringBuilder.append("task/output/");
+            }
+            stringBuilder.append(IDGenerator.generate()).append(".json");
+            String objectKey = stringBuilder.toString();
+            externalStorageLocation.setPath(objectKey);
+
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, objectKey)
+                    .withMethod(httpMethod)
+                    .withExpiration(expiration);
+
+            externalStorageLocation.setUri(s3Client.generatePresignedUrl(generatePresignedUrlRequest).toURI().toASCIIString());
+            return externalStorageLocation;
+        } catch (SdkClientException e) {
+            String msg = "Error communicating with S3";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        } catch (URISyntaxException e) {
+            String msg = "Invalid URI Syntax";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, msg, e);
+        }
+    }
+
+    @Override
+    public void upload(String path, InputStream payload, long payloadSize) {
+        try {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(CONTENT_TYPE);
+            objectMetadata.setContentLength(payloadSize);
+            PutObjectRequest request = new PutObjectRequest(bucketName, path, payload, objectMetadata);
+            s3Client.putObject(request);
+        } catch (SdkClientException e) {
+            String msg = "Error communicating with S3";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+
+    @Override
+    public InputStream download(String path) {
+        try {
+            S3Object s3Object = s3Client.getObject(new GetObjectRequest(bucketName, path));
+            return s3Object.getObjectContent();
+        } catch (SdkClientException e) {
+            String msg = "Error communicating with S3";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java
@@ -56,8 +56,8 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
     @Inject
     public S3PayloadStorage(Configuration config) {
         s3Client = AmazonS3ClientBuilder.standard().withRegion("us-east-1").build();
-        bucketName = config.getProperty("s3bucket", "");
-        expirationSec = config.getIntProperty("s3signedurlexpirationseconds", 5);
+        bucketName = config.getProperty("workflow.external.payload.storage.s3.bucket", "");
+        expirationSec = config.getIntProperty("workflow.external.payload.storage.s3.signedurlexpirationseconds", 5);
     }
 
     /**
@@ -104,6 +104,14 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
         }
     }
 
+    /**
+     * Uploads the payload to the given s3 object key.
+     * It is expected that the caller retrieves the object key using {@link #getLocation(Operation, PayloadType, String)} before making this call.
+     *
+     * @param path        the s3 key of the object to be uploaded
+     * @param payload     an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     */
     @Override
     public void upload(String path, InputStream payload, long payloadSize) {
         try {
@@ -120,6 +128,8 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
     }
 
     /**
+     * Downloads the payload stored in the s3 object.
+     *
      * @param path the S3 key of the object
      * @return an input stream containing the contents of the object
      * Caller is expected to close the input stream.

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -247,4 +247,8 @@ public class Monitors {
 	public static void recordDaoPayloadSize(String dao, String action, String taskType, String workflowType, int size) {
 		gauge(classQualifier, "dao_payload_size", size, "dao", dao, "action", action, "taskType", taskType, "workflowType", workflowType);
 	}
+
+	public static void recordExternalPayloadStorageUsage(String name, String operation, String payloadType) {
+		counter(classQualifier, "external_payload_storage_usage", "name", name, "operation", operation, "payloadType", payloadType);
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/AdminService.java
+++ b/core/src/main/java/com/netflix/conductor/service/AdminService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.service;
 
 import com.netflix.conductor.annotations.Trace;

--- a/core/src/main/java/com/netflix/conductor/service/EventService.java
+++ b/core/src/main/java/com/netflix/conductor/service/EventService.java
@@ -1,12 +1,10 @@
 package com.netflix.conductor.service;
 
-import com.google.common.base.Preconditions;
 import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.core.events.EventProcessor;
 import com.netflix.conductor.core.events.EventQueues;
 import com.netflix.conductor.service.utils.ServiceUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -21,13 +19,14 @@ import java.util.Map;
 public class EventService {
 
     private final MetadataService metadataService;
-
     private final EventProcessor eventProcessor;
+    private final EventQueues eventQueues;
 
     @Inject
-    public EventService(MetadataService metadataService, EventProcessor eventProcessor) {
+    public EventService(MetadataService metadataService, EventProcessor eventProcessor, EventQueues eventQueues) {
         this.metadataService = metadataService;
         this.eventProcessor = eventProcessor;
+        this.eventQueues = eventQueues;
     }
 
     /**
@@ -88,6 +87,6 @@ public class EventService {
      * @return list of registered queue providers.
      */
     public List<String> getEventQueueProviders() {
-        return EventQueues.providers();
+        return eventQueues.getProviders();
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/EventService.java
+++ b/core/src/main/java/com/netflix/conductor/service/EventService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.service;
 
 import com.netflix.conductor.annotations.Trace;

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -104,7 +104,7 @@ public class ExecutionService {
         this.maxSearchSize = config.getIntProperty("workflow.max.search.size", 5_000);
 	}
 
-	public Task poll(String taskType, String workerId) throws Exception {
+	public Task poll(String taskType, String workerId) {
 		return poll(taskType, workerId, null);
 	}
 	public Task poll(String taskType, String workerId, String domain) {
@@ -172,7 +172,7 @@ public class ExecutionService {
 
 	public List<PollData> getAllPollData() {
 		Map<String, Long> queueSizes = queueDAO.queuesDetail();
-		List<PollData> allPollData = new ArrayList<PollData>();
+		List<PollData> allPollData = new ArrayList<>();
 		queueSizes.keySet().forEach(k -> {
 			try {
 				if(!k.contains(QueueUtils.DOMAIN_SEPARATOR)){
@@ -210,8 +210,8 @@ public class ExecutionService {
 	/**
 	 * This method removes the task from the un-acked Queue
 	 *
-	 * @param taskId: the taskId that needs to be updated and removed from the unacked queueDAO
-	 * @return True in case of successful removal of the taskId from the un-acked queueDAO
+	 * @param taskId: the taskId that needs to be updated and removed from the unacked queue
+	 * @return True in case of successful removal of the taskId from the un-acked queue
 	 */
 	public boolean ackTaskReceived(String taskId) {
 		return Optional.ofNullable(getTask(taskId))
@@ -457,7 +457,7 @@ public class ExecutionService {
      * @param payloadType the {@link PayloadType} at the external uri
      * @return the external uri at which the payload is stored/to be stored
      */
-	public ExternalStorageLocation getPayloadUri(Operation operation, PayloadType payloadType) {
-		return externalPayloadStorage.getExternalUri(operation, payloadType);
+	public ExternalStorageLocation getExternalStorageLocation(Operation operation, PayloadType payloadType) {
+		return externalPayloadStorage.getLocation(operation, payloadType);
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -455,9 +455,10 @@ public class ExecutionService {
      *
      * @param operation the type of {@link Operation} to be performed
      * @param payloadType the {@link PayloadType} at the external uri
+	 * @param path the path for which the external storage location is to be populated
      * @return the external uri at which the payload is stored/to be stored
      */
-	public ExternalStorageLocation getExternalStorageLocation(Operation operation, PayloadType payloadType) {
-		return externalPayloadStorage.getLocation(operation, payloadType);
+	public ExternalStorageLocation getExternalStorageLocation(Operation operation, PayloadType payloadType, String path) {
+		return externalPayloadStorage.getLocation(operation, payloadType, path);
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataService.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataService.java
@@ -18,7 +18,6 @@
  */
 package com.netflix.conductor.service;
 
-import com.google.common.base.Preconditions;
 import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -42,12 +41,14 @@ import java.util.List;
 @Trace
 public class MetadataService {
 
-    private MetadataDAO metadataDAO;
+    private final MetadataDAO metadataDAO;
+    private final EventQueues eventQueues;
 
 
     @Inject
-    public MetadataService(MetadataDAO metadataDAO) {
+    public MetadataService(MetadataDAO metadataDAO, EventQueues eventQueues) {
         this.metadataDAO = metadataDAO;
+        this.eventQueues = eventQueues;
     }
 
     /**
@@ -237,6 +238,6 @@ public class MetadataService {
         ServiceUtils.checkNotNullOrEmpty(eh.getEvent(), "Missing event location");
         ServiceUtils.checkNotNullOrEmpty(eh.getActions(), "No actions specified. Please specify at-least one action");
         String event = eh.getEvent();
-        EventQueues.getQueue(event);
+        eventQueues.getQueue(event);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -21,8 +21,10 @@ import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.service.utils.ServiceUtils;
@@ -60,9 +62,10 @@ public class TaskService {
 
     /**
      * Poll for a task of a certain type.
+     *
      * @param taskType Task name
      * @param workerId Id of the workflow
-     * @param domain Domain of the workflow
+     * @param domain   Domain of the workflow
      * @return polled {@link Task}
      */
     public Task poll(String taskType, String workerId, String domain) {
@@ -78,11 +81,12 @@ public class TaskService {
 
     /**
      * Batch Poll for a task of a certain type.
+     *
      * @param taskType Task Name
      * @param workerId Id of the workflow
-     * @param domain Domain of the workflow
-     * @param count Number of tasks
-     * @param timeout Timeout for polling in milliseconds
+     * @param domain   Domain of the workflow
+     * @param count    Number of tasks
+     * @param timeout  Timeout for polling in milliseconds
      * @return list of {@link Task}
      */
     public List<Task> batchPoll(String taskType, String workerId, String domain, Integer count, Integer timeout) {
@@ -98,9 +102,10 @@ public class TaskService {
 
     /**
      * Get in progress tasks. The results are paginated.
+     *
      * @param taskType Task Name
      * @param startKey Start index of pagination
-     * @param count Number of entries
+     * @param count    Number of entries
      * @return list of {@link Task}
      */
     public List<Task> getTasks(String taskType, String startKey, Integer count) {
@@ -110,7 +115,8 @@ public class TaskService {
 
     /**
      * Get in progress task for a given workflow id.
-     * @param workflowId Id of the workflow
+     *
+     * @param workflowId        Id of the workflow
      * @param taskReferenceName Task reference name.
      * @return instance of {@link Task}
      */
@@ -122,6 +128,7 @@ public class TaskService {
 
     /**
      * Updates a task.
+     *
      * @param taskResult Instance of {@link TaskResult}
      * @return task Id of the updated task.
      */
@@ -137,7 +144,8 @@ public class TaskService {
 
     /**
      * Ack Task is received.
-     * @param taskId Id of the task
+     *
+     * @param taskId   Id of the task
      * @param workerId Id of the worker
      * @return `true|false` if task if received or not
      */
@@ -149,8 +157,9 @@ public class TaskService {
 
     /**
      * Log Task Execution Details.
+     *
      * @param taskId Id of the task
-     * @param log Details you want to log
+     * @param log    Details you want to log
      */
     public void log(String taskId, String log) {
         ServiceUtils.checkNotNullOrEmpty(taskId, "TaskId cannot be null or empty.");
@@ -159,6 +168,7 @@ public class TaskService {
 
     /**
      * Get Task Execution Logs.
+     *
      * @param taskId Id of the task.
      * @return list of {@link TaskExecLog}
      */
@@ -169,6 +179,7 @@ public class TaskService {
 
     /**
      * Get task by Id.
+     *
      * @param taskId Id of the task.
      * @return instance of {@link Task}
      */
@@ -180,8 +191,9 @@ public class TaskService {
 
     /**
      * Remove Task from a Task type queue.
+     *
      * @param taskType Task Name
-     * @param taskId ID of the task
+     * @param taskId   ID of the task
      */
     public void removeTaskFromQueue(String taskType, String taskId) {
         ServiceUtils.checkNotNullOrEmpty(taskType, "TaskType cannot be null or empty.");
@@ -191,6 +203,7 @@ public class TaskService {
 
     /**
      * Get Task type queue sizes.
+     *
      * @param taskTypes List of task types.
      * @return map of task type as Key and queue size as value.
      */
@@ -200,6 +213,7 @@ public class TaskService {
 
     /**
      * Get the details about each queue.
+     *
      * @return map of queue details.
      */
     public Map<String, Map<String, Map<String, Long>>> allVerbose() {
@@ -208,6 +222,7 @@ public class TaskService {
 
     /**
      * Get the details about each queue.
+     *
      * @return map of details about each queue.
      */
     public Map<String, Long> getAllQueueDetails() {
@@ -218,6 +233,7 @@ public class TaskService {
 
     /**
      * Get the last poll data for a given task type.
+     *
      * @param taskType Task Name
      * @return list of {@link PollData}
      */
@@ -229,6 +245,7 @@ public class TaskService {
 
     /**
      * Get the last poll data for all task types.
+     *
      * @return list of {@link PollData}
      */
     public List<PollData> getAllPollData() {
@@ -237,6 +254,7 @@ public class TaskService {
 
     /**
      * Requeue pending tasks for all the running workflows.
+     *
      * @return number of tasks requeued.
      */
     public String requeue() {
@@ -245,26 +263,37 @@ public class TaskService {
 
     /**
      * Requeue pending tasks.
+     *
      * @param taskType Task name.
      * @return number of tasks requeued.
      */
     public String requeuePendingTask(String taskType) {
-        ServiceUtils.checkNotNullOrEmpty(taskType,"TaskType cannot be null or empty.");
+        ServiceUtils.checkNotNullOrEmpty(taskType, "TaskType cannot be null or empty.");
         return String.valueOf(executionService.requeuePendingTasks(taskType));
     }
 
     /**
      * Search for tasks based in payload and other parameters. Use sort options as ASC or DESC e.g.
      * sort=name or sort=workflowId. If order is not specified, defaults to ASC.
-     * @param start Start index of pagination
-     * @param size  Number of entries
-     * @param sort Sorting type ASC|DESC
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
      * @param freeText Text you want to search
-     * @param query Query you want to search
+     * @param query    Query you want to search
      * @return instance of {@link SearchResult}
      */
     public SearchResult<TaskSummary> search(int start, int size, String sort, String freeText, String query) {
         return executionService.getSearchTasks(query, freeText, start, size, sort);
+    }
+
+    /**
+     * Get the external storage location where the task output payload is stored/to be stored
+     *
+     * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
+     */
+    public ExternalStorageLocation getPayloadUri() {
+        return executionService.getPayloadUri(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT);
     }
 }
 

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -292,8 +292,8 @@ public class TaskService {
      *
      * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
      */
-    public ExternalStorageLocation getPayloadUri() {
-        return executionService.getPayloadUri(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT);
+    public ExternalStorageLocation getExternalStorageLocation() {
+        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT);
     }
 }
 

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -290,10 +290,10 @@ public class TaskService {
     /**
      * Get the external storage location where the task output payload is stored/to be stored
      *
+     * @param path the path for which the external storage location is to be populated
      * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
      */
-    public ExternalStorageLocation getExternalStorageLocation() {
-        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT);
+    public ExternalStorageLocation getExternalStorageLocation(String path) {
+        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, path);
     }
 }
-

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowBulkService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowBulkService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.service;
 
 import com.google.inject.Singleton;

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -58,7 +58,7 @@ public class WorkflowService {
                             startWorkflowRequest.getVersion()));
         }
         return workflowExecutor.startWorkflow(workflowDef.getName(), workflowDef.getVersion(),
-                startWorkflowRequest.getCorrelationId(), startWorkflowRequest.getInput(), null,
+                startWorkflowRequest.getCorrelationId(), startWorkflowRequest.getInput(), startWorkflowRequest.getExternalInputPayloadStoragePath(), null,
                 startWorkflowRequest.getTaskToDomain());
 
     }
@@ -286,7 +286,7 @@ public class WorkflowService {
      *
      * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
      */
-    public ExternalStorageLocation getExternalPayloadUri() {
-        return executionService.getPayloadUri(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT);
+    public ExternalStorageLocation getExternalStorageLocation() {
+        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.service;
 
 import com.netflix.conductor.annotations.Trace;
@@ -284,9 +299,10 @@ public class WorkflowService {
     /**
      * Get the external storage location where the workflow input payload is stored/to be stored
      *
+     * @param path the path for which the external storage location is to be populated
      * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
      */
-    public ExternalStorageLocation getExternalStorageLocation() {
-        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT);
+    public ExternalStorageLocation getExternalStorageLocation(String path) {
+        return executionService.getExternalStorageLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT, path);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -5,9 +5,11 @@ import com.netflix.conductor.common.metadata.workflow.RerunWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.SkipTaskRequest;
 import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
@@ -279,4 +281,12 @@ public class WorkflowService {
         return executionService.searchWorkflowByTasks(query, freeText, start, size, ServiceUtils.convertStringToList(sort));
     }
 
+    /**
+     * Get the external storage location where the workflow input payload is stored/to be stored
+     *
+     * @return {@link ExternalStorageLocation} containing the uri and the path to the payload is stored in external storage
+     */
+    public ExternalStorageLocation getExternalPayloadUri() {
+        return executionService.getPayloadUri(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT);
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/service/utils/ServiceUtils.java
+++ b/core/src/main/java/com/netflix/conductor/service/utils/ServiceUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.service.utils;
 
 import com.google.common.base.Preconditions;

--- a/core/src/test/java/com/netflix/conductor/core/events/TestEventProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestEventProcessor.java
@@ -31,8 +31,10 @@ import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.execution.ParametersUtils;
 import com.netflix.conductor.core.execution.TestConfiguration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.DummyPayloadStorage;
 import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.service.MetadataService;
 import org.junit.Before;
@@ -74,14 +76,21 @@ public class TestEventProcessor {
     private ExecutionService executionService;
     private WorkflowExecutor workflowExecutor;
     private ActionProcessor actionProcessor;
+    private EventQueues eventQueues;
+    private ParametersUtils parametersUtils;
 
     @Before
     public void setup() {
         event = "sqs:arn:account090:sqstest1";
         queueURI = "arn:account090:sqstest1";
 
-        EventQueueProvider provider = mock(EventQueueProvider.class);
+        metadataService = mock(MetadataService.class);
+        executionService = mock(ExecutionService.class);
+        workflowExecutor = mock(WorkflowExecutor.class);
+        actionProcessor = mock(ActionProcessor.class);
+        parametersUtils = new ParametersUtils();
 
+        EventQueueProvider provider = mock(EventQueueProvider.class);
         queue = mock(ObservableQueue.class);
         Message[] messages = new Message[1];
         messages[0] = new Message("t0", "{\"Type\":\"Notification\",\"MessageId\":\"7e4e6415-01e9-5caf-abaa-37fd05d446ff\",\"Message\":\"{\\n    \\\"testKey1\\\": \\\"level1\\\",\\n    \\\"metadata\\\": {\\n      \\\"testKey2\\\": 123456 }\\n  }\",\"Timestamp\":\"2018-08-10T21:22:05.029Z\",\"SignatureVersion\":\"1\"}", "t0");
@@ -92,14 +101,10 @@ public class TestEventProcessor {
         when(queue.getName()).thenReturn(queueURI);
         when(queue.getType()).thenReturn("sqs");
         when(provider.getQueue(queueURI)).thenReturn(queue);
-        EventQueues.providers = new HashMap<>();
 
-        EventQueues.providers.put("sqs", provider);
-
-        metadataService = mock(MetadataService.class);
-        executionService = mock(ExecutionService.class);
-        workflowExecutor = mock(WorkflowExecutor.class);
-        actionProcessor = mock(ActionProcessor.class);
+        Map<String, EventQueueProvider> providers = new HashMap<>();
+        providers.put("sqs", provider);
+        eventQueues = new EventQueues(providers, parametersUtils);
     }
 
     @Test
@@ -155,9 +160,9 @@ public class TestEventProcessor {
         workflowDef.setName(startWorkflowAction.getStart_workflow().getName());
         when(metadataService.getWorkflowDef(any(), any())).thenReturn(workflowDef);
 
-        ActionProcessor actionProcessor = new ActionProcessor(workflowExecutor, metadataService);
+        ActionProcessor actionProcessor = new ActionProcessor(workflowExecutor, metadataService, parametersUtils);
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         assertNotNull(eventProcessor.getQueues());
         assertEquals(1, eventProcessor.getQueues().size());
 
@@ -214,9 +219,9 @@ public class TestEventProcessor {
         workflowDef.setName(startWorkflowAction.getStart_workflow().getName());
         when(metadataService.getWorkflowDef(any(), any())).thenReturn(workflowDef);
 
-        ActionProcessor actionProcessor = new ActionProcessor(workflowExecutor, metadataService);
+        ActionProcessor actionProcessor = new ActionProcessor(workflowExecutor, metadataService, parametersUtils);
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         assertNotNull(eventProcessor.getQueues());
         assertEquals(1, eventProcessor.getQueues().size());
 
@@ -245,7 +250,7 @@ public class TestEventProcessor {
         when(executionService.addEventExecution(any())).thenReturn(true);
         when(actionProcessor.execute(any(), any(), any(), any())).thenThrow(new ApplicationException(ApplicationException.Code.BACKEND_ERROR, "some retriable error"));
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         assertNotNull(eventProcessor.getQueues());
         assertEquals(1, eventProcessor.getQueues().size());
 
@@ -276,7 +281,7 @@ public class TestEventProcessor {
 
         when(actionProcessor.execute(any(), any(), any(), any())).thenThrow(new ApplicationException(ApplicationException.Code.INVALID_INPUT, "some non-retriable error"));
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         assertNotNull(eventProcessor.getQueues());
         assertEquals(1, eventProcessor.getQueues().size());
 
@@ -295,7 +300,7 @@ public class TestEventProcessor {
             throw new UnsupportedOperationException("error");
         }).when(actionProcessor).execute(any(), any(), any(), any());
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         EventExecution eventExecution = new EventExecution("id", "messageId");
         eventExecution.setStatus(EventExecution.Status.IN_PROGRESS);
         eventExecution.setEvent("event");
@@ -315,7 +320,7 @@ public class TestEventProcessor {
             throw new ApplicationException(ApplicationException.Code.INVALID_INPUT, "some non-retriable error");
         }).when(actionProcessor).execute(any(), any(), any(), any());
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         EventExecution eventExecution = new EventExecution("id", "messageId");
         eventExecution.setStatus(EventExecution.Status.IN_PROGRESS);
         eventExecution.setEvent("event");
@@ -336,7 +341,7 @@ public class TestEventProcessor {
             throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, "some retriable error");
         }).when(actionProcessor).execute(any(), any(), any(), any());
 
-        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, new TestConfiguration());
+        EventProcessor eventProcessor = new EventProcessor(executionService, metadataService, actionProcessor, eventQueues, new TestConfiguration());
         EventExecution eventExecution = new EventExecution("id", "messageId");
         eventExecution.setStatus(EventExecution.Status.IN_PROGRESS);
         eventExecution.setEvent("event");

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 package com.netflix.conductor.core.execution;
-/**
- * 
- */
-
-
-import java.util.Map;
 
 import com.netflix.conductor.core.config.Configuration;
+
+import java.util.Map;
 
 /**
  * @author Viren
@@ -83,6 +79,46 @@ public class TestConfiguration implements Configuration {
 	public String getRegion() {
 		return "us-east-1";
 	}
+
+	@Override
+	public Long getWorkflowInputPayloadSizeThresholdKB() {
+		return 10L;
+	}
+
+	@Override
+	public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getWorkflowOutputPayloadSizeThresholdKB() {
+		return 10L;
+	}
+
+	@Override
+	public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskInputPayloadSizeThresholdKB() {
+		return 10L;
+	}
+
+	@Override
+	public Long getMaxTaskInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskOutputPayloadSizeThresholdKB() {
+		return 10L;
+	}
+
+	@Override
+	public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
 	
 	@Override
 	public Map<String, Object> getAll() {
@@ -91,6 +127,6 @@ public class TestConfiguration implements Configuration {
 
 	@Override
 	public long getLongProperty(String name, long defaultValue) {
-		return 1000000l;
+		return 1000000L;
 	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
 import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.execution.DeciderService.DeciderOutcome;
 import com.netflix.conductor.core.execution.mapper.DecisionTaskMapper;
 import com.netflix.conductor.core.execution.mapper.DynamicTaskMapper;
@@ -86,6 +87,7 @@ public class TestDeciderOutcomes {
 		
 		MetadataDAO metadataDAO = mock(MetadataDAO.class);
 		QueueDAO queueDAO = mock(QueueDAO.class);
+		ExternalPayloadStorage externalPayloadStorage = mock(ExternalPayloadStorage.class);
 		TaskDef taskDef = new TaskDef();
 		taskDef.setRetryCount(1);
 		taskDef.setName("mockTaskDef");
@@ -104,7 +106,7 @@ public class TestDeciderOutcomes {
 		taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
 		taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 
-		this.deciderService = new DeciderService(metadataDAO, queueDAO, taskMappers);
+		this.deciderService = new DeciderService(metadataDAO, parametersUtils, queueDAO, externalPayloadStorage, taskMappers);
 	}
 
 	@Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
 import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.execution.mapper.DecisionTaskMapper;
 import com.netflix.conductor.core.execution.mapper.DynamicTaskMapper;
 import com.netflix.conductor.core.execution.mapper.EventTaskMapper;
@@ -83,6 +84,7 @@ public class TestWorkflowExecutor {
         executionDAO = mock(ExecutionDAO.class);
         metadataDAO = mock(MetadataDAO.class);
         queueDAO = mock(QueueDAO.class);
+        ExternalPayloadStorage externalPayloadStorage = mock(ExternalPayloadStorage.class);
         ObjectMapper objectMapper = new ObjectMapper();
         ParametersUtils parametersUtils = new ParametersUtils();
         Map<String, TaskMapper> taskMappers = new HashMap<>();
@@ -96,12 +98,12 @@ public class TestWorkflowExecutor {
         taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
-        DeciderService deciderService = new DeciderService(metadataDAO, queueDAO, taskMappers);
-        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, config);
+        DeciderService deciderService = new DeciderService(metadataDAO, parametersUtils, queueDAO, externalPayloadStorage, taskMappers);
+        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, parametersUtils, config);
     }
 
     @Test
-    public void testScheduleTask() throws Exception {
+    public void testScheduleTask() {
 
         AtomicBoolean httpTaskExecuted = new AtomicBoolean(false);
         AtomicBoolean http2TaskExecuted = new AtomicBoolean(false);
@@ -119,7 +121,6 @@ public class TestWorkflowExecutor {
                 task.setStatus(Status.COMPLETED);
                 super.start(workflow, task, executor);
             }
-
         };
 
         new WorkflowSystemTask("HTTP2") {
@@ -130,7 +131,6 @@ public class TestWorkflowExecutor {
                 task.setStatus(Status.COMPLETED);
                 super.start(workflow, task, executor);
             }
-
         };
 
         Workflow workflow = new Workflow();
@@ -225,7 +225,7 @@ public class TestWorkflowExecutor {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCompleteWorkflow() throws Exception {
+    public void testCompleteWorkflow() {
         Workflow workflow = new Workflow();
         workflow.setWorkflowId("1");
         workflow.setWorkflowType("test");

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -25,7 +25,6 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask.Type;
 import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.execution.mapper.DecisionTaskMapper;
 import com.netflix.conductor.core.execution.mapper.DynamicTaskMapper;
 import com.netflix.conductor.core.execution.mapper.EventTaskMapper;
@@ -39,6 +38,7 @@ import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
 import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
 import com.netflix.conductor.core.execution.tasks.Wait;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
@@ -84,7 +84,7 @@ public class TestWorkflowExecutor {
         executionDAO = mock(ExecutionDAO.class);
         metadataDAO = mock(MetadataDAO.class);
         queueDAO = mock(QueueDAO.class);
-        ExternalPayloadStorage externalPayloadStorage = mock(ExternalPayloadStorage.class);
+        ExternalPayloadStorageUtils externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         ObjectMapper objectMapper = new ObjectMapper();
         ParametersUtils parametersUtils = new ParametersUtils();
         Map<String, TaskMapper> taskMappers = new HashMap<>();
@@ -98,7 +98,7 @@ public class TestWorkflowExecutor {
         taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
-        DeciderService deciderService = new DeciderService(metadataDAO, parametersUtils, queueDAO, externalPayloadStorage, taskMappers);
+        DeciderService deciderService = new DeciderService(metadataDAO, parametersUtils, queueDAO, externalPayloadStorageUtils, taskMappers);
         workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, parametersUtils, config);
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -20,13 +19,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DecisionTaskMapperTest {
 
-    private ParametersUtils parametersUtils = new ParametersUtils();
+    private ParametersUtils parametersUtils;
     private DeciderService deciderService;
     //Subject
     private DecisionTaskMapper decisionTaskMapper;
@@ -34,14 +33,14 @@ public class DecisionTaskMapperTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-
     Map<String, Object> ip1;
     WorkflowTask task1;
     WorkflowTask task2;
     WorkflowTask task3;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
+        parametersUtils = new ParametersUtils();
 
         ip1 = new HashMap<>();
         ip1.put("p1", "workflow.input.param1");
@@ -67,7 +66,7 @@ public class DecisionTaskMapperTest {
     }
 
     @Test
-    public void getMappedTasks() throws Exception {
+    public void getMappedTasks() {
 
         //Given
         //Task Definition
@@ -134,7 +133,7 @@ public class DecisionTaskMapperTest {
     }
 
     @Test
-    public void getEvaluatedCaseValue() throws Exception {
+    public void getEvaluatedCaseValue() {
 
         WorkflowTask decisionTask = new WorkflowTask();
         decisionTask.setType(WorkflowTask.Type.DECISION.name());
@@ -163,7 +162,7 @@ public class DecisionTaskMapperTest {
     }
 
     @Test
-    public void getEvaluatedCaseValueUsingExpression() throws Exception {
+    public void getEvaluatedCaseValueUsingExpression() {
         //Given
         //Task Definition
         TaskDef taskDef = new TaskDef();
@@ -246,10 +245,5 @@ public class DecisionTaskMapperTest {
         expectedException.expectMessage("Error while evaluating the script " + decisionTask.getCaseExpression());
 
         decisionTaskMapper.getEvaluatedCaseValue(decisionTask, evaluatorInput);
-
     }
-
-
-
-
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
@@ -46,7 +46,7 @@ public class ForkJoinDynamicTaskMapperTest {
 
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         parametersUtils = Mockito.mock(ParametersUtils.class);
         objectMapper = Mockito.mock(ObjectMapper.class);
         deciderService = Mockito.mock(DeciderService.class);
@@ -56,7 +56,7 @@ public class ForkJoinDynamicTaskMapperTest {
     }
 
     @Test
-    public void getMappedTasksException() throws Exception {
+    public void getMappedTasksException() {
 
         WorkflowDef def = new WorkflowDef();
         def.setName("DYNAMIC_FORK_JOIN_WF");
@@ -134,7 +134,7 @@ public class ForkJoinDynamicTaskMapperTest {
     }
 
     @Test
-    public void getMappedTasks() throws Exception {
+    public void getMappedTasks() {
 
         WorkflowDef def = new WorkflowDef();
         def.setName("DYNAMIC_FORK_JOIN_WF");
@@ -219,7 +219,7 @@ public class ForkJoinDynamicTaskMapperTest {
 
 
     @Test
-    public void getDynamicForkJoinTasksAndInput() throws Exception {
+    public void getDynamicForkJoinTasksAndInput() {
         //Given
         WorkflowTask dynamicForkJoinToSchedule = new WorkflowTask();
         dynamicForkJoinToSchedule.setType(WorkflowTask.Type.FORK_JOIN_DYNAMIC.name());
@@ -257,7 +257,7 @@ public class ForkJoinDynamicTaskMapperTest {
     }
 
     @Test
-    public void getDynamicForkJoinTasksAndInputException() throws Exception {
+    public void getDynamicForkJoinTasksAndInputException() {
         //Given
         WorkflowTask dynamicForkJoinToSchedule = new WorkflowTask();
         dynamicForkJoinToSchedule.setType(WorkflowTask.Type.FORK_JOIN_DYNAMIC.name());
@@ -294,7 +294,7 @@ public class ForkJoinDynamicTaskMapperTest {
     }
 
     @Test
-    public void getDynamicForkTasksAndInput() throws Exception {
+    public void getDynamicForkTasksAndInput() {
         //Given
         WorkflowTask dynamicForkJoinToSchedule = new WorkflowTask();
         dynamicForkJoinToSchedule.setType(WorkflowTask.Type.FORK_JOIN_DYNAMIC.name());
@@ -336,7 +336,7 @@ public class ForkJoinDynamicTaskMapperTest {
     }
 
     @Test
-    public void getDynamicForkTasksAndInputException() throws Exception {
+    public void getDynamicForkTasksAndInputException() {
 
         //Given
         WorkflowTask dynamicForkJoinToSchedule = new WorkflowTask();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
@@ -40,15 +40,16 @@ public class SubWorkflowTaskMapperTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         parametersUtils = mock(ParametersUtils.class);
         metadataDAO = mock(MetadataDAO.class);
         subWorkflowTaskMapper = new SubWorkflowTaskMapper(parametersUtils, metadataDAO);
         deciderService = mock(DeciderService.class);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void getMappedTasks() throws Exception {
+    public void getMappedTasks() {
         //Given
         WorkflowDef workflowDef = new WorkflowDef();
         Workflow  workflowInstance = new Workflow();
@@ -90,7 +91,7 @@ public class SubWorkflowTaskMapperTest {
 
 
     @Test
-    public void getSubWorkflowParams() throws Exception {
+    public void getSubWorkflowParams() {
         WorkflowTask workflowTask = new WorkflowTask();
         SubWorkflowParams subWorkflowParams = new SubWorkflowParams();
         subWorkflowParams.setName("Foo");
@@ -101,7 +102,7 @@ public class SubWorkflowTaskMapperTest {
     }
 
     @Test
-    public void getExceptionWhenNoSubWorkflowParamsPassed() throws Exception {
+    public void getExceptionWhenNoSubWorkflowParamsPassed() {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("FooWorkFLow");
 
@@ -114,7 +115,7 @@ public class SubWorkflowTaskMapperTest {
 
 
     @Test
-    public void getSubWorkflowVersion() throws Exception {
+    public void getSubWorkflowVersion() {
         Map<String, Object> subWorkflowParamMap = new HashMap<>();
         subWorkflowParamMap.put("name","FooWorkFlow");
         subWorkflowParamMap.put("version","2");
@@ -125,7 +126,7 @@ public class SubWorkflowTaskMapperTest {
     }
 
     @Test
-    public void getSubworkflowVersionFromMeta() throws Exception {
+    public void getSubworkflowVersionFromMeta() {
         Map<String, Object> subWorkflowParamMap = new HashMap<>();
         WorkflowDef workflowDef = new WorkflowDef();
         workflowDef.setName("FooWorkFlow");
@@ -138,7 +139,7 @@ public class SubWorkflowTaskMapperTest {
     }
 
     @Test
-    public void getSubworkflowVersionFromMetaException() throws Exception {
+    public void getSubworkflowVersionFromMetaException() {
         Map<String, Object> subWorkflowParamMap = new HashMap<>();
         when(metadataDAO.getLatest(any())).thenReturn(null);
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapperTest.java
@@ -13,13 +13,12 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class WaitTaskMapperTest {
 
-
     @Test
-    public void getMappedTasks() throws Exception {
+    public void getMappedTasks() {
 
         //Given
         WorkflowTask taskToSchedule = new WorkflowTask();
@@ -46,10 +45,5 @@ public class WaitTaskMapperTest {
         //Then
         assertEquals(1, mappedTasks.size());
         assertEquals(Wait.NAME, mappedTasks.get(0).getTaskType());
-
-
-
-
     }
-
 }

--- a/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
@@ -1,0 +1,153 @@
+package com.netflix.conductor.core.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import com.netflix.conductor.core.execution.TestConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExternalPayloadStorageUtilsTest {
+
+    private ExternalPayloadStorage externalPayloadStorage;
+    private ObjectMapper objectMapper;
+    private ExternalStorageLocation location;
+
+    // Subject
+    private ExternalPayloadStorageUtils externalPayloadStorageUtils;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        externalPayloadStorage = mock(ExternalPayloadStorage.class);
+        Configuration configuration = new TestConfiguration();
+        objectMapper = new ObjectMapper();
+        location = new ExternalStorageLocation();
+        location.setPath("some/test/path");
+
+        externalPayloadStorageUtils = new ExternalPayloadStorageUtils(externalPayloadStorage, configuration);
+    }
+
+    @Test
+    public void testDownloadPayload() throws IOException {
+        String path = "test/payload";
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("key1", "value1");
+        payload.put("key2", 200);
+        byte[] payloadBytes = objectMapper.writeValueAsString(payload).getBytes();
+        when(externalPayloadStorage.download(path)).thenReturn(new ByteArrayInputStream(payloadBytes));
+
+        Map<String, Object> result = externalPayloadStorageUtils.downloadPayload(path);
+        assertNotNull(result);
+        assertEquals(payload, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadTaskPayload() throws IOException {
+        AtomicInteger uploadCount = new AtomicInteger(0);
+
+        InputStream stream = ExternalPayloadStorageUtilsTest.class.getResourceAsStream("/payload.json");
+        Map<String, Object> payload = objectMapper.readValue(stream, Map.class);
+
+        when(externalPayloadStorage.getLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_INPUT, "")).thenReturn(location);
+        doAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            return null;
+        }).when(externalPayloadStorage).upload(anyString(), any(), anyLong());
+
+        Task task = new Task();
+        task.setInputData(payload);
+        externalPayloadStorageUtils.verifyAndUpload(task, ExternalPayloadStorage.PayloadType.TASK_INPUT);
+        assertNull(task.getInputData());
+        assertEquals(1, uploadCount.get());
+        assertNotNull(task.getExternalInputPayloadStoragePath());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadWorkflowPayload() throws IOException {
+        AtomicInteger uploadCount = new AtomicInteger(0);
+
+        InputStream stream = ExternalPayloadStorageUtilsTest.class.getResourceAsStream("/payload.json");
+        Map<String, Object> payload = objectMapper.readValue(stream, Map.class);
+
+        when(externalPayloadStorage.getLocation(ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT, "")).thenReturn(location);
+        doAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            return null;
+        }).when(externalPayloadStorage).upload(anyString(), any(), anyLong());
+
+        Workflow workflow = new Workflow();
+        workflow.setOutput(payload);
+        externalPayloadStorageUtils.verifyAndUpload(workflow, ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT);
+        assertNull(workflow.getOutput());
+        assertEquals(1, uploadCount.get());
+        assertNotNull(workflow.getExternalOutputPayloadStoragePath());
+    }
+
+    @Test
+    public void testUploadHelper() {
+        AtomicInteger uploadCount = new AtomicInteger(0);
+        String path = "some/test/path.json";
+        ExternalStorageLocation location = new ExternalStorageLocation();
+        location.setPath(path);
+
+        when(externalPayloadStorage.getLocation(any(), any(), any())).thenReturn(location);
+        doAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            return null;
+        }).when(externalPayloadStorage).upload(anyString(), any(), anyLong());
+
+        assertEquals(path, externalPayloadStorageUtils.uploadHelper(new byte[]{}, 10L, ExternalPayloadStorage.PayloadType.TASK_OUTPUT));
+        assertEquals(1, uploadCount.get());
+    }
+
+    @Test
+    public void testFailTaskWithInputPayload() {
+        Task task = new Task();
+        task.setInputData(new HashMap<>());
+
+        expectedException.expect(TerminateWorkflowException.class);
+        externalPayloadStorageUtils.failTask(task, ExternalPayloadStorage.PayloadType.TASK_INPUT, "error");
+        assertNotNull(task);
+        assertNull(task.getInputData());
+    }
+
+    @Test
+    public void testFailTaskWithOutputPayload() {
+        Task task = new Task();
+        task.setOutputData(new HashMap<>());
+
+        expectedException.expect(TerminateWorkflowException.class);
+        externalPayloadStorageUtils.failTask(task, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, "error");
+        assertNotNull(task);
+        assertNull(task.getOutputData());
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -19,7 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -27,7 +28,6 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,8 +40,6 @@ public class WorkflowServiceTest {
 
     private MetadataService mockMetadata;
 
-    private Configuration mockConfig;
-
     private WorkflowService workflowService;
 
     @Before
@@ -49,15 +47,15 @@ public class WorkflowServiceTest {
         this.mockWorkflowExecutor = Mockito.mock(WorkflowExecutor.class);
         this.mockExecutionService = Mockito.mock(ExecutionService.class);
         this.mockMetadata = Mockito.mock(MetadataService.class);
-        this.mockConfig = Mockito.mock(Configuration.class);
+        Configuration mockConfig = Mockito.mock(Configuration.class);
 
         when(mockConfig.getIntProperty(anyString(), anyInt())).thenReturn(5_000);
         this.workflowService = new WorkflowService(this.mockWorkflowExecutor, this.mockExecutionService,
-                this.mockMetadata, this.mockConfig);
+                this.mockMetadata, mockConfig);
     }
 
     @Test
-    public void testStartWorkflow() throws Exception {
+    public void testStartWorkflow() {
         WorkflowDef workflowDef = new WorkflowDef();
         workflowDef.setName("test");
         workflowDef.setVersion(1);
@@ -72,13 +70,13 @@ public class WorkflowServiceTest {
 
         when(mockMetadata.getWorkflowDef(anyString(), anyInt())).thenReturn(workflowDef);
         when(mockWorkflowExecutor.startWorkflow(anyString(), anyInt(), anyString(),
-                anyMapOf(String.class, Object.class), any(String.class),
+                anyMapOf(String.class, Object.class), any(String.class), any(String.class),
                 anyMapOf(String.class, String.class))).thenReturn(workflowID);
         assertEquals("w112", workflowService.startWorkflow(startWorkflowRequest));
     }
 
     @Test(expected = ApplicationException.class)
-    public void testApplicationExceptionStartWorkflowMessage() throws Exception {
+    public void testApplicationExceptionStartWorkflowMessage() {
         try {
             when(mockMetadata.getWorkflowDef(anyString(), anyInt())).thenReturn(null);
 
@@ -95,7 +93,7 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testStartWorkflowParam() throws Exception {
+    public void testStartWorkflowParam() {
         WorkflowDef workflowDef = new WorkflowDef();
         workflowDef.setName("test");
         workflowDef.setVersion(1);
@@ -111,7 +109,7 @@ public class WorkflowServiceTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void testApplicationExceptionStartWorkflowMessageParam() throws Exception {
+    public void testApplicationExceptionStartWorkflowMessageParam() {
         try {
             when(mockMetadata.getWorkflowDef(anyString(), anyInt())).thenReturn(null);
 
@@ -143,7 +141,7 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testGetWorklfowsMultipleCorrelationId() throws Exception {
+    public void testGetWorklfowsMultipleCorrelationId() {
         Workflow workflow = new Workflow();
         workflow.setCorrelationId("c123");
 
@@ -165,7 +163,7 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testGetExecutionStatus() throws Exception {
+    public void testGetExecutionStatus() {
         Workflow workflow = new Workflow();
         workflow.setCorrelationId("c123");
 
@@ -174,7 +172,7 @@ public class WorkflowServiceTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void testApplicationExceptionGetExecutionStatus() throws Exception {
+    public void testApplicationExceptionGetExecutionStatus() {
         try {
             when(mockExecutionService.getExecutionStatus(anyString(), anyBoolean())).thenReturn(null);
             workflowService.getExecutionStatus("w123", true);
@@ -187,13 +185,13 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testDeleteWorkflow() throws Exception {
+    public void testDeleteWorkflow() {
         workflowService.deleteWorkflow("w123", true);
         verify(mockExecutionService, times(1)).removeWorkflow(anyString(), anyBoolean());
     }
 
     @Test(expected = ApplicationException.class)
-    public void testInvalidDeleteWorkflow() throws Exception {
+    public void testInvalidDeleteWorkflow() {
         try {
             workflowService.deleteWorkflow(null, true);
         } catch (ApplicationException ex) {
@@ -205,7 +203,7 @@ public class WorkflowServiceTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void testInvalidWorkflowNameGetRunningWorkflows() throws Exception {
+    public void testInvalidWorkflowNameGetRunningWorkflows() {
         try {
             workflowService.getRunningWorkflows(null, 123, null, null);
         } catch (ApplicationException ex) {
@@ -217,51 +215,51 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testGetRunningWorkflowsTime() throws Exception{
+    public void testGetRunningWorkflowsTime() {
         workflowService.getRunningWorkflows("test", 1, 100L, 120L);
         verify(mockWorkflowExecutor, times(1)).getWorkflows(anyString(), anyInt(), anyLong(), anyLong());
     }
 
     @Test
-    public void testGetRunningWorkflows() throws Exception{
+    public void testGetRunningWorkflows() {
         workflowService.getRunningWorkflows("test", 1, null, null);
         verify(mockWorkflowExecutor, times(1)).getRunningWorkflowIds(anyString());
     }
 
     @Test
-    public void testDecideWorkflow() throws Exception {
+    public void testDecideWorkflow() {
         workflowService.decideWorkflow("test");
         verify(mockWorkflowExecutor, times(1)).decide(anyString());
     }
 
     @Test
-    public void testPauseWorkflow() throws Exception{
+    public void testPauseWorkflow() {
         workflowService.pauseWorkflow("test");
         verify(mockWorkflowExecutor, times(1)).pauseWorkflow(anyString());
     }
 
     @Test
-    public void testResumeWorkflow() throws Exception {
+    public void testResumeWorkflow() {
         workflowService.resumeWorkflow("test");
         verify(mockWorkflowExecutor, times(1)).resumeWorkflow(anyString());
     }
 
     @Test
-    public void testSkipTaskFromWorkflow() throws Exception {
+    public void testSkipTaskFromWorkflow() {
         workflowService.skipTaskFromWorkflow("test", "testTask", null);
         verify(mockWorkflowExecutor, times(1)).skipTaskFromWorkflow(anyString(), anyString(),
                 any(SkipTaskRequest.class));
     }
 
     @Test
-    public void testRerunWorkflow() throws Exception {
+    public void testRerunWorkflow() {
         RerunWorkflowRequest request = new RerunWorkflowRequest();
         workflowService.rerunWorkflow("test", request);
         verify(mockWorkflowExecutor, times(1)).rerun(any(RerunWorkflowRequest.class));
     }
 
     @Test
-    public void testRerunWorkflowReturnWorkflowId() throws Exception {
+    public void testRerunWorkflowReturnWorkflowId() {
         RerunWorkflowRequest request = new RerunWorkflowRequest();
         String workflowId = "w123";
         when(mockWorkflowExecutor.rerun(any(RerunWorkflowRequest.class))).thenReturn(workflowId);
@@ -269,25 +267,25 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void testRestartWorkflow() throws Exception {
+    public void testRestartWorkflow() {
         workflowService.restartWorkflow("w123");
         verify(mockWorkflowExecutor, times(1)).rewind(anyString());
     }
 
     @Test
-    public void testRetryWorkflow() throws Exception {
+    public void testRetryWorkflow() {
         workflowService.retryWorkflow("w123");
         verify(mockWorkflowExecutor, times(1)).retry(anyString());
     }
 
     @Test
-    public void testResetWorkflow() throws Exception{
+    public void testResetWorkflow() {
         workflowService.resetWorkflow("w123");
         verify(mockWorkflowExecutor, times(1)).resetCallbacksForInProgressTasks(anyString());
     }
 
     @Test
-    public void testTerminateWorkflow() throws Exception {
+    public void testTerminateWorkflow() {
         workflowService.terminateWorkflow("w123", "test");
         verify(mockWorkflowExecutor, times(1)).terminateWorkflow(anyString(), anyString());
     }
@@ -308,7 +306,7 @@ public class WorkflowServiceTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void testInvalidSizeSearchWorkflows() throws Exception {
+    public void testInvalidSizeSearchWorkflows() {
         try {
             workflowService.searchWorkflows(0,6000,"asc", "*", "*");
         } catch (ApplicationException ex) {

--- a/core/src/test/resources/payload.json
+++ b/core/src/test/resources/payload.json
@@ -1,0 +1,423 @@
+{
+  "imageType": "TEST_SAMPLE",
+  "filteredSourceList": {
+    "TEST_SAMPLE": [
+      {
+        "sourceId": "1413900_10830",
+        "url": "file/location/a0bdc4d0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_50241",
+        "url": "file/location/cd4e00a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-55ee8663-85c2-42d3-aca2-4076707e6d4e",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-14056154-1544-4350-81db-b3751fe44777",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-0b0ae5ea-d5c5-410c-adc9-bf16d2909c2e",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-08869779-614d-417c-bfea-36a3f8f199da",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-e117db45-1c48-45d0-b751-89386eb2d81d",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f0221421-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/4a009209-002f-4b58-8b96-cb2198f8ba3c"
+      },
+      {
+        "sourceId": "f0252161-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/55b56298-5e7a-4949-b919-88c5c9557e8e"
+      },
+      {
+        "sourceId": "f038d070-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/3c4804f4-e826-436f-90c9-52b8d9266d52"
+      },
+      {
+        "sourceId": "f04e0621-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/689283a1-1816-48ef-83da-7f9ac874bf45"
+      },
+      {
+        "sourceId": "f04ddf10-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/586666ae-7321-445a-80b6-323c8c241ecd"
+      },
+      {
+        "sourceId": "f05950c0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/31795cc4-2590-4b20-a617-deaa18301f99"
+      },
+      {
+        "sourceId": "1413900_46819",
+        "url": "file/location/c74497a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_11177",
+        "url": "file/location/a231c730-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_48713",
+        "url": "file/location/ca638ae0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_48525",
+        "url": "file/location/ca0c9140-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_73303",
+        "url": "file/location/d5943a40-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_55202",
+        "url": "file/location/d1a4d7a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-61413adf-3c10-4484-b25d-e238df898f45",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-addca397-f050-4339-ae86-9ba8c4e1b0d5",
+        "url": "file/sample/location/838a0ddb-a315-453a-8b8a-fa795f9d7691"
+      },
+      {
+        "sourceId": "generated-e4de9810-0f69-4593-8926-01ed82cbebcb",
+        "url": "file/sample/location/838a0ddb-a315-453a-8b8a-fa795f9d7691"
+      },
+      {
+        "sourceId": "generated-e16e2074-7af6-4700-ab05-ca41ba9c9ab4",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-341c86f8-57a5-40e1-8842-3eb41dd9f528",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-88c2ea9b-cef7-4120-8043-b92713d8fade",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-3f6a731f-3c92-4677-9923-f80b8a6be632",
+        "url": "file/sample/location/3881aea9-a731-4e22-9ead-2d6eccc51140"
+      },
+      {
+        "sourceId": "generated-1508b871-64de-47ce-8b07-76c5cb3f3e1e",
+        "url": "file/sample/location/a2e4195f-3900-45b4-9335-45f85fca6467"
+      },
+      {
+        "sourceId": "generated-1406dce8-7b9c-4956-a7e8-78721c476ce9",
+        "url": "file/sample/location/a2e4195f-3900-45b4-9335-45f85fca6467"
+      },
+      {
+        "sourceId": "f0206671-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/35ebee36-3072-44c5-abb5-702a5a3b1a91"
+      },
+      {
+        "sourceId": "f01f5501-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d3a9133d-c681-4910-a769-8195526ae634"
+      },
+      {
+        "sourceId": "f022b060-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8fc1413d-170e-4644-a554-5e0c596b225c"
+      },
+      {
+        "sourceId": "f02fa8b1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/35bed0a2-7def-457b-bded-4f4d7d94f76e"
+      },
+      {
+        "sourceId": "f031f2a0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a5a2ea1f-8d13-429c-a44d-3057d21f608a"
+      },
+      {
+        "sourceId": "f0424650-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/1c599ffc-4f10-4c0b-8d9a-ae41c7256113"
+      },
+      {
+        "sourceId": "f04ec970-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8404a421-e1a6-41cf-af63-a35ccb474457"
+      },
+      {
+        "sourceId": "1413900_47197",
+        "url": "file/location/c81b6fa0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-2a63c0c8-62ea-44a4-a33b-f0b3047e8b00",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-b27face7-3589-4209-944a-5153b20c5996",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-144675b3-9321-48d2-8b5b-e19a40d30ef2",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-8cbe821e-b1fb-48ce-beb5-735319af4db6",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-ecc4ea47-9bad-4b91-97c7-35f4ea6fb479",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-c1eb9ed0-8560-4e09-a748-f926edb7cdc2",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-6bed81fd-c777-4c61-8da1-0bb7f7cf0082",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-852e5510-dd5d-4900-a614-854148fcc716",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-f4dedcb7-37c9-4ba9-ab37-64ec9be7c882",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f0259691-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/721bc0de-e75f-4386-8b2e-ca84eb653596"
+      },
+      {
+        "sourceId": "f02b3be1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d2043b17-8ce5-42ee-a5e4-81c68f0c4838"
+      },
+      {
+        "sourceId": "f02b62f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/63931561-3b5b-4ffe-af47-da2c9de94684"
+      },
+      {
+        "sourceId": "f0315660-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d99ed629-2885-4e4a-8a1b-22e487b875fa"
+      },
+      {
+        "sourceId": "f0306c00-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/6f8e673a-7003-44aa-96b9-e2ed8a4654ff"
+      },
+      {
+        "sourceId": "f033c760-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/627c00f9-14b3-4057-b6e2-0f962ad0308e"
+      },
+      {
+        "sourceId": "f03526f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fafabaf9-fe58-4a9a-b555-026521aeb2fe"
+      },
+      {
+        "sourceId": "f03acc41-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/6c9fed2c-558a-4db3-8360-659b5e8c46e4"
+      },
+      {
+        "sourceId": "f0463df1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e9fb83d2-5f14-4442-92b5-67e613f2e35f"
+      },
+      {
+        "sourceId": "f04fb3d0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e7a0f82f-be8d-4ada-a4b1-13e8165e08be"
+      },
+      {
+        "sourceId": "f05272f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/9aba488a-22b3-4932-85a7-52c461203541"
+      },
+      {
+        "sourceId": "f0581841-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/457415f6-6d0c-4304-8533-0d5b43fac564"
+      },
+      {
+        "sourceId": "generated-8fefb48c-6fde-4fd6-8f33-a1f3f3b62105",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-30c61aa5-f5bd-4077-8c32-336b87acbe96",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-d5da37db-d486-46d4-8f7d-1e0710a77eb5",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-77af26fe-9e22-48af-99e3-f63f10fbe6de",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-2e807016-3d11-4b60-bec7-c380a608b67d",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-615d02e9-62c2-43ab-9df7-753b6b8e2c22",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-3e1600fd-a626-4ee6-972b-5f0187e96c38",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "generated-1dcb208c-6a58-4334-a60c-6fb54c8a2af5",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f024ac30-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0af2107b-4231-4d23-bef3-4e417ac6c5d3"
+      },
+      {
+        "sourceId": "f0282ea1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0f592681-fd23-4194-ae43-42f61c664485"
+      },
+      {
+        "sourceId": "f02c4d50-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/ec46b9a3-99af-410a-af7d-726f8854909f"
+      },
+      {
+        "sourceId": "f02b8a00-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/aed7e5da-b524-4d41-b264-28ce615ec826"
+      },
+      {
+        "sourceId": "f02b14d1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/b88c9055-ab0d-4d27-a405-265ba2a15f0c"
+      },
+      {
+        "sourceId": "f03044f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fb8c4df9-d59e-4ac3-880e-4ea94cd880a4"
+      },
+      {
+        "sourceId": "f034ffe1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/59f3fbe8-b300-4861-9b2f-dac7b15aea7d"
+      },
+      {
+        "sourceId": "f03c2bd0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/19a06d54-41ed-419d-9947-f10cd5f0d85c"
+      },
+      {
+        "sourceId": "f03fae41-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a9a48a62-7d62-4f67-b281-cc6fdc1e722c"
+      },
+      {
+        "sourceId": "f0455390-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0aeffc0a-a5ad-46ff-abab-1b3bc6a5840a"
+      },
+      {
+        "sourceId": "f04b1ff1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/9a08aaed-c125-48f7-9d1d-fd11266c2b12"
+      },
+      {
+        "sourceId": "f04cf4b1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/17a6e0f9-aa64-411f-9af7-837c84f7443f"
+      },
+      {
+        "sourceId": "f0511360-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fb633c73-cb33-4806-bc08-049024644856"
+      },
+      {
+        "sourceId": "f0538460-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a7012248-6769-42da-a6c8-d4b831f6efce"
+      },
+      {
+        "sourceId": "f058db91-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/bcf71522-6168-48c4-86c9-995bca60ae51"
+      },
+      {
+        "sourceId": "generated-adf005c4-95c1-4904-9968-09cc19a26bfe",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-c4d367a4-4cdc-412e-af79-09b227f2e3ba",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-48dba018-f884-49db-b87e-67274e244c8f",
+        "url": "file/sample/location/4bce4154-fb4b-4f0a-887d-a0cd12d4d214"
+      },
+      {
+        "sourceId": "generated-26700b83-4892-420e-8b46-1ee21eba75fb",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-632f3198-c0dc-4348-974f-51684d4e443e",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "generated-86e2dd1d-1aa4-4dbe-b37b-b488f5dd1c70",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f04134e0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/ff8f59bf-7757-4d51-a7e4-619f3e8ffaf2"
+      },
+      {
+        "sourceId": "f04f65b0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d66467d1-3ac6-4041-8d15-e722ee07231f"
+      },
+      {
+        "sourceId": "1413900_15255",
+        "url": "file/location/a9e20260-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-e953493b-cbe3-4319-885e-00c82089c76c",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-65c54676-3adb-4ef0-b65e-8e2a49533cbf",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "f02ac6b0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/21568877-07a5-411f-9715-5e92806c4448"
+      },
+      {
+        "sourceId": "f02fcfc1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/f3b1f1a2-48d3-475d-a607-2e5a1fe532e7"
+      },
+      {
+        "sourceId": "f03526f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/84a40c66-d925-4a4a-ba62-8491d26e29e9"
+      },
+      {
+        "sourceId": "f03e75c1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e84c00e8-a148-46cf-9a0b-431c4c2aeb08"
+      },
+      {
+        "sourceId": "f0429471-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/178de9fa-7cc8-457a-8fb6-5c080e6163ea"
+      },
+      {
+        "sourceId": "f047eba0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/18d153aa-e13b-4264-ae03-f3da75eb425b"
+      },
+      {
+        "sourceId": "f04fdae0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/7c843e53-8d87-47cf-bca5-1a02e7f5e33f"
+      },
+      {
+        "sourceId": "f0553210-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/26bacd65-9082-4d83-9506-90e5f1ccd16a"
+      },
+      {
+        "sourceId": "1413900_84904",
+        "url": "file/location/d8f7b090-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-84adc784-8d7d-4088-ba51-16fde57fbc21",
+        "url": "file/sample/location/3881aea9-a731-4e22-9ead-2d6eccc51140"
+      },
+      {
+        "sourceId": "generated-9e49c58b-0b33-4daf-a39a-8fc91e302328",
+        "url": "file/sample/location/4bce4154-fb4b-4f0a-887d-a0cd12d4d214"
+      },
+      {
+        "sourceId": "f02dd3f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8937b328-8f0d-4762-8d1f-7d7bc80c3d2e"
+      },
+      {
+        "sourceId": "f03240c0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/aab6e386-4d59-4b40-b257-9aed12a45446"
+      }
+    ]
+  }
+}

--- a/es2-persistence/dependencies.lock
+++ b/es2-persistence/dependencies.lock
@@ -1,5 +1,11 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -91,6 +97,12 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -205,6 +217,12 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -296,6 +314,12 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -387,6 +411,12 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -492,6 +522,12 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -591,6 +627,12 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -690,6 +732,12 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -798,6 +846,12 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"

--- a/es5-persistence/dependencies.lock
+++ b/es5-persistence/dependencies.lock
@@ -1,5 +1,11 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -104,6 +110,12 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -208,6 +220,12 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -312,6 +330,12 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -416,6 +440,12 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -520,6 +550,12 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -632,6 +668,12 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -744,6 +786,12 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -856,6 +904,12 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"

--- a/jersey/dependencies.lock
+++ b/jersey/dependencies.lock
@@ -1,5 +1,11 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -99,6 +105,12 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -198,6 +210,12 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -303,6 +321,12 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -402,6 +426,12 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -501,6 +531,12 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -608,6 +644,12 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -715,6 +757,12 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -822,6 +870,12 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -19,6 +19,7 @@ import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.service.TaskService;
@@ -221,4 +222,11 @@ public class TaskResource {
 		return taskService.search(start, size, sort, freeText, query);
 	}
 
+	@GET
+	@ApiOperation("Get the external uri where the task output payload is to be stored")
+	@Consumes(MediaType.WILDCARD)
+	@Path("/externalstoragelocation")
+	public ExternalStorageLocation getPayloadURI() {
+		return taskService.getPayloadUri();
+	}
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -116,7 +116,7 @@ public class TaskResource {
 	@ApiOperation("Ack Task is received")
 	@Consumes({MediaType.WILDCARD})
 	public String ack(@PathParam("taskId") String taskId,
-                      @QueryParam("workerid") String workerId) throws Exception{
+                      @QueryParam("workerid") String workerId) {
 		return taskService.ackTaskReceived(taskId, workerId);
 	}
 	
@@ -194,7 +194,7 @@ public class TaskResource {
 	@POST
 	@Path("/queue/requeue")
 	@ApiOperation("Requeue pending tasks for all the running workflows")
-	public String requeue() throws Exception {
+	public String requeue() {
 		return taskService.requeue();
 	}
 	
@@ -226,7 +226,7 @@ public class TaskResource {
 	@ApiOperation("Get the external uri where the task output payload is to be stored")
 	@Consumes(MediaType.WILDCARD)
 	@Path("/externalstoragelocation")
-	public ExternalStorageLocation getPayloadURI() {
-		return taskService.getPayloadUri();
+	public ExternalStorageLocation getExternalStorageLocation() {
+		return taskService.getExternalStorageLocation();
 	}
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -226,7 +226,7 @@ public class TaskResource {
 	@ApiOperation("Get the external uri where the task output payload is to be stored")
 	@Consumes(MediaType.WILDCARD)
 	@Path("/externalstoragelocation")
-	public ExternalStorageLocation getExternalStorageLocation() {
-		return taskService.getExternalStorageLocation();
+	public ExternalStorageLocation getExternalStorageLocation(@QueryParam("path") String path) {
+		return taskService.getExternalStorageLocation(path);
 	}
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -247,7 +247,7 @@ public class WorkflowResource {
     @ApiOperation("Get the uri and path of the external storage where the workflow input payload is to be stored")
     @Consumes(MediaType.WILDCARD)
     @Path("/externalstoragelocation")
-    public ExternalStorageLocation getExternalStorageLocation() {
-        return workflowService.getExternalStorageLocation();
+    public ExternalStorageLocation getExternalStorageLocation(@QueryParam("path") String path) {
+        return workflowService.getExternalStorageLocation(path);
     }
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -80,7 +80,7 @@ public class WorkflowResource {
     public String startWorkflow(@PathParam("name") String name,
                                 @QueryParam("version") Integer version,
                                 @QueryParam("correlationId") String correlationId,
-                                Map<String, Object> input) throws Exception {
+                                Map<String, Object> input) {
         return workflowService.startWorkflow(name, version, correlationId, input);
     }
 
@@ -166,7 +166,7 @@ public class WorkflowResource {
     @Consumes(MediaType.WILDCARD)
     public void skipTaskFromWorkflow(@PathParam("workflowId") String workflowId,
                                      @PathParam("taskReferenceName") String taskReferenceName,
-                                     SkipTaskRequest skipTaskRequest) throws Exception {
+                                     SkipTaskRequest skipTaskRequest) {
         workflowService.skipTaskFromWorkflow(workflowId, taskReferenceName, skipTaskRequest);
     }
 
@@ -247,7 +247,7 @@ public class WorkflowResource {
     @ApiOperation("Get the uri and path of the external storage where the workflow input payload is to be stored")
     @Consumes(MediaType.WILDCARD)
     @Path("/externalstoragelocation")
-    public ExternalStorageLocation getExternalPayloadURI() {
-        return workflowService.getExternalPayloadUri();
+    public ExternalStorageLocation getExternalStorageLocation() {
+        return workflowService.getExternalStorageLocation();
     }
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.netflix.conductor.common.metadata.workflow.RerunWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.SkipTaskRequest;
 import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
@@ -240,5 +241,13 @@ public class WorkflowResource {
                                                                 @QueryParam("freeText") @DefaultValue("*") String freeText,
                                                                 @QueryParam("query") String query) {
         return workflowService.searchWorkflowsByTasks(start, size, sort, freeText, query);
+    }
+
+    @GET
+    @ApiOperation("Get the uri and path of the external storage where the workflow input payload is to be stored")
+    @Consumes(MediaType.WILDCARD)
+    @Path("/externalstoragelocation")
+    public ExternalStorageLocation getExternalPayloadURI() {
+        return workflowService.getExternalPayloadUri();
     }
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -15,11 +15,11 @@
  */
 package com.netflix.conductor.config;
 
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.netflix.conductor.core.config.Configuration;
+
+import java.util.Map;
 
 /**
  * @author Viren
@@ -62,6 +62,46 @@ public class TestConfiguration implements Configuration {
 	@Override
 	public String getAppId() {
 		return "workflow";
+	}
+
+	@Override
+	public Long getWorkflowInputPayloadSizeThresholdKB() {
+		return 5120L;
+	}
+
+	@Override
+	public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getWorkflowOutputPayloadSizeThresholdKB() {
+		return 5120L;
+	}
+
+	@Override
+	public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskInputPayloadSizeThresholdKB() {
+		return 3072L;
+	}
+
+	@Override
+	public Long getMaxTaskInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskOutputPayloadSizeThresholdKB() {
+		return 3072L;
+	}
+
+	@Override
+	public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+		return 10240L;
 	}
 
 	@Override

--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -1,5 +1,11 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -100,6 +106,12 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -200,6 +212,12 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -300,6 +318,12 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -400,6 +424,12 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -500,6 +530,12 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -612,6 +648,12 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -724,6 +766,12 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -836,6 +884,12 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -560,12 +560,12 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 	}
 
 	/**
-	 * This is not just an insert or update, the terminal state workflow is removed from the
-	 * QQ there can be partial updates if the node goes down
-	 * TODO add logger statements for different if conditions
-	 * @param workflow
-	 * @param update
-	 * @return
+	 * Inserts a new workflow/ updates an existing workflow in the datastore.
+	 * Additionally, if a workflow is in terminal state, it is removed from the set of pending workflows.
+	 *
+	 * @param workflow the workflow instance
+	 * @param update flag to identify if update or create operation
+	 * @return the workflowId
 	 */
 	private String insertOrUpdateWorkflow(Workflow workflow, boolean update) {
 		Preconditions.checkNotNull(workflow, "workflow object cannot be null");

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -15,8 +15,24 @@
  */
 package com.netflix.conductor.dao.dynomite;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.inject.Singleton;
+import com.netflix.conductor.annotations.Trace;
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.execution.ApplicationException.Code;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.metrics.Monitors;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -26,25 +42,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
-import com.google.inject.Singleton;
-import com.netflix.conductor.annotations.Trace;
-import com.netflix.conductor.common.metadata.events.EventHandler;
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.core.config.Configuration;
-import com.netflix.conductor.core.execution.ApplicationException;
-import com.netflix.conductor.core.execution.ApplicationException.Code;
-import com.netflix.conductor.dao.MetadataDAO;
-import com.netflix.conductor.metrics.Monitors;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 @Trace

--- a/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -85,6 +85,46 @@ public class TestConfiguration implements Configuration {
 	}
 
 	@Override
+	public Long getWorkflowInputPayloadSizeThresholdKB() {
+		return 5120L;
+	}
+
+	@Override
+	public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getWorkflowOutputPayloadSizeThresholdKB() {
+		return 5120L;
+	}
+
+	@Override
+	public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskInputPayloadSizeThresholdKB() {
+		return 3072L;
+	}
+
+	@Override
+	public Long getMaxTaskInputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
+	public Long getTaskOutputPayloadSizeThresholdKB() {
+		return 3072L;
+	}
+
+	@Override
+	public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+		return 10240L;
+	}
+
+	@Override
 	public long getLongProperty(String name, long defaultValue) {
 		return 1000000l;
 	}

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -1,10 +1,16 @@
 {
     "compile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -272,11 +278,17 @@
         }
     },
     "compileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -544,11 +556,17 @@
         }
     },
     "default": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -816,11 +834,17 @@
         }
     },
     "grettyProductRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1148,11 +1172,17 @@
         }
     },
     "runtime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1420,11 +1450,17 @@
         }
     },
     "runtimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1692,11 +1728,17 @@
         }
     },
     "springBoot": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1964,11 +2006,17 @@
         }
     },
     "testCompile": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2244,11 +2292,17 @@
         }
     },
     "testCompileClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2524,11 +2578,17 @@
         }
     },
     "testRuntime": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -2804,11 +2864,17 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
+        },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [

--- a/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
@@ -18,6 +18,12 @@
  */
 package com.netflix.conductor.server;
 
+import com.google.inject.AbstractModule;
+import com.netflix.conductor.core.config.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
@@ -26,13 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.inject.AbstractModule;
-import com.netflix.conductor.core.config.Configuration;
 
 /**
  * @author Viren
@@ -98,7 +97,9 @@ public class ConductorConfig implements Configuration {
 		String val = getProperty(key, Integer.toString(defaultValue));
 		try{
 			defaultValue = Integer.parseInt(val);
-		}catch(NumberFormatException e){}
+		} catch(NumberFormatException e){
+			logger.error("Error parsing the Int value for Key:{} , returning a default value: {}", key, defaultValue);
+		}
 		return defaultValue;
 	}
 
@@ -132,7 +133,7 @@ public class ConductorConfig implements Configuration {
 	public Map<String, Object> getAll() {
 		Map<String, Object> map = new HashMap<>();
 		Properties props = System.getProperties();
-		props.entrySet().forEach(entry -> map.put(entry.getKey().toString(), entry.getValue()));
+		props.forEach((key, value) -> map.put(key.toString(), value));
 		return map;
 	}
 

--- a/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorConfig.java
@@ -93,6 +93,46 @@ public class ConductorConfig implements Configuration {
 	}
 
 	@Override
+	public Long getWorkflowInputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.workflow.input.payload.threshold.kb", 5120L);
+	}
+
+	@Override
+	public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.max.workflow.input.payload.threshold.kb", 10240L);
+	}
+
+	@Override
+	public Long getWorkflowOutputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.workflow.output.payload.threshold.kb", 5120L);
+	}
+
+	@Override
+	public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.max.workflow.output.payload.threshold.kb", 10240L);
+	}
+
+	@Override
+	public Long getTaskInputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.task.input.payload.threshold.kb", 3072L);
+	}
+
+	@Override
+	public Long getMaxTaskInputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.max.task.input.payload.threshold.kb", 10240L);
+	}
+
+	@Override
+	public Long getTaskOutputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.task.output.payload.threshold.kb", 3072L);
+	}
+
+	@Override
+	public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+		return getLongProperty("conductor.max.task.output.payload.threshold.kb", 10240L);
+	}
+
+	@Override
 	public int getIntProperty(String key, int defaultValue) {
 		String val = getProperty(key, Integer.toString(defaultValue));
 		try{
@@ -124,7 +164,7 @@ public class ConductorConfig implements Configuration {
 				val = Optional.ofNullable(System.getProperty(key)).orElse(defaultValue);
 			}
 		}catch(Exception e){
-			logger.error(e.getMessage(), e);
+			logger.error("Error reading property: {}", key, e);
 		}
 		return val;
 	}
@@ -156,7 +196,7 @@ public class ConductorConfig implements Configuration {
 				}
 				return modules;
 			}catch(Exception e) {
-				logger.warn(e.getMessage(), e);
+				logger.warn("Error loading additional modules", e);
 			}
 		}
 		return null;

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -65,7 +65,7 @@ public class ConductorServer {
 		redis, dynomite, memory, redis_cluster, mysql
 	}
 
-	enum ExternalPayloadStorage {
+	enum ExternalPayloadStorageType {
 		S3
 	}
 	
@@ -77,7 +77,7 @@ public class ConductorServer {
 	
 	private DB database;
 
-	private ExternalPayloadStorage externalPayloadStorage;
+	private ExternalPayloadStorageType externalPayloadStorageType;
 	
 	public ConductorServer(ConductorConfig conductorConfig) {
 		this.conductorConfig = conductorConfig;
@@ -117,9 +117,9 @@ public class ConductorServer {
 
 		String externalPayloadStorageString = conductorConfig.getProperty("workflow.external.payload.storage", "");
 		try {
-			externalPayloadStorage = ConductorServer.ExternalPayloadStorage.valueOf(externalPayloadStorageString);
+			externalPayloadStorageType = ExternalPayloadStorageType.valueOf(externalPayloadStorageString);
 		} catch(IllegalArgumentException e) {
-			logger.info("External payload storage is not configured, provided: {}, supported values are: {}", externalPayloadStorageString, Arrays.toString(ConductorServer.ExternalPayloadStorage.values()), e);
+			logger.info("External payload storage is not configured, provided: {}, supported values are: {}", externalPayloadStorageString, Arrays.toString(ExternalPayloadStorageType.values()), e);
 		}
 
 		init(dynoClusterName, dynoHosts);
@@ -187,7 +187,7 @@ public class ConductorServer {
 			break;
 		}
 		
-		this.serverModule = new ServerModule(jedis, hostSupplier, conductorConfig, database, externalPayloadStorage);
+		this.serverModule = new ServerModule(jedis, hostSupplier, conductorConfig, database, externalPayloadStorageType);
 	}
 
 	private TokenMapSupplier getTokenMapSupplier(List<Host> dynoHosts) {

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -39,5 +39,5 @@ workflow.elasticsearch.index.name=conductor
 #Elasticsearch major release version.
 workflow.elasticsearch.version=2
 
-# For a single node dynomite or redis server, make sure the value below is set to same as rack specified in the "workflow.dynomite.cluster.hosts" property. 
+# For a single node dynomite or redis server, make sure the value below is set to same as rack specified in the "workflow.dynomite.cluster.hosts" property.
 EC2_AVAILABILITY_ZONE=us-east-1c

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -4,13 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
+        },
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -360,13 +366,19 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
+        },
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -716,13 +728,19 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
+        },
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1072,13 +1090,19 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
+        },
+        "com.amazonaws:aws-java-sdk-s3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.380"
+            "locked": "1.11.389"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
@@ -298,11 +298,8 @@ public class End2EndTests {
         StartWorkflowRequest startWorkflowRequest = new StartWorkflowRequest();
         try{
             wc.startWorkflow(startWorkflowRequest);
-        } catch (ConductorClientException e) {
-            int statuCode = e.getStatus();
-            assertEquals(400, statuCode);
+        } catch (IllegalArgumentException e) {
             assertEquals("Workflow name cannot be null or empty", e.getMessage());
-            assertFalse(e.isRetryable());
         }
     }
 

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockConfiguration.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockConfiguration.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.conductor.tests.utils;
+
+import com.netflix.conductor.core.config.Configuration;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+public class MockConfiguration implements Configuration {
+
+    @Override
+    public int getSweepFrequency() {
+        return 30;
+    }
+
+    @Override
+    public boolean disableSweep() {
+        return false;
+    }
+
+    @Override
+    public boolean disableAsyncWorkers() {
+        return false;
+    }
+
+    @Override
+    public String getServerId() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return "unknown";
+        }
+    }
+
+    @Override
+    public String getEnvironment() {
+        return "test";
+    }
+
+    @Override
+    public String getStack() {
+        return "test";
+    }
+
+    @Override
+    public String getAppId() {
+        return "conductor";
+    }
+
+    @Override
+    public String getProperty(String string, String def) {
+        return "dummy";
+    }
+
+    @Override
+    public String getAvailabilityZone() {
+        return "us-east-1c";
+    }
+
+    @Override
+    public int getIntProperty(String string, int def) {
+        return 100;
+    }
+
+    @Override
+    public String getRegion() {
+        return "us-east-1";
+    }
+
+    @Override
+    public Long getWorkflowInputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getWorkflowOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskInputPayloadSizeThresholdKB() {
+        return 1L;
+    }
+
+    @Override
+    public Long getMaxTaskInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Map<String, Object> getAll() {
+        return null;
+    }
+
+    @Override
+    public long getLongProperty(String name, long defaultValue) {
+        return 1000000L;
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockExternalPayloadStorage.java
@@ -15,15 +15,22 @@
  */
 package com.netflix.conductor.tests.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MockExternalPayloadStorage implements ExternalPayloadStorage {
 
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
-    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType) {
         return null;
     }
 
@@ -33,6 +40,27 @@ public class MockExternalPayloadStorage implements ExternalPayloadStorage {
 
     @Override
     public InputStream download(String path) {
-        return null;
+        try {
+
+            Map<String, Object> payload = getPayload(path);
+            String jsonString = objectMapper.writeValueAsString(payload);
+            return new ByteArrayInputStream(jsonString.getBytes());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private Map<String, Object> getPayload(String path) {
+        Map<String, Object> stringObjectMap = new HashMap<>();
+        switch (path) {
+            case "workflow/input":
+                stringObjectMap.put("param1", "p1 value");
+                stringObjectMap.put("param2", "p2 value");
+                break;
+            case "task/output":
+                stringObjectMap.put("op", "success_task1");
+                break;
+        }
+        return stringObjectMap;
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockExternalPayloadStorage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.tests.utils;
+
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+
+import java.io.InputStream;
+
+public class MockExternalPayloadStorage implements ExternalPayloadStorage {
+
+    @Override
+    public ExternalStorageLocation getExternalUri(Operation operation, PayloadType payloadType) {
+        return null;
+    }
+
+    @Override
+    public void upload(String path, InputStream payload, long payloadSize) {
+    }
+
+    @Override
+    public InputStream download(String path) {
+        return null;
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
@@ -18,16 +18,9 @@
  */
 package com.netflix.conductor.tests.utils;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.CoreModule;
 import com.netflix.conductor.dao.ExecutionDAO;
@@ -41,8 +34,13 @@ import com.netflix.conductor.dao.dynomite.queue.DynoQueueDAO;
 import com.netflix.conductor.redis.utils.JedisMock;
 import com.netflix.conductor.server.ConductorConfig;
 import com.netflix.dyno.queues.ShardSupplier;
-
 import redis.clients.jedis.JedisCommands;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Viren
@@ -89,6 +87,7 @@ public class TestModule extends AbstractModule {
 		bind(DynoProxy.class).toInstance(proxy);
 		install(new CoreModule());
 		bind(UserTask.class).asEagerSingleton();
+		bind(ExternalPayloadStorage.class).to(MockExternalPayloadStorage.class);
 	}
 	
 	@Provides

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.tests.utils;
 
@@ -32,7 +32,6 @@ import com.netflix.conductor.dao.dynomite.RedisExecutionDAO;
 import com.netflix.conductor.dao.dynomite.RedisMetadataDAO;
 import com.netflix.conductor.dao.dynomite.queue.DynoQueueDAO;
 import com.netflix.conductor.redis.utils.JedisMock;
-import com.netflix.conductor.server.ConductorConfig;
 import com.netflix.dyno.queues.ShardSupplier;
 import redis.clients.jedis.JedisCommands;
 
@@ -47,11 +46,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  */
 public class TestModule extends AbstractModule {
-	
+
 	private int maxThreads = 50;
-	
+
 	private ExecutorService executorService;
-	
+
 	@Override
 	protected void configure() {
 
@@ -61,40 +60,40 @@ public class TestModule extends AbstractModule {
 
 		configureExecutorService();
 
-		ConductorConfig config = new ConductorConfig();
+		MockConfiguration config = new MockConfiguration();
 		bind(Configuration.class).toInstance(config);
 		JedisCommands jedisMock = new JedisMock();
 
 		DynoQueueDAO queueDao = new DynoQueueDAO(jedisMock, jedisMock, new ShardSupplier() {
-			
+
 			@Override
 			public Set<String> getQueueShards() {
 				return new HashSet<>(Collections.singletonList("a"));
 			}
-			
+
 			@Override
 			public String getCurrentShard() {
 				return "a";
 			}
 		}, config);
-		
+
 		bind(MetadataDAO.class).to(RedisMetadataDAO.class);
 		bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
 		bind(DynoQueueDAO.class).toInstance(queueDao);
 		bind(QueueDAO.class).to(DynoQueueDAO.class);
-		bind(IndexDAO.class).to(MockIndexDAO.class);		
+		bind(IndexDAO.class).to(MockIndexDAO.class);
 		DynoProxy proxy = new DynoProxy(jedisMock);
 		bind(DynoProxy.class).toInstance(proxy);
 		install(new CoreModule());
 		bind(UserTask.class).asEagerSingleton();
 		bind(ExternalPayloadStorage.class).to(MockExternalPayloadStorage.class);
 	}
-	
+
 	@Provides
 	public ExecutorService getExecutorService(){
 		return this.executorService;
 	}
-	
+
 	private void configureExecutorService(){
 		AtomicInteger count = new AtomicInteger(0);
 		this.executorService = java.util.concurrent.Executors.newFixedThreadPool(maxThreads, runnable -> {

--- a/test-harness/src/test/resources/payload.json
+++ b/test-harness/src/test/resources/payload.json
@@ -1,0 +1,423 @@
+{
+  "imageType": "TEST_SAMPLE",
+  "op": {
+    "TEST_SAMPLE": [
+      {
+        "sourceId": "1413900_10830",
+        "url": "file/location/a0bdc4d0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_50241",
+        "url": "file/location/cd4e00a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-55ee8663-85c2-42d3-aca2-4076707e6d4e",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-14056154-1544-4350-81db-b3751fe44777",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-0b0ae5ea-d5c5-410c-adc9-bf16d2909c2e",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-08869779-614d-417c-bfea-36a3f8f199da",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-e117db45-1c48-45d0-b751-89386eb2d81d",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f0221421-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/4a009209-002f-4b58-8b96-cb2198f8ba3c"
+      },
+      {
+        "sourceId": "f0252161-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/55b56298-5e7a-4949-b919-88c5c9557e8e"
+      },
+      {
+        "sourceId": "f038d070-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/3c4804f4-e826-436f-90c9-52b8d9266d52"
+      },
+      {
+        "sourceId": "f04e0621-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/689283a1-1816-48ef-83da-7f9ac874bf45"
+      },
+      {
+        "sourceId": "f04ddf10-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/586666ae-7321-445a-80b6-323c8c241ecd"
+      },
+      {
+        "sourceId": "f05950c0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/31795cc4-2590-4b20-a617-deaa18301f99"
+      },
+      {
+        "sourceId": "1413900_46819",
+        "url": "file/location/c74497a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_11177",
+        "url": "file/location/a231c730-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_48713",
+        "url": "file/location/ca638ae0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_48525",
+        "url": "file/location/ca0c9140-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_73303",
+        "url": "file/location/d5943a40-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "1413900_55202",
+        "url": "file/location/d1a4d7a0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-61413adf-3c10-4484-b25d-e238df898f45",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-addca397-f050-4339-ae86-9ba8c4e1b0d5",
+        "url": "file/sample/location/838a0ddb-a315-453a-8b8a-fa795f9d7691"
+      },
+      {
+        "sourceId": "generated-e4de9810-0f69-4593-8926-01ed82cbebcb",
+        "url": "file/sample/location/838a0ddb-a315-453a-8b8a-fa795f9d7691"
+      },
+      {
+        "sourceId": "generated-e16e2074-7af6-4700-ab05-ca41ba9c9ab4",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-341c86f8-57a5-40e1-8842-3eb41dd9f528",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-88c2ea9b-cef7-4120-8043-b92713d8fade",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-3f6a731f-3c92-4677-9923-f80b8a6be632",
+        "url": "file/sample/location/3881aea9-a731-4e22-9ead-2d6eccc51140"
+      },
+      {
+        "sourceId": "generated-1508b871-64de-47ce-8b07-76c5cb3f3e1e",
+        "url": "file/sample/location/a2e4195f-3900-45b4-9335-45f85fca6467"
+      },
+      {
+        "sourceId": "generated-1406dce8-7b9c-4956-a7e8-78721c476ce9",
+        "url": "file/sample/location/a2e4195f-3900-45b4-9335-45f85fca6467"
+      },
+      {
+        "sourceId": "f0206671-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/35ebee36-3072-44c5-abb5-702a5a3b1a91"
+      },
+      {
+        "sourceId": "f01f5501-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d3a9133d-c681-4910-a769-8195526ae634"
+      },
+      {
+        "sourceId": "f022b060-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8fc1413d-170e-4644-a554-5e0c596b225c"
+      },
+      {
+        "sourceId": "f02fa8b1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/35bed0a2-7def-457b-bded-4f4d7d94f76e"
+      },
+      {
+        "sourceId": "f031f2a0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a5a2ea1f-8d13-429c-a44d-3057d21f608a"
+      },
+      {
+        "sourceId": "f0424650-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/1c599ffc-4f10-4c0b-8d9a-ae41c7256113"
+      },
+      {
+        "sourceId": "f04ec970-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8404a421-e1a6-41cf-af63-a35ccb474457"
+      },
+      {
+        "sourceId": "1413900_47197",
+        "url": "file/location/c81b6fa0-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-2a63c0c8-62ea-44a4-a33b-f0b3047e8b00",
+        "url": "file/sample/location/e008d018-63d7-44b2-b07e-c7435430ac71"
+      },
+      {
+        "sourceId": "generated-b27face7-3589-4209-944a-5153b20c5996",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-144675b3-9321-48d2-8b5b-e19a40d30ef2",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-8cbe821e-b1fb-48ce-beb5-735319af4db6",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-ecc4ea47-9bad-4b91-97c7-35f4ea6fb479",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-c1eb9ed0-8560-4e09-a748-f926edb7cdc2",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-6bed81fd-c777-4c61-8da1-0bb7f7cf0082",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-852e5510-dd5d-4900-a614-854148fcc716",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-f4dedcb7-37c9-4ba9-ab37-64ec9be7c882",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f0259691-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/721bc0de-e75f-4386-8b2e-ca84eb653596"
+      },
+      {
+        "sourceId": "f02b3be1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d2043b17-8ce5-42ee-a5e4-81c68f0c4838"
+      },
+      {
+        "sourceId": "f02b62f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/63931561-3b5b-4ffe-af47-da2c9de94684"
+      },
+      {
+        "sourceId": "f0315660-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d99ed629-2885-4e4a-8a1b-22e487b875fa"
+      },
+      {
+        "sourceId": "f0306c00-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/6f8e673a-7003-44aa-96b9-e2ed8a4654ff"
+      },
+      {
+        "sourceId": "f033c760-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/627c00f9-14b3-4057-b6e2-0f962ad0308e"
+      },
+      {
+        "sourceId": "f03526f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fafabaf9-fe58-4a9a-b555-026521aeb2fe"
+      },
+      {
+        "sourceId": "f03acc41-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/6c9fed2c-558a-4db3-8360-659b5e8c46e4"
+      },
+      {
+        "sourceId": "f0463df1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e9fb83d2-5f14-4442-92b5-67e613f2e35f"
+      },
+      {
+        "sourceId": "f04fb3d0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e7a0f82f-be8d-4ada-a4b1-13e8165e08be"
+      },
+      {
+        "sourceId": "f05272f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/9aba488a-22b3-4932-85a7-52c461203541"
+      },
+      {
+        "sourceId": "f0581841-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/457415f6-6d0c-4304-8533-0d5b43fac564"
+      },
+      {
+        "sourceId": "generated-8fefb48c-6fde-4fd6-8f33-a1f3f3b62105",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-30c61aa5-f5bd-4077-8c32-336b87acbe96",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-d5da37db-d486-46d4-8f7d-1e0710a77eb5",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-77af26fe-9e22-48af-99e3-f63f10fbe6de",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-2e807016-3d11-4b60-bec7-c380a608b67d",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-615d02e9-62c2-43ab-9df7-753b6b8e2c22",
+        "url": "file/sample/location/519f6c80-96ef-440f-9d37-ccf36c7d1e5d"
+      },
+      {
+        "sourceId": "generated-3e1600fd-a626-4ee6-972b-5f0187e96c38",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "generated-1dcb208c-6a58-4334-a60c-6fb54c8a2af5",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f024ac30-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0af2107b-4231-4d23-bef3-4e417ac6c5d3"
+      },
+      {
+        "sourceId": "f0282ea1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0f592681-fd23-4194-ae43-42f61c664485"
+      },
+      {
+        "sourceId": "f02c4d50-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/ec46b9a3-99af-410a-af7d-726f8854909f"
+      },
+      {
+        "sourceId": "f02b8a00-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/aed7e5da-b524-4d41-b264-28ce615ec826"
+      },
+      {
+        "sourceId": "f02b14d1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/b88c9055-ab0d-4d27-a405-265ba2a15f0c"
+      },
+      {
+        "sourceId": "f03044f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fb8c4df9-d59e-4ac3-880e-4ea94cd880a4"
+      },
+      {
+        "sourceId": "f034ffe1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/59f3fbe8-b300-4861-9b2f-dac7b15aea7d"
+      },
+      {
+        "sourceId": "f03c2bd0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/19a06d54-41ed-419d-9947-f10cd5f0d85c"
+      },
+      {
+        "sourceId": "f03fae41-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a9a48a62-7d62-4f67-b281-cc6fdc1e722c"
+      },
+      {
+        "sourceId": "f0455390-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/0aeffc0a-a5ad-46ff-abab-1b3bc6a5840a"
+      },
+      {
+        "sourceId": "f04b1ff1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/9a08aaed-c125-48f7-9d1d-fd11266c2b12"
+      },
+      {
+        "sourceId": "f04cf4b1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/17a6e0f9-aa64-411f-9af7-837c84f7443f"
+      },
+      {
+        "sourceId": "f0511360-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/fb633c73-cb33-4806-bc08-049024644856"
+      },
+      {
+        "sourceId": "f0538460-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/a7012248-6769-42da-a6c8-d4b831f6efce"
+      },
+      {
+        "sourceId": "f058db91-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/bcf71522-6168-48c4-86c9-995bca60ae51"
+      },
+      {
+        "sourceId": "generated-adf005c4-95c1-4904-9968-09cc19a26bfe",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-c4d367a4-4cdc-412e-af79-09b227f2e3ba",
+        "url": "file/sample/location/3d927190-1c4d-4af2-91cf-2968d3ccfe70"
+      },
+      {
+        "sourceId": "generated-48dba018-f884-49db-b87e-67274e244c8f",
+        "url": "file/sample/location/4bce4154-fb4b-4f0a-887d-a0cd12d4d214"
+      },
+      {
+        "sourceId": "generated-26700b83-4892-420e-8b46-1ee21eba75fb",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "generated-632f3198-c0dc-4348-974f-51684d4e443e",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "generated-86e2dd1d-1aa4-4dbe-b37b-b488f5dd1c70",
+        "url": "file/sample/location/e87da4d1-72da-47a3-801d-43e01c050c89"
+      },
+      {
+        "sourceId": "f04134e0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/ff8f59bf-7757-4d51-a7e4-619f3e8ffaf2"
+      },
+      {
+        "sourceId": "f04f65b0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/d66467d1-3ac6-4041-8d15-e722ee07231f"
+      },
+      {
+        "sourceId": "1413900_15255",
+        "url": "file/location/a9e20260-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-e953493b-cbe3-4319-885e-00c82089c76c",
+        "url": "file/sample/location/ec16facd-86e3-4c3f-8dfb-7a2ad3a4e18c"
+      },
+      {
+        "sourceId": "generated-65c54676-3adb-4ef0-b65e-8e2a49533cbf",
+        "url": "file/sample/location/07ec28a1-189e-4f2a-9dd5-f3ca68ce977d"
+      },
+      {
+        "sourceId": "f02ac6b0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/21568877-07a5-411f-9715-5e92806c4448"
+      },
+      {
+        "sourceId": "f02fcfc1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/f3b1f1a2-48d3-475d-a607-2e5a1fe532e7"
+      },
+      {
+        "sourceId": "f03526f0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/84a40c66-d925-4a4a-ba62-8491d26e29e9"
+      },
+      {
+        "sourceId": "f03e75c1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/e84c00e8-a148-46cf-9a0b-431c4c2aeb08"
+      },
+      {
+        "sourceId": "f0429471-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/178de9fa-7cc8-457a-8fb6-5c080e6163ea"
+      },
+      {
+        "sourceId": "f047eba0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/18d153aa-e13b-4264-ae03-f3da75eb425b"
+      },
+      {
+        "sourceId": "f04fdae0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/7c843e53-8d87-47cf-bca5-1a02e7f5e33f"
+      },
+      {
+        "sourceId": "f0553210-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/26bacd65-9082-4d83-9506-90e5f1ccd16a"
+      },
+      {
+        "sourceId": "1413900_84904",
+        "url": "file/location/d8f7b090-5315-11e8-bf88-0efd527701fc"
+      },
+      {
+        "sourceId": "generated-84adc784-8d7d-4088-ba51-16fde57fbc21",
+        "url": "file/sample/location/3881aea9-a731-4e22-9ead-2d6eccc51140"
+      },
+      {
+        "sourceId": "generated-9e49c58b-0b33-4daf-a39a-8fc91e302328",
+        "url": "file/sample/location/4bce4154-fb4b-4f0a-887d-a0cd12d4d214"
+      },
+      {
+        "sourceId": "f02dd3f1-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/8937b328-8f0d-4762-8d1f-7d7bc80c3d2e"
+      },
+      {
+        "sourceId": "f03240c0-86e8-11e8-af77-0a2ba4eae3ec",
+        "url": "file/test/location/aab6e386-4d59-4b40-b257-9aed12a45446"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This is part 1 of the externalize large payloads feature.

The idea is to provide a pluggable ExternalPayloadStorage interface which can be used for this purpose. We also provide an S3 implementation of this interface and a dummy implementation, which is initialized using configuration.

This contains implementation for uploading to the external storage when starting a workflow and uploading to the external storage when updating the task with TaskResult. These upload operations are done on the client by obtaining a signed URL (in case of S3), from the server. This abstraction allows the conductor server to restrict access to the external storage. The client decides whether the external storage is used or not, based on ConductorClientConfiguration and manages the upload and download, completely invisible to the user.

Second commit makes use of external workflow input and external task output. These are the APIs that the client uses when submitting large payloads.

Third commit makes use of externalizing workflow and task input and outputs on the server and wiring in the external payload storage with the execution and retry mechanisms. 

***TODO:***
- remove the barriers from RedisExecutionDAO
- add metrics for external storage usage
- more tests