### PR TITLE
fix response timeout seconds evaluation

### DIFF
--- a/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/http/TestHttpTask.java
@@ -43,6 +43,7 @@ import com.netflix.conductor.core.execution.mapper.TaskMapper;
 import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
 import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.QueueDAO;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -295,6 +296,7 @@ public class TestHttpTask {
  		wft.setTaskReferenceName("t1");
 		def.getTasks().add(wft);
  		MetadataDAO metadataDAO = mock(MetadataDAO.class);
+		QueueDAO queueDAO = mock(QueueDAO.class);
 		ParametersUtils parametersUtils = new ParametersUtils();
 		Map<String, TaskMapper> taskMappers = new HashMap<>();
 		taskMappers.put("DECISION", new DecisionTaskMapper());
@@ -307,7 +309,7 @@ public class TestHttpTask {
 		taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
 		taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
 		taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
- 		new DeciderService(metadataDAO, taskMappers).decide(workflow, def);
+ 		new DeciderService(metadataDAO, queueDAO, taskMappers).decide(workflow, def);
  		
  		System.out.println(workflow.getTasks());
  		System.out.println(workflow.getStatus());

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -132,5 +132,12 @@ public interface QueueDAO {
 	 */
 	boolean setOffsetTime(String queueName, String id, long offsetTimeInSecond);
 
-
+	/**
+	 * Checks if a message with the given id exists on the queue
+	 * @param queueName name of the queue
+	 * @param id message id
+	 * @return true if the message with the specified id is present in the queue
+	 * false if the message with the given id is not present in the queue
+	 */
+	boolean exists(String queueName, String id);
 }

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -16,17 +16,6 @@
 package com.netflix.conductor.service;
 
 
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import com.google.common.base.Preconditions;
 import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -34,15 +23,20 @@ import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.TaskSummary;
-
-import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.dao.QueueDAO;
-
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.service.utils.ServiceUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * @author fjhaveri

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -42,6 +42,7 @@ import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
 import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
 import com.netflix.conductor.core.execution.tasks.Join;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.QueueDAO;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -81,9 +82,10 @@ public class TestDeciderOutcomes {
 
 
 	@Before
-	public void init() throws Exception {
+	public void init() {
 		
 		MetadataDAO metadataDAO = mock(MetadataDAO.class);
+		QueueDAO queueDAO = mock(QueueDAO.class);
 		TaskDef taskDef = new TaskDef();
 		taskDef.setRetryCount(1);
 		taskDef.setName("mockTaskDef");
@@ -102,7 +104,7 @@ public class TestDeciderOutcomes {
 		taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
 		taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 
-		this.deciderService = new DeciderService(metadataDAO, taskMappers);
+		this.deciderService = new DeciderService(metadataDAO, queueDAO, taskMappers);
 	}
 
 	@Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -44,8 +44,8 @@ import com.netflix.conductor.core.execution.mapper.SubWorkflowTaskMapper;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
 import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
 import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
-import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
@@ -113,6 +113,7 @@ public class TestDeciderService {
     @Before
     public void setup() {
         MetadataDAO metadataDAO = mock(MetadataDAO.class);
+        QueueDAO queueDAO = mock(QueueDAO.class);
         TaskDef taskDef = new TaskDef();
         WorkflowDef workflowDef = new WorkflowDef();
         when(metadataDAO.getTaskDef(any())).thenReturn(taskDef);
@@ -130,7 +131,7 @@ public class TestDeciderService {
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 
-        deciderService = new DeciderService(metadataDAO, taskMappers);
+        deciderService = new DeciderService(metadataDAO, queueDAO, taskMappers);
 
         workflow = new Workflow();
         workflow.getInput().put("requestId", "request id 001");

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -91,7 +91,7 @@ public class TestWorkflowExecutor {
         taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
-        DeciderService deciderService = new DeciderService(metadataDAO, taskMappers);
+        DeciderService deciderService = new DeciderService(metadataDAO, queueDAO, taskMappers);
         workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, config);
     }
 

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -162,6 +162,11 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
                 .addParameter(offsetTimeInSecond).addParameter(queueName).addParameter(messageId).executeUpdate() == 1);
     }
 
+    @Override
+    public boolean exists(String queueName, String messageId) {
+        return getWithTransaction(tx -> existsMessage(tx, queueName, messageId));
+    }
+
     private boolean existsMessage(Connection connection, String queueName, String messageId) {
         String EXISTS_MESSAGE = "SELECT EXISTS(SELECT 1 FROM queue_message WHERE queue_name = ? AND message_id = ?)";
         return query(connection, EXISTS_MESSAGE, q -> q.addParameter(queueName).addParameter(messageId).exists());

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -1,25 +1,26 @@
 package com.netflix.conductor.dao.mysql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.google.common.collect.ImmutableList;
 import com.netflix.conductor.core.events.queue.Message;
-import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("Duplicates")
 public class MySQLQueueDAOTest extends MySQLBaseDAOTest {
@@ -29,7 +30,7 @@ public class MySQLQueueDAOTest extends MySQLBaseDAOTest {
 	private MySQLQueueDAO dao;
 
 	@Before
-	public void setup() throws Exception {
+	public void setup() {
 		dao = new MySQLQueueDAO(objectMapper, dataSource);
 		resetAllData();
 	}

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
@@ -15,19 +15,6 @@
  */
 package com.netflix.conductor.dao.dynomite.queue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.discovery.DiscoveryClient;
@@ -41,8 +28,18 @@ import com.netflix.dyno.queues.ShardSupplier;
 import com.netflix.dyno.queues.redis.DynoShardSupplier;
 import com.netflix.dyno.queues.redis.RedisDynoQueue;
 import com.netflix.dyno.queues.redis.RedisQueues;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCommands;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Singleton
 public class DynoQueueDAO implements QueueDAO {
@@ -210,4 +207,9 @@ public class DynoQueueDAO implements QueueDAO {
 		
 	}
 
+	@Override
+	public boolean exists(String queueName, String id) {
+		DynoQueue queue = queues.get(queueName);
+		return queue.get(id) != null;
+	}
 }

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowServiceTest.java
@@ -73,6 +73,9 @@ import java.util.stream.Collectors;
 
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.COMPLETED;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.FAILED;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRESS;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1334,7 +1337,7 @@ public class WorkflowServiceTest {
         assertEquals(1, workflow.getTasks().size());        //The very first task is the one that should be scheduled.
         assertEquals(1, queueDAO.getSize("task_rt"));
 
-        // Polling for the first task should return the same task as before
+        // Polling for the first task should return the first task
         Task task = workflowExecutionService.poll("task_rt", "task1.junit.worker.testTimeout");
         assertNotNull(task);
         assertEquals("task_rt", task.getTaskType());
@@ -1349,33 +1352,59 @@ public class WorkflowServiceTest {
         workflowExecutor.decide(workflowId);
         assertEquals(1, queueDAO.getSize("task_rt"));
 
+        // The first task would be timed_out and a new task will be scheduled
         workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
         assertNotNull(workflow);
         assertEquals(WorkflowStatus.RUNNING, workflow.getStatus());
         assertEquals(2, workflow.getTasks().size());
+        assertTrue(workflow.getTasks().stream().allMatch(t-> t.getReferenceTaskName().equals("task_rt_t1")));
+        assertEquals(TIMED_OUT, workflow.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, workflow.getTasks().get(1).getStatus());
 
-        // Polling now should get the same task back because it should have been put back in the queue
+        // Polling now should get the seco task back because it is now scheduled
         Task taskAgain = workflowExecutionService.poll("task_rt", "task1.junit.worker");
         assertNotNull(taskAgain);
 
+        // update task with callback after seconds greater than the response timeout
+        taskAgain.setStatus(IN_PROGRESS);
+        taskAgain.setCallbackAfterSeconds(20);
+        workflowExecutionService.updateTask(taskAgain);
+
+        workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals(WorkflowStatus.RUNNING, workflow.getStatus());
+        assertEquals(2, workflow.getTasks().size());
+        assertEquals(IN_PROGRESS, workflow.getTasks().get(1).getStatus());
+
+        // wait for callback after seconds which is longer than response timeout seconds and then call decide
+        Thread.sleep(20000);
+        workflowExecutor.decide(workflowId);
+        workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
+        assertNotNull(workflow);
+
+        // Poll for task again
+        taskAgain = workflowExecutionService.poll("task_rt", "task1.junit.worker");
+        assertNotNull(taskAgain);
+
+        // set task to completed
         taskAgain.getOutputData().put("op", "task1.Done");
         taskAgain.setStatus(COMPLETED);
         workflowExecutionService.updateTask(taskAgain);
 
+        // poll for next task
         task = workflowExecutionService.poll("junit_task_2", "task2.junit.worker.testTimeout");
         assertNotNull(task);
         assertEquals("junit_task_2", task.getTaskType());
         assertTrue(workflowExecutionService.ackTaskReceived(task.getTaskId()));
 
+        // set task to completed
         task.setStatus(COMPLETED);
         task.setReasonForIncompletion("unit test failure");
         workflowExecutionService.updateTask(task);
 
-
         workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
         assertNotNull(workflow);
         assertEquals(WorkflowStatus.COMPLETED, workflow.getStatus());
-
     }
 
     @Test
@@ -1440,7 +1469,7 @@ public class WorkflowServiceTest {
         // Since we are re running from the sub workflow task, there
         // should be only 1 task that is SCHEDULED
         assertEquals(1, subWorkflow.getTasks().size());
-        assertEquals(Status.SCHEDULED, subWorkflow.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, subWorkflow.getTasks().get(0).getStatus());
 
         // Now execute the task
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
@@ -2271,7 +2300,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // The first task would be marked as scheduled
         assertEquals(1, es.getTasks().size());
-        assertEquals(Task.Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
 
         // decideNow should be idempotent if re-run on the same state!
         es = workflowExecutionService.getExecutionStatus(wfid, true);
@@ -2279,7 +2308,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         assertEquals(1, es.getTasks().size());
         Task t = es.getTasks().get(0);
-        assertEquals(Status.SCHEDULED, t.getStatus());
+        assertEquals(SCHEDULED, t.getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertTrue(workflowExecutionService.ackTaskReceived(task.getTaskId()));
@@ -2310,7 +2339,7 @@ public class WorkflowServiceTest {
             if (wfTask.getTaskId().equals(taskId)) {
                 assertEquals(COMPLETED, wfTask.getStatus());
             } else {
-                assertEquals(Status.SCHEDULED, wfTask.getStatus());
+                assertEquals(SCHEDULED, wfTask.getStatus());
             }
         });
 
@@ -2394,7 +2423,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // The first task would be marked as scheduled
         assertEquals(1, es.getTasks().size());
-        assertEquals(Task.Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertTrue(workflowExecutionService.ackTaskReceived(task.getTaskId()));
@@ -2415,7 +2444,7 @@ public class WorkflowServiceTest {
             if (wfTask.getTaskId().equals(taskId)) {
                 assertEquals(COMPLETED, wfTask.getStatus());
             } else {
-                assertEquals(Status.SCHEDULED, wfTask.getStatus());
+                assertEquals(SCHEDULED, wfTask.getStatus());
             }
         });
 
@@ -2480,7 +2509,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // The first task would be marked as scheduled
         assertEquals(1, es.getTasks().size());
-        assertEquals(Task.Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
 
         List<Future<Void>> futures = new LinkedList<>();
         for (int i = 0; i < 10; i++) {
@@ -2499,7 +2528,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // The first task would be marked as scheduled
         assertEquals(1, es.getTasks().size());
-        assertEquals(Task.Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
 
 
         // decideNow should be idempotent if re-run on the same state!
@@ -2509,7 +2538,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         assertEquals(1, es.getTasks().size());
         Task t = es.getTasks().get(0);
-        assertEquals(Status.SCHEDULED, t.getStatus());
+        assertEquals(SCHEDULED, t.getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertTrue(workflowExecutionService.ackTaskReceived(task.getTaskId()));
@@ -2540,7 +2569,7 @@ public class WorkflowServiceTest {
             if (wfTask.getTaskId().equals(taskId)) {
                 assertEquals(COMPLETED, wfTask.getStatus());
             } else {
-                assertEquals(Status.SCHEDULED, wfTask.getStatus());
+                assertEquals(SCHEDULED, wfTask.getStatus());
             }
         });
 
@@ -2980,7 +3009,7 @@ public class WorkflowServiceTest {
         Task task1 = es.getTasks().get(0);
         assertEquals(Status.TIMED_OUT, task1.getStatus());
         Task task2 = es.getTasks().get(1);
-        assertEquals(Status.SCHEDULED, task2.getStatus());
+        assertEquals(SCHEDULED, task2.getStatus());
 
         task = workflowExecutionService.poll(task2.getTaskDefName(), "task1.junit.worker");
         assertNotNull(task);
@@ -3026,7 +3055,7 @@ public class WorkflowServiceTest {
         // Check the tasks, at this time there should be 1 task
         assertEquals(es.getTasks().size(), 1);
         Task t = es.getTasks().get(0);
-        assertEquals(Status.SCHEDULED, t.getStatus());
+        assertEquals(SCHEDULED, t.getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertNotNull(task);
@@ -3052,7 +3081,7 @@ public class WorkflowServiceTest {
             if (wfTask.getTaskId().equals(t.getTaskId())) {
                 assertEquals(wfTask.getStatus(), COMPLETED);
             } else {
-                assertEquals(wfTask.getStatus(), Status.SCHEDULED);
+                assertEquals(wfTask.getStatus(), SCHEDULED);
             }
         });
 
@@ -3089,7 +3118,7 @@ public class WorkflowServiceTest {
         assertEquals(esRR.getTasks().toString(), 2, esRR.getTasks().size());
         assertEquals(COMPLETED, esRR.getTasks().get(0).getStatus());
         Task tRR = esRR.getTasks().get(1);
-        assertEquals(esRR.getTasks().toString(), Status.SCHEDULED, tRR.getStatus());
+        assertEquals(esRR.getTasks().toString(), SCHEDULED, tRR.getStatus());
         assertEquals(tRR.getTaskType(), "junit_task_2");
 
         task = workflowExecutionService.poll("junit_task_2", "task2.junit.worker");
@@ -3122,7 +3151,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // Check the tasks, at this time there should be 1 task
         assertEquals(es.getTasks().size(), 1);
-        assertEquals(Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
 
         task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertNotNull(task);
@@ -3176,7 +3205,7 @@ public class WorkflowServiceTest {
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         // Check the tasks, at this time there should be 3 task
         assertEquals(2, es.getTasks().size());
-        assertEquals(Task.Status.SCHEDULED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
         assertEquals(Task.Status.SKIPPED, es.getTasks().get(1).getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
@@ -3206,7 +3235,7 @@ public class WorkflowServiceTest {
             } else if (wfTask.getReferenceTaskName().equals("t2")) {
                 assertEquals(Status.SKIPPED, wfTask.getStatus());
             } else {
-                assertEquals(Status.SCHEDULED, wfTask.getStatus());
+                assertEquals(SCHEDULED, wfTask.getStatus());
             }
         });
 
@@ -3258,7 +3287,7 @@ public class WorkflowServiceTest {
         assertNotNull(es);
         assertEquals(WorkflowStatus.RUNNING, es.getStatus());
         Task t = es.getTasks().get(0);
-        assertEquals(Status.SCHEDULED, t.getStatus());
+        assertEquals(SCHEDULED, t.getStatus());
 
         // PAUSE
         workflowExecutor.pauseWorkflow(wfid);
@@ -3969,7 +3998,7 @@ public class WorkflowServiceTest {
         }
     }
 
-    private void createWFWithResponseTimeout() throws Exception {
+    private void createWFWithResponseTimeout() {
         TaskDef task = new TaskDef();
         task.setName("task_rt");
         task.setTimeoutSeconds(120);


### PR DESCRIPTION
* Evaluate response timeout seconds only if the task is IN_PROGRESS and not present in the queue. This means that the task was put into the queue with a callbackAfterSeconds value.

* Reset callbackAfterSeconds for a task when it is given to a worker for execution through a poll.
