### PR TITLE
Dockerfile java image updates

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:serverAndUI - Netflix conductor server and UI
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 


### PR DESCRIPTION
This replaces the base images for Conductor Server with openjdk. The "java" images were deprecated 12/31/2016, so the versions of alpine and JRE 8 are rather old in these images.

In testing, I found some issues with these versions of JRE / Alpine when deploying to Docker in Windows using the overlay file system. Elasticache was unable to run due to file system errors.