### PR TITLE
Fixing EC2_AVAILABILITY_ZONE property name

### DIFF
--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -40,4 +40,4 @@ workflow.elasticsearch.index.name=conductor
 workflow.elasticsearch.version=2
 
 # For a single node dynomite or redis server, make sure the value below is set to same as rack specified in the "workflow.dynomite.cluster.hosts" property. 
-EC2_AVAILABILTY_ZONE=us-east-1c
+EC2_AVAILABILITY_ZONE=us-east-1c


### PR DESCRIPTION
Property name "EC2_AVAILABILITY_ZONE" was incorrectly defined in server.properties, and always the fallback value in System.getProperty was taken for this even if value was changed in properties file.

@cyzhao @kishorebanala @v1r3n 