### PR TITLE
Pin the Nodejs version to 9. 

### DIFF
--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:ui - Netflix conductor UI
 #
-FROM node:alpine
+FROM node:9-alpine
 MAINTAINER Netflix OSS <conductor@netflix.com>
 
 # Install the required packages for the node build


### PR DESCRIPTION
 Gulp and perhaps other dependencies have issues with 10.  Ref: https://github.com/gulpjs/gulp/issues/2162.

The short term fix is to pin the Dockerfile node version to 9 until someone can update the dependencies to work with 10.