### PR TITLE
Fix elastic search configuration issues.

### DIFF
--- a/docker/grpc/docker-compose.dependencies.yaml
+++ b/docker/grpc/docker-compose.dependencies.yaml
@@ -18,13 +18,14 @@ services:
     ports:
       - 3306:3306
 
+  # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html
   elasticsearch:
-    image: elasticsearch:5.6-alpine
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.8
     environment:
-      ES_JAVA_OPTS: "-Xms750m -Xmx750m"
-      transport.host: 0.0.0.0
-      discovery.type: single-node
-      cluster.name: conductor
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - transport.host=0.0.0.0
+      - discovery.type=single-node
+      - xpack.security.enabled=false
     networks:
       - internal
     ports:

--- a/server/src/main/java/com/netflix/conductor/bootstrap/Main.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/Main.java
@@ -62,10 +62,17 @@ public class Main {
                  */
                 Thread.sleep(EMBEDDED_ES_INIT_TIME);
             } catch (Exception ioe) {
+                ioe.printStackTrace(System.err);
                 System.exit(3);
             }
         }
-        serverInjector.getInstance(IndexDAO.class).setup();
+
+        try {
+            serverInjector.getInstance(IndexDAO.class).setup();
+        } catch (Exception e){
+            e.printStackTrace(System.err);
+            System.exit(3);
+        }
 
 
         System.out.println("\n\n\n");
@@ -80,6 +87,7 @@ public class Main {
             try {
                 server.start();
             } catch (IOException ioe) {
+                ioe.printStackTrace(System.err);
                 System.exit(3);
             }
         });
@@ -88,6 +96,7 @@ public class Main {
             try {
                 server.start();
             } catch (Exception ioe) {
+                ioe.printStackTrace(System.err);
                 System.exit(3);
             }
         });


### PR DESCRIPTION
There were some issues with the docker-compose configuration for elastic search.  They were preventing the application from starting correctly.  It seems like they were due mostly to change in the underlying ES version and its configuration.

I also improved the error handling and output of `Main` in order to make these failures more clear.