### PR TITLE
GRPC server reflection support 

### DIFF
--- a/grpc-server/build.gradle
+++ b/grpc-server/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile project(':conductor-grpc')
 
     compile "io.grpc:grpc-netty:${revGrpc}"
+    compile "io.grpc:grpc-services:${revGrpc}"
     compile "log4j:log4j:1.2.17"
 
     testCompile "io.grpc:grpc-testing:${revGrpc}"

--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServer.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServer.java
@@ -1,18 +1,15 @@
 package com.netflix.conductor.grpc.server;
 
 import com.netflix.conductor.service.Lifecycle;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Arrays;
-
-import javax.inject.Singleton;
-
 import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.List;
 
 @Singleton
 public class GRPCServer implements Lifecycle {
@@ -21,9 +18,9 @@ public class GRPCServer implements Lifecycle {
 
     private final Server server;
 
-    public GRPCServer(int port, BindableService... services) {
+    public GRPCServer(int port, List<BindableService> services) {
         ServerBuilder<?> builder = ServerBuilder.forPort(port);
-        Arrays.stream(services).forEach(builder::addService);
+        services.stream().forEach(builder::addService);
         server = builder.build();
     }
 

--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServer.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServer.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
 
 @Singleton
 public class GRPCServer implements Lifecycle {
@@ -18,9 +18,9 @@ public class GRPCServer implements Lifecycle {
 
     private final Server server;
 
-    public GRPCServer(int port, List<BindableService> services) {
+    public GRPCServer(int port, BindableService... services) {
         ServerBuilder<?> builder = ServerBuilder.forPort(port);
-        services.stream().forEach(builder::addService);
+        Arrays.stream(services).forEach(builder::addService);
         server = builder.build();
     }
 

--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServerConfiguration.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServerConfiguration.java
@@ -9,11 +9,18 @@ public interface GRPCServerConfiguration extends Configuration {
     String PORT_PROPERTY_NAME = "conductor.grpc.server.port";
     int PORT_DEFAULT_VALUE = 8090;
 
+    String SERVICE_REFLECTION_ENABLED_PROPERTY_NAME = "conductor.grpc.server.reflection.enabled";
+    boolean SERVICE_REFLECTION_ENABLED_DEFAULT_VALUE = true;
+
     default boolean isEnabled(){
        return getBooleanProperty(ENABLED_PROPERTY_NAME, ENABLED_DEFAULT_VALUE);
     }
 
     default int getPort(){
         return getIntProperty(PORT_PROPERTY_NAME, PORT_DEFAULT_VALUE);
+    }
+
+    default boolean isReflectionEnabled() {
+        return getBooleanProperty(SERVICE_REFLECTION_ENABLED_PROPERTY_NAME, SERVICE_REFLECTION_ENABLED_DEFAULT_VALUE);
     }
 }

--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServerProvider.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/GRPCServerProvider.java
@@ -6,7 +6,6 @@ import com.netflix.conductor.grpc.MetadataServiceGrpc;
 import com.netflix.conductor.grpc.TaskServiceGrpc;
 import com.netflix.conductor.grpc.WorkflowServiceGrpc;
 
-import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -46,11 +45,11 @@ public class GRPCServerProvider implements Provider<Optional<GRPCServer>> {
     @Override
     public Optional<GRPCServer> get() {
         return configuration.isEnabled() ?
-                Optional.of(getGRPCServer())
+                Optional.of(buildGRPCServer(configuration))
                 : Optional.empty();
     }
 
-    private GRPCServer getGRPCServer() {
+    private GRPCServer buildGRPCServer(GRPCServerConfiguration grpcServerConfiguration) {
         ImmutableList.Builder<BindableService> services = ImmutableList.<BindableService>builder().add(
                 healthServiceImpl,
                 eventServiceImpl,
@@ -58,13 +57,13 @@ public class GRPCServerProvider implements Provider<Optional<GRPCServer>> {
                 taskServiceImpl,
                 workflowServiceImpl);
 
-        if (configuration.isReflectionEnabled()) {
+        if (grpcServerConfiguration.isReflectionEnabled()) {
             services.add(ProtoReflectionService.newInstance());
         }
 
         return new GRPCServer(
-                configuration.getPort(),
-                services.build()
+                grpcServerConfiguration.getPort(),
+                services.build().toArray(new BindableService[]{})
         );
     }
 }


### PR DESCRIPTION
- Having the ability of enabling reflection on the grpc server will allow grpc clients to know which services are exposed.
- The feature can be controlled through the property `conductor.grpc.server.reflection.enabled`. By default the feature is enabled.