### PR TITLE
Docker CI

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8-jdk
+
+WORKDIR /workspace/conductor
+COPY . /workspace/conductor
+
+RUN ./gradlew clean build

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/server/Dockerfile.build
+++ b/docker/server/Dockerfile.build
@@ -1,7 +1,7 @@
 #
 # conductor:server - Netflix conductor server
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:serverAndUI - Netflix conductor server and UI
 #
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/EmbeddedDatabase.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/EmbeddedDatabase.java
@@ -1,5 +1,7 @@
 package com.netflix.conductor.dao.mysql;
 
+import ch.vorburger.mariadb4j.DBConfiguration;
+import ch.vorburger.mariadb4j.DBConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +20,11 @@ public enum EmbeddedDatabase {
 
 	private DB startEmbeddedDatabase() {
 		try {
-			DB db = DB.newEmbeddedDB(33307);
+			DBConfiguration dbConfiguration = DBConfigurationBuilder.newBuilder()
+					.setPort(33307)
+					.addArg("--user=root")
+					.build();
+			DB db = DB.newEmbeddedDB(dbConfiguration);
 			db.start();
 			db.createDB("conductor");
 			return db;


### PR DESCRIPTION
- Added Dockerfile for building and testing conductor. This should be a reference to solve issues related to a build (example: https://github.com/Netflix/conductor/pull/755). Can be used for extending a CI process as well. 
- Changed base image to `openjdk` as the java one is deprecated (https://hub.docker.com/_/java/)
- Updated how we initialize the embedded database used on the integration tests (Mariadb) so tests can be run on a docker container.

cc/ @gorzell 