### PR TITLE
Fixes the docker conductor:ui build.

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8346,9 +8346,9 @@
       }
     },
     "natives": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.2.tgz",
-      "integrity": "sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
       "dev": true
     },
     "natural-compare": {
@@ -11829,7 +11829,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.2"
+            "natives": "1.1.4"
           }
         },
         "isarray": {


### PR DESCRIPTION
There appears to be a weird error with the node dependencies and the current node version
used in the docker UI container image. You can find more information: https://github.com/gulpjs/gulp/issues/2162.

If you run the conductor UI container, it will not startup properly because the `npm run build --server` will fail with the following error:

```
../src/node_contextify.cc:631:static void node::contextify::ContextifyScript::New(const FunctionCallbackInfo<v8::Value> &): Assertion `args[1]->IsString()' failed.
```

Which is caused by the natives library. I simply just `npm update` in order to upgrade the packages.

This isn't caught in the Dockerfile for some reason. Even after using `set -e`, docker will run the command and continue on. Not sure why that happens, but you can run the command from the specific layer to see the real error message. Because the `dist` folder is never created, the `startup.sh` script will not run.
