### PR TITLE
fix: Set the reasonForIncompletion on the subworkflow task if subworkflow failed

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -88,6 +88,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 		if (subWorkflowStatus.isSuccessful()) {
 			task.setStatus(Status.COMPLETED);
 		} else {
+			task.setReasonForIncompletion(subWorkflow.getReasonForIncompletion());
 			task.setStatus(Status.FAILED);
 		}
 		return true;


### PR DESCRIPTION
Not sure why this was not set originally, but setting the `reasonForIncompletion` message on the subworkflow task if the subworkflow failed. This allows error messages to propagate to the parent without needing to drill down to the subworkflow if something failed.