### PR TITLE
feature for customizing url path using system property or environment property variable

### DIFF
--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -270,16 +271,20 @@ public class ConductorServer {
 		
 		Client client = Client.create();
 		ObjectMapper om = new ObjectMapper();
-		client.resource("http://localhost:" + port + "/api/metadata/taskdefs").type(MediaType.APPLICATION_JSON).post(om.writeValueAsString(taskDefs));
+		
+		String path = Optional.ofNullable(System.getProperty("url.path")).orElse(Optional.ofNullable(System.getenv("url_path")).orElse("/api"));
+        String uri = "http://localhost:"+ port + path;        
+		
+		client.resource(uri + "/metadata/taskdefs").type(MediaType.APPLICATION_JSON).post(om.writeValueAsString(taskDefs));
 		
 		InputStream stream = Main.class.getResourceAsStream("/kitchensink.json");
-		client.resource("http://localhost:" + port + "/api/metadata/workflow").type(MediaType.APPLICATION_JSON).post(stream);
+		client.resource(uri + "/metadata/workflow").type(MediaType.APPLICATION_JSON).post(stream);
 		
 		stream = Main.class.getResourceAsStream("/sub_flow_1.json");
-		client.resource("http://localhost:" + port + "/api/metadata/workflow").type(MediaType.APPLICATION_JSON).post(stream);
+		client.resource(uri + "/metadata/workflow").type(MediaType.APPLICATION_JSON).post(stream);
 		
 		String input = "{\"task2Name\":\"task_5\"}";
-		client.resource("http://localhost:" + port + "/api/workflow/kitchensink").type(MediaType.APPLICATION_JSON).post(input);
+		client.resource(uri + "/workflow/kitchensink").type(MediaType.APPLICATION_JSON).post(input);
 		
 		logger.info("Kitchen sink workflows are created!");
 	}

--- a/server/src/main/java/com/netflix/conductor/server/JerseyModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/JerseyModule.java
@@ -18,6 +18,7 @@ package com.netflix.conductor.server;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Singleton;
 import javax.servlet.Filter;
@@ -56,7 +57,9 @@ public final class JerseyModule extends JerseyServletModule {
 		jerseyParams.put("com.sun.jersey.config.property.WebPageContentRegex", "/(((webjars|api-docs|swagger-ui/docs|manage)/.*)|(favicon\\.ico))");
 		jerseyParams.put(PackagesResourceConfig.PROPERTY_PACKAGES, "com.netflix.conductor.server.resources;io.swagger.jaxrs.json;io.swagger.jaxrs.listing");
 		jerseyParams.put(ResourceConfig.FEATURE_DISABLE_WADL, "false");
-		serve("/api/*").with(GuiceContainer.class, jerseyParams);
+		
+		String path = Optional.ofNullable(System.getProperty("url.path")).orElse(Optional.ofNullable(System.getenv("url_path")).orElse("/api"));
+       	serve(path + "/*").with(GuiceContainer.class, jerseyParams);
     }
     
     @Provides 

--- a/server/src/main/resources/swagger-ui/index.html
+++ b/server/src/main/resources/swagger-ui/index.html
@@ -49,12 +49,13 @@
           if(window.SwaggerTranslator) {
               window.SwaggerTranslator.translate();
           }
-          window.swaggerUi = new SwaggerUi({
-              url: "http://" + url + "/api/swagger.json",
+         //Swagger URL: http://localhost:8080/?url=localhost:8080 + "/api" or "url_path property/env"
+          window.swaggerUi = new SwaggerUi({              
+              url: "http://" + url + "/swagger.json",
               dom_id: "swagger-ui-container",
               supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
               onComplete: function(swaggerApi, swaggerUi){
-                  window.swaggerUi.api.setHost(url + "/api");
+                  window.swaggerUi.api.setHost(url);
                   if(typeof initOAuth == "function") {
                       initOAuth({
                           clientId: "your-client-id",

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -78,15 +79,18 @@ public class End2EndTests {
 
 		ConductorServer server = new ConductorServer(new ConductorConfig());
 		server.start(8080, false);
-
+		
+		String path = Optional.ofNullable(System.getProperty("url.path")).orElse(Optional.ofNullable(System.getenv("url_path")).orElse("/api"));
+        String uri = "http://localhost:8080" + path + "/";
+        
 		taskClient = new TaskClient();
-		taskClient.setRootURI("http://localhost:8080/api/");
+		taskClient.setRootURI(uri);
 
 		workflowClient = new WorkflowClient();
-		workflowClient.setRootURI("http://localhost:8080/api/");
+		workflowClient.setRootURI(uri);
 
 		metadataClient = new MetadataClient();
-		metadataClient.setRootURI("http://localhost:8080/api/");
+		metadataClient.setRootURI(uri);
 	}
 
 	@Test
@@ -253,7 +257,8 @@ public class End2EndTests {
 	@Test
 	public void testInvalidResource() {
         MetadataClient metadataClient = new MetadataClient();
-        metadataClient.setRootURI("http://localhost:8080/api/invalid");
+        String path = Optional.ofNullable(System.getProperty("url.path")).orElse(Optional.ofNullable(System.getenv("url_path")).orElse("/api"));
+        metadataClient.setRootURI("http://localhost:8080" + path + "/invalid");
 
         WorkflowDef def = new WorkflowDef();
         def.setName("testWorkflowDel");

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/End2EndTests.java
@@ -81,7 +81,7 @@ public class End2EndTests {
 		server.start(8080, false);
 		
 		String path = Optional.ofNullable(System.getProperty("url.path")).orElse(Optional.ofNullable(System.getenv("url_path")).orElse("/api"));
-        String uri = "http://localhost:8080" + path + "/";
+        String uri = "http://localhost:8080" + path + "/"; 
         
 		taskClient = new TaskClient();
 		taskClient.setRootURI(uri);


### PR DESCRIPTION
Added url.path property (url_path system env) for customizing the uri path. This application was hard coded with /api path, which did not fit our organization standard. This feature would enable users to customize their url path as per their internal standards, by passing in the value externally either through system property or system environment variable. If the variable is not set, the application would use the default /api path.