### PR TITLE
add responseTimeoutSeconds field validation

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/MetadataService.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataService.java
@@ -18,6 +18,8 @@
  */
 package com.netflix.conductor.service;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -61,6 +63,11 @@ public class MetadataService {
             taskDefinition.setCreateTime(System.currentTimeMillis());
             taskDefinition.setUpdatedBy(null);
             taskDefinition.setUpdateTime(null);
+
+            ServiceUtils.checkNotNull(taskDefinition,"TaskDef object cannot be null");
+            ServiceUtils.checkNotNull(taskDefinition.getName(),"TaskDef name cannot be null");
+            ServiceUtils.checkArgument(taskDefinition.getResponseTimeoutSeconds()>0, "ResponseTimeoutSeconds must be positive");
+
             metadataDAO.createTaskDef(taskDefinition);
         }
     }
@@ -114,6 +121,8 @@ public class MetadataService {
      * @param def Workflow definition to be updated
      */
     public void updateWorkflowDef(WorkflowDef def) {
+        Preconditions.checkNotNull(def, "WorkflowDef object cannot be null");
+        Preconditions.checkNotNull(def.getName(), "WorkflowDef name cannot be null");
         metadataDAO.update(def);
     }
 
@@ -233,7 +242,8 @@ public class MetadataService {
         return metadataDAO.getEventHandlersForEvent(event, activeOnly);
     }
 
-    private void validateEvent(EventHandler eh) {
+    @VisibleForTesting
+    public void validateEvent(EventHandler eh) {
         ServiceUtils.checkNotNullOrEmpty(eh.getName(), "Missing event handler name");
         ServiceUtils.checkNotNullOrEmpty(eh.getEvent(), "Missing event location");
         ServiceUtils.checkNotNullOrEmpty(eh.getActions(), "No actions specified. Please specify at-least one action");

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -46,7 +46,6 @@ import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -97,7 +96,7 @@ public class TestDeciderOutcomes {
 		TaskDef taskDef = new TaskDef();
 		taskDef.setRetryCount(1);
 		taskDef.setName("mockTaskDef");
-		taskDef.setResponseTimeoutSeconds(0);
+		taskDef.setResponseTimeoutSeconds(60*60);
 		when(metadataDAO.getTaskDef(any())).thenReturn(taskDef);
 		ParametersUtils parametersUtils = new ParametersUtils();
 		Map<String, TaskMapper> taskMappers = new HashMap<>();
@@ -237,6 +236,10 @@ public class TestDeciderOutcomes {
 
 		task1Id = outcome.tasksToBeScheduled.get(1).getTaskId();
 		outcome.tasksToBeScheduled.get(1).setStatus(Status.FAILED);
+
+		for(Task taskToBeScheduled : outcome.tasksToBeScheduled) {
+			taskToBeScheduled.setUpdateTime(System.currentTimeMillis());
+		}
 		workflow.getTasks().addAll(outcome.tasksToBeScheduled);
 
 		outcome = deciderService.decide(workflow, def);
@@ -361,7 +364,10 @@ public class TestDeciderOutcomes {
 		assertEquals(Task.Status.IN_PROGRESS, outcome.tasksToBeScheduled.get(4).getStatus());
 		workflow.getTasks().clear();
 		workflow.getTasks().addAll(outcome.tasksToBeScheduled);
-
+		
+		for(Task taskToBeScheduled : outcome.tasksToBeScheduled) {
+			taskToBeScheduled.setUpdateTime(System.currentTimeMillis());
+		}
 		outcome = deciderService.decide(workflow, workflowDef);
 		assertNotNull(outcome);
 		assertEquals(SystemTaskType.JOIN.name(), outcome.tasksToBeScheduled.get(0).getTaskType());

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -1,0 +1,142 @@
+package com.netflix.conductor.service;
+
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.core.events.EventQueues;
+import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.dao.MetadataDAO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class MetadataServiceTest {
+
+    private MetadataService metadataService;
+    private MetadataDAO metadataDAO;
+    private EventQueues eventQueues;
+
+    @Before
+    public void before() {
+        metadataDAO = Mockito.mock(MetadataDAO.class);
+        eventQueues = Mockito.mock(EventQueues.class);
+        metadataService = new MetadataService(metadataDAO, eventQueues);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testRegisterTaskDefNoName() {
+        TaskDef taskDef = new TaskDef();//name is null
+        metadataService.registerTaskDef(Arrays.asList(taskDef));
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testRegisterTaskDefNoResponseTimeout() {
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("somename");
+        taskDef.setResponseTimeoutSeconds(0);//wrong
+        metadataService.registerTaskDef(Arrays.asList(taskDef));
+    }
+
+    @Test
+    public void testRegisterTaskDef() {
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("somename");
+        taskDef.setResponseTimeoutSeconds(60 * 60);//wrong
+        metadataService.registerTaskDef(Arrays.asList(taskDef));
+        verify(metadataDAO, times(1)).createTaskDef(any(TaskDef.class));
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testUpdateWorkflowDefNoName() {
+        WorkflowDef workflowDef = new WorkflowDef();//name is null
+        metadataService.updateWorkflowDef(Arrays.asList(workflowDef));
+    }
+
+    @Test
+    public void testUpdateWorkflowDef() {
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("somename");
+        metadataService.updateWorkflowDef(Arrays.asList(workflowDef));
+        verify(metadataDAO, times(1)).update(workflowDef);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testRegisterWorkflowDefNoName() {
+        WorkflowDef workflowDef = new WorkflowDef();//name is null
+        metadataService.registerWorkflowDef(workflowDef);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testRegisterWorkflowDefInvalidName() {
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("invalid:name");//not allowed
+        metadataService.registerWorkflowDef(workflowDef);
+    }
+
+    @Test
+    public void testRegisterWorkflowDef() {
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("somename");
+        workflowDef.setSchemaVersion(5);
+        metadataService.registerWorkflowDef(workflowDef);
+        verify(metadataDAO, times(1)).create(workflowDef);
+        assertEquals(2, workflowDef.getSchemaVersion());
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testUnregisterWorkflowDefNoName() {
+        metadataService.unregisterWorkflowDef("", 1);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testUnregisterWorkflowDefNoVersion() {
+        metadataService.unregisterWorkflowDef("somename", null);
+    }
+
+    @Test
+    public void testUnregisterWorkflowDef() {
+        metadataService.unregisterWorkflowDef("somename", 111);
+        verify(metadataDAO, times(1)).removeWorkflowDef("somename", 111);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testValidateEventNoName() {
+        EventHandler eventHandler = new EventHandler();
+        metadataService.validateEvent(eventHandler);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testValidateEventNoEvent() {
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName("somename");
+        metadataService.validateEvent(eventHandler);
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testValidateEventNoAction() {
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName("somename");
+        eventHandler.setEvent("someevent");
+        metadataService.validateEvent(eventHandler);
+    }
+
+    @Test
+    public void testValidateEvent() {
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName("somename");
+        eventHandler.setEvent("someevent");
+        EventHandler.Action action = new EventHandler.Action();
+        eventHandler.setActions(Arrays.asList(action));
+        metadataService.validateEvent(eventHandler);
+
+        verify(eventQueues, times(1)).getQueue("someevent");
+    }
+
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
@@ -38,7 +38,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
     @Override
     public String createTaskDef(TaskDef taskDef) {
-        validate(taskDef);
         if (null == taskDef.getCreateTime() || taskDef.getCreateTime() < 1) {
             taskDef.setCreateTime(System.currentTimeMillis());
         }
@@ -48,7 +47,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
     @Override
     public String updateTaskDef(TaskDef taskDef) {
-        validate(taskDef);
         taskDef.setUpdateTime(System.currentTimeMillis());
         return insertOrUpdateTaskDef(taskDef);
     }
@@ -87,7 +85,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
     @Override
     public void create(WorkflowDef def) {
-        validate(def);
         if (null == def.getCreateTime() || def.getCreateTime() == 0) {
             def.setCreateTime(System.currentTimeMillis());
         }
@@ -104,7 +101,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
     @Override
     public void update(WorkflowDef def) {
-        validate(def);
         def.setUpdateTime(System.currentTimeMillis());
         withTransaction(tx -> insertOrUpdateWorkflowDef(tx, def));
     }
@@ -252,29 +248,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
                 return handlers;
             });
         });
-    }
-
-    /**
-     * Use {@link Preconditions} to check for required {@link TaskDef} fields, throwing a Runtime exception
-     * if validations fail.
-     *
-     * @param taskDef The {@code TaskDef} to check.
-     */
-    private void validate(TaskDef taskDef) {
-        Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
-        Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
-        Preconditions.checkNotNull(taskDef.getResponseTimeoutSeconds(), "ResponseTimeoutSeconds cannot be null");
-    }
-
-    /**
-     * Use {@link Preconditions} to check for required {@link WorkflowDef} fields, throwing a Runtime exception
-     * if validations fail.
-     *
-     * @param def The {@code WorkflowDef} to check.
-     */
-    private void validate(WorkflowDef def) {
-        Preconditions.checkNotNull(def, "WorkflowDef object cannot be null");
-        Preconditions.checkNotNull(def.getName(), "WorkflowDef name cannot be null");
     }
 
     /**

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
@@ -263,6 +263,7 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
     private void validate(TaskDef taskDef) {
         Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
         Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
+        Preconditions.checkNotNull(taskDef.getResponseTimeoutSeconds(), "ResponseTimeoutSeconds cannot be null");
     }
 
     /**

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
@@ -1,25 +1,25 @@
 package com.netflix.conductor.dao.mysql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.execution.ApplicationException;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("Duplicates")
 @RunWith(JUnit4.class)
@@ -31,12 +31,6 @@ public class MySQLMetadataDAOTest extends MySQLBaseDAOTest {
     public void setup() throws Exception {
         dao = new MySQLMetadataDAO(objectMapper, dataSource, testConfiguration);
         resetAllData();
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testMissingName() throws Exception {
-        WorkflowDef def = new WorkflowDef();
-        dao.create(def);
     }
 
     @Test(expected=ApplicationException.class)

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -83,6 +83,7 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 
         Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
         Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
+        Preconditions.checkNotNull(taskDef.getResponseTimeoutSeconds(), "ResponseTimeoutSeconds cannot be null");
 
         // Store all task def in under one key
         String payload = toJson(taskDef);

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -80,11 +80,6 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
     }
 
     private String insertOrUpdateTaskDef(TaskDef taskDef) {
-
-        Preconditions.checkNotNull(taskDef, "TaskDef object cannot be null");
-        Preconditions.checkNotNull(taskDef.getName(), "TaskDef name cannot be null");
-        Preconditions.checkNotNull(taskDef.getResponseTimeoutSeconds(), "ResponseTimeoutSeconds cannot be null");
-
         // Store all task def in under one key
         String payload = toJson(taskDef);
         dynoClient.hset(nsKey(ALL_TASK_DEFS), taskDef.getName(), payload);
@@ -377,9 +372,6 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
     }
 
     private void _createOrUpdate(WorkflowDef workflowDef) {
-        Preconditions.checkNotNull(workflowDef, "WorkflowDef object cannot be null");
-        Preconditions.checkNotNull(workflowDef.getName(), "WorkflowDef name cannot be null");
-
         // First set the workflow def
         dynoClient.hset(nsKey(WORKFLOW_DEF, workflowDef.getName()), String.valueOf(workflowDef.getVersion()),
                 toJson(workflowDef));

--- a/redis-persistence/src/test/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAOTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAOTest.java
@@ -18,22 +18,6 @@
  */
 package com.netflix.conductor.dao.dynomite;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import com.netflix.conductor.common.run.Workflow;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,8 +33,21 @@ import com.netflix.conductor.config.TestConfiguration;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.dao.redis.JedisMock;
-
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.junit.Before;
+import org.junit.Test;
 import redis.clients.jedis.JedisCommands;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Viren
@@ -77,12 +74,6 @@ public class RedisMetadataDAOTest {
         DynoProxy dynoClient = new DynoProxy(jedisMock);
 
         dao = new RedisMetadataDAO(dynoClient, om, config);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testMissingName() throws Exception {
-        WorkflowDef def = new WorkflowDef();
-        dao.create(def);
     }
 
     @Test(expected=ApplicationException.class)


### PR DESCRIPTION
enforcing responseTimeoutSeconds field to be not null whenever task definition gets created or updated (default is 1h)