### PR TITLE
Fix Python client task update procedure 

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -171,7 +171,8 @@ class TaskClient(BaseClient):
 
     def updateTask(self, taskObj):
         url = self.makeUrl('')
-        self.post(url, None, taskObj)
+        headers = {'Accept': 'text/plain'}
+        self.post(url, None, taskObj, headers)
 
     def pollForTask(self, taskType, workerid, domain=None):
         url = self.makeUrl('poll/{}', taskType)

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -107,7 +107,7 @@ public class TaskResource {
 
 	@POST
 	@ApiOperation("Update a task")
-    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
+	@Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
 	public String updateTask(TaskResult taskResult) {
 		return taskService.updateTask(taskResult);
 	}

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 
+ *
  * @author visingh
  *
  */
@@ -107,6 +107,7 @@ public class TaskResource {
 
 	@POST
 	@ApiOperation("Update a task")
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
 	public String updateTask(TaskResult taskResult) {
 		return taskService.updateTask(taskResult);
 	}
@@ -119,14 +120,14 @@ public class TaskResource {
                       @QueryParam("workerid") String workerId) {
 		return taskService.ackTaskReceived(taskId, workerId);
 	}
-	
+
 	@POST
 	@Path("/{taskId}/log")
 	@ApiOperation("Log Task Execution Details")
 	public void log(@PathParam("taskId") String taskId, String log) {
         taskService.log(taskId, log);
 	}
-	
+
 	@GET
 	@Path("/{taskId}/log")
 	@ApiOperation("Get Task Execution Logs")
@@ -197,7 +198,7 @@ public class TaskResource {
 	public String requeue() {
 		return taskService.requeue();
 	}
-	
+
 	@POST
 	@Path("/queue/requeue/{taskType}")
 	@ApiOperation("Requeue pending tasks")
@@ -206,7 +207,7 @@ public class TaskResource {
 	public String requeuePendingTask(@PathParam("taskType") String taskType) {
 		return taskService.requeuePendingTask(taskType);
 	}
-	
+
 	@ApiOperation(value="Search for tasks based in payload and other parameters",
             notes="use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC." +
                     " If order is not specified, defaults to ASC")


### PR DESCRIPTION
As raised in #764 the task update API response has changed and no longer returns a JSON formatted string. This breaks the Python client when it tries to parse the response as a JSON response. 

This change updates the task POST endpoint to allow `'Accept': 'text/plain'` headers and implements the corresponding change in the Python client so that it does not expect a JSON response. I have left the `MediaType.APPLICATION_JSON` as valid response type so that any clients that are currently expecting such a response do not break with the change assuming they are able to parse the non JSON formatted string.