### PR TITLE
Updated event handling to lookup tasks by id if available

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
@@ -241,6 +241,9 @@ public class EventHandler {
 		@ProtoField(id = 4)
 		private Any outputMessage;
 
+		@ProtoField(id = 5)
+		private String taskId;
+
 		/**
 		 * @return the workflowId
 		 */
@@ -293,6 +296,20 @@ public class EventHandler {
 		public void setOutputMessage(Any outputMessage) {
 			this.outputMessage = outputMessage;
 		}
+
+        /**
+         * @return the taskId
+         */
+        public String getTaskId() {
+            return taskId;
+        }
+
+        /**
+         * @param taskId the taskId to set
+         */
+        public void setTaskId(String taskId) {
+            this.taskId = taskId;
+        }
 	}
 
 	@ProtoMessage

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/QueueAdminResource.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/QueueAdminResource.java
@@ -18,6 +18,7 @@
  */
 package com.netflix.conductor.contribs.queue;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -73,7 +74,14 @@ public class QueueAdminResource {
 	@Path("/update/{workflowId}/{taskRefName}/{status}")
 	@ApiOperation("Publish a message in queue to mark a wait task as completed.")
 	public void update(@PathParam("workflowId") String workflowId, @PathParam("taskRefName") String taskRefName, @PathParam("status") Status status, Map<String, Object> output) throws Exception {
-		qm.update(workflowId, taskRefName, output, status);
+		qm.updateByTaskRefName(workflowId, taskRefName, output, status);
+	}
+
+	@POST
+	@Path("/update/{workflowId}/task/{taskId}/{status}")
+	@ApiOperation("Publish a message in queue to mark a wait task (by taskId) as completed.")
+	public void updateByTaskId(@PathParam("workflowId") String workflowId, @PathParam("taskId") String taskId, @PathParam("status") Status status, Map<String, Object> output) throws Exception {
+		qm.updateByTaskId(workflowId, taskId, output, status);
 	}
 	
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -741,6 +741,12 @@ public class WorkflowExecutor {
         }
     }
 
+    public Task getTask(String taskId) {
+        return Optional.ofNullable(executionDAO.getTask(taskId))
+            .map(metadataMapperService::populateTaskWithDefinition)
+            .orElse(null);
+    }
+
     public List<Task> getTasks(String taskType, String startKey, int count) {
         return executionDAO.getTasks(taskType, startKey, count);
     }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -211,9 +211,7 @@ public class ExecutionService {
 	}
 
 	public Task getTask(String taskId) {
-		return Optional.ofNullable(executionDAO.getTask(taskId))
-                .map(t -> metadataMapperService.populateTaskWithDefinition(t))
-				.orElse(null);
+		return workflowExecutor.getTask(taskId);
 	}
 
 	public Task getPendingTaskForWorkflow(String taskReferenceName, String workflowId) {

--- a/core/src/test/java/com/netflix/conductor/core/events/TestActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestActionProcessor.java
@@ -1,0 +1,129 @@
+package com.netflix.conductor.core.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.events.EventHandler.Action;
+import com.netflix.conductor.common.metadata.events.EventHandler.Action.Type;
+import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
+import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.metadata.tasks.TaskResult.Status;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ParametersUtils;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class TestActionProcessor {
+    private WorkflowExecutor workflowExecutor;
+    private ActionProcessor actionProcessor;
+
+    @Before
+    public void setup() {
+        workflowExecutor = mock(WorkflowExecutor.class);
+
+        actionProcessor = new ActionProcessor(workflowExecutor, new ParametersUtils());
+    }
+
+    @Test
+    public void testStartWorkflow() throws Exception {
+        StartWorkflow startWorkflow = new StartWorkflow();
+        startWorkflow.setName("testWorkflow");
+        startWorkflow.getInput().put("testInput", "${testId}");
+
+        Action action = new Action();
+        action.setAction(Type.START_WORKFLOW);
+        action.setStartWorkflow(startWorkflow);
+
+        Object payload = new ObjectMapper().readValue("{\"testId\":\"test_1\"}", Object.class);
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("testWorkflow");
+        workflowDef.setVersion(1);
+
+        when(workflowExecutor.startWorkflow(eq("testWorkflow"), eq(null), any(), any(), eq("testEvent")))
+            .thenReturn("workflow_1");
+
+        Map<String, Object> output = actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        assertNotNull(output);
+        assertEquals("workflow_1", output.get("workflowId"));
+
+        ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(workflowExecutor).startWorkflow(eq("testWorkflow"), eq(null), any(), argumentCaptor.capture(), eq("testEvent"));
+        assertEquals("test_1", argumentCaptor.getValue().get("testInput"));
+        assertEquals("testMessage", argumentCaptor.getValue().get("conductor.event.messageId"));
+        assertEquals("testEvent", argumentCaptor.getValue().get("conductor.event.name"));
+    }
+
+    @Test
+    public void testCompleteTask() throws Exception {
+        TaskDetails taskDetails = new TaskDetails();
+        taskDetails.setWorkflowId("${workflowId}");
+        taskDetails.setTaskRefName("testTask");
+
+        Action action = new Action();
+        action.setAction(Type.COMPLETE_TASK);
+        action.setCompleteTask(taskDetails);
+
+        Object payload = new ObjectMapper().readValue("{\"workflowId\":\"workflow_1\"}", Object.class);
+
+        Task task = new Task();
+        task.setReferenceTaskName("testTask");
+        Workflow workflow = new Workflow();
+        workflow.getTasks().add(task);
+
+        when(workflowExecutor.getWorkflow(eq("workflow_1"), anyBoolean())).thenReturn(workflow);
+
+        actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        ArgumentCaptor<TaskResult> argumentCaptor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(workflowExecutor).updateTask(argumentCaptor.capture());
+        assertEquals(Status.COMPLETED, argumentCaptor.getValue().getStatus());
+        assertEquals("testMessage", argumentCaptor.getValue().getOutputData().get("conductor.event.messageId"));
+        assertEquals("testEvent", argumentCaptor.getValue().getOutputData().get("conductor.event.name"));
+        assertEquals("workflow_1", argumentCaptor.getValue().getOutputData().get("workflowId"));
+        assertEquals("testTask", argumentCaptor.getValue().getOutputData().get("taskRefName"));
+    }
+
+    @Test
+    public void testCompleteTaskByTaskId() throws Exception {
+        TaskDetails taskDetails = new TaskDetails();
+        taskDetails.setWorkflowId("${workflowId}");
+        taskDetails.setTaskId("${taskId}");
+
+        Action action = new Action();
+        action.setAction(Type.COMPLETE_TASK);
+        action.setCompleteTask(taskDetails);
+
+        Object payload = new ObjectMapper().readValue("{\"workflowId\":\"workflow_1\", \"taskId\":\"task_1\"}", Object.class);
+
+        Task task = new Task();
+        task.setTaskId("task_1");
+        task.setReferenceTaskName("testTask");
+
+        when(workflowExecutor.getTask(eq("task_1"))).thenReturn(task);
+
+        actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        ArgumentCaptor<TaskResult> argumentCaptor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(workflowExecutor).updateTask(argumentCaptor.capture());
+        assertEquals(Status.COMPLETED, argumentCaptor.getValue().getStatus());
+        assertEquals("testMessage", argumentCaptor.getValue().getOutputData().get("conductor.event.messageId"));
+        assertEquals("testEvent", argumentCaptor.getValue().getOutputData().get("conductor.event.name"));
+        assertEquals("workflow_1", argumentCaptor.getValue().getOutputData().get("workflowId"));
+        assertEquals("task_1", argumentCaptor.getValue().getOutputData().get("taskId"));
+    }
+}

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -197,6 +197,9 @@ public abstract class AbstractProtoMapper {
         if (from.getOutputMessage() != null) {
             to.setOutputMessage( toProto( from.getOutputMessage() ) );
         }
+        if (from.getTaskId() != null) {
+            to.setTaskId( from.getTaskId() );
+        }
         return to.build();
     }
 
@@ -212,6 +215,7 @@ public abstract class AbstractProtoMapper {
         if (from.hasOutputMessage()) {
             to.setOutputMessage( fromProto( from.getOutputMessage() ) );
         }
+        to.setTaskId( from.getTaskId() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/eventhandler.proto
+++ b/grpc/src/main/proto/model/eventhandler.proto
@@ -21,6 +21,7 @@ message EventHandler {
         string task_ref_name = 2;
         map<string, google.protobuf.Value> output = 3;
         google.protobuf.Any output_message = 4;
+        string task_id = 5;
     }
     message Action {
         enum Type {


### PR DESCRIPTION
- Currently, the event handler uses the workflowId and taskRefName in the message payload to lookup the task. Updated the event handler to lookup the task by taskId if it is available in the message payload. 

-Updated to ack the message when no matching waiting tasks are found for the message.