### PR TITLE
Fix Main class when using 'gradle server'.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -80,6 +80,6 @@ task server(type: JavaExec) {
     // Switch between Elasticsearch versions 2 & 5 with major version number.
     systemProperty 'loadSample', 'true'
     systemProperties System.properties
-    main = 'com.netflix.conductor.server.Main'
+    main = 'com.netflix.conductor.bootstrap.Main'
     classpath = sourceSets.test.runtimeClasspath
 }


### PR DESCRIPTION
The Main class for server has been changed to `com.netflix.conductor.bootstrap.Main`, but doesn't change it in `server/build.gradle`, so if executing 'gradle server', a ClassNotFoundException is broken out.

So, update build.gradle to fix the problem!