### PR TITLE
fix TaskSummary Serializing, missed no-arguments constructor

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
@@ -86,6 +86,9 @@ public class TaskSummary {
 	@ProtoField(id = 16)
 	private String taskId;
 
+    public TaskSummary() {
+    }
+
 	public TaskSummary(Task task) {
 		
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");

--- a/common/src/test/java/com/netflix/conductor/common/run/TestTaskSummary.java
+++ b/common/src/test/java/com/netflix/conductor/common/run/TestTaskSummary.java
@@ -1,0 +1,23 @@
+package com.netflix.conductor.common.run;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestTaskSummary {
+
+    @Test
+    public void testJsonSerializing() throws Exception {
+        ObjectMapper om = new ObjectMapper();
+
+        Task task = new Task();
+        TaskSummary taskSummary = new TaskSummary(task);
+
+        String json = om.writeValueAsString(taskSummary);
+        TaskSummary read = om.readValue(json, TaskSummary.class);
+        assertNotNull(read);
+    }
+
+}


### PR DESCRIPTION
In `TaskSummary` class,  missed no-arguments constructor, but it is necessary for jersy `getEntity` method to parse to object. If missed, a exception broken out, for example:
```
Caused by: com.sun.jersey.api.client.ClientHandlerException: 
com.fasterxml.jackson.databind.JsonMappingException: 
Can not construct instance of com.netflix.conductor.common.run.TaskSummary: 
no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)
```

So, add no-arguments constructor to resolve it .