### PR TITLE
Refactor and fixes

### DIFF
--- a/client/src/test/java/com/netflix/conductor/client/http/MetadataClientTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/MetadataClientTest.java
@@ -1,22 +1,16 @@
 package com.netflix.conductor.client.http;
 
-import com.sun.jersey.api.client.Client;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.netflix.conductor.client.http.MetadataClient;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 /**

--- a/client/src/test/java/com/netflix/conductor/client/metadata/workflow/TestWorkflowTask.java
+++ b/client/src/test/java/com/netflix/conductor/client/metadata/workflow/TestWorkflowTask.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,46 +15,65 @@
  */
 package com.netflix.conductor.client.metadata.workflow;
 
-import static org.junit.Assert.*;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.utils.JsonMapperProvider;
+import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
- * 
  * @author Viren
- *
  */
 public class TestWorkflowTask {
 
-	@Test
-	public void test() throws Exception {
-		ObjectMapper om = new ObjectMapper();
-		WorkflowTask task = new WorkflowTask();
-		task.setType("Hello");
-		task.setName("name");
-		
-		String json = om.writeValueAsString(task);
+    private ObjectMapper objectMapper;
 
-		WorkflowTask read = om.readValue(json, WorkflowTask.class);
-		assertNotNull(read);
-		assertEquals(task.getName(), read.getName());
-		assertEquals(task.getType(), read.getType());
-		
-		task = new WorkflowTask();
-		task.setWorkflowTaskType(TaskType.SUB_WORKFLOW);
-		task.setName("name");
-		
-		json = om.writeValueAsString(task);
+    @Before
+    public void setup() {
+        objectMapper = new JsonMapperProvider().get();
+    }
 
-		read = om.readValue(json, WorkflowTask.class);
-		assertNotNull(read);
-		assertEquals(task.getName(), read.getName());
-		assertEquals(task.getType(), read.getType());
-		assertEquals(TaskType.SUB_WORKFLOW.name(), read.getType());
-	}
+    @Test
+    public void test() throws Exception {
+        WorkflowTask task = new WorkflowTask();
+        task.setType("Hello");
+        task.setName("name");
 
+        String json = objectMapper.writeValueAsString(task);
+
+        WorkflowTask read = objectMapper.readValue(json, WorkflowTask.class);
+        assertNotNull(read);
+        assertEquals(task.getName(), read.getName());
+        assertEquals(task.getType(), read.getType());
+
+        task = new WorkflowTask();
+        task.setWorkflowTaskType(TaskType.SUB_WORKFLOW);
+        task.setName("name");
+
+        json = objectMapper.writeValueAsString(task);
+
+        read = objectMapper.readValue(json, WorkflowTask.class);
+        assertNotNull(read);
+        assertEquals(task.getName(), read.getName());
+        assertEquals(task.getType(), read.getType());
+        assertEquals(TaskType.SUB_WORKFLOW.name(), read.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testObectMapper() throws Exception {
+        try (InputStream stream = TestWorkflowTask.class.getResourceAsStream("/tasks.json")) {
+            List<Task> tasks = objectMapper.readValue(stream, List.class);
+            assertNotNull(tasks);
+            assertEquals(1, tasks.size());
+        }
+    }
 }

--- a/client/src/test/resources/tasks.json
+++ b/client/src/test/resources/tasks.json
@@ -1,0 +1,70 @@
+[
+  {
+    "taskType": "task_1",
+    "status": "IN_PROGRESS",
+    "inputData": {
+      "mod": null,
+      "oddEven": null
+    },
+    "referenceTaskName": "task_1",
+    "retryCount": 0,
+    "seq": 1,
+    "pollCount": 1,
+    "taskDefName": "task_1",
+    "scheduledTime": 1539623183131,
+    "startTime": 1539623436841,
+    "endTime": 0,
+    "updateTime": 1539623436841,
+    "startDelayInSeconds": 0,
+    "retried": false,
+    "executed": false,
+    "callbackFromWorker": true,
+    "responseTimeoutSeconds": 0,
+    "workflowInstanceId": "2d525ed8-d0e5-44c8-a2df-a110b25c09ac",
+    "workflowType": "kitchensink",
+    "taskId": "bc5d9deb-cf86-443d-a1f6-59c36d2464f7",
+    "callbackAfterSeconds": 0,
+    "workerId": "test",
+    "workflowTask": {
+      "name": "task_1",
+      "taskReferenceName": "task_1",
+      "inputParameters": {
+        "mod": "${workflow.input.mod}",
+        "oddEven": "${workflow.input.oddEven}"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": false,
+      "taskDefinition": {
+        "ownerApp": "falguni-test",
+        "createTime": 1534274994644,
+        "createdBy": "CPEWORKFLOW",
+        "name": "task_1",
+        "description": "Test Task 01",
+        "retryCount": 0,
+        "timeoutSeconds": 5,
+        "inputKeys": [
+          "mod",
+          "oddEven"
+        ],
+        "outputKeys": [
+          "someOutput"
+        ],
+        "timeoutPolicy": "TIME_OUT_WF",
+        "retryLogic": "FIXED",
+        "retryDelaySeconds": 0,
+        "responseTimeoutSeconds": 0,
+        "concurrentExecLimit": 0,
+        "rateLimitPerFrequency": 0,
+        "rateLimitFrequencyInSeconds": 1
+      }
+    },
+    "rateLimitPerFrequency": 0,
+    "rateLimitFrequencyInSeconds": 0,
+    "taskDefinition": {
+      "present": true
+    },
+    "queueWaitTime": 253710,
+    "taskStatus": "IN_PROGRESS"
+  }
+]

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -135,7 +135,7 @@ public class Task {
     private boolean callbackFromWorker = true;
 
     @ProtoField(id = 19)
-    private int responseTimeoutSeconds;
+    private long responseTimeoutSeconds;
 
     @ProtoField(id = 20)
     private String workflowInstanceId;
@@ -459,14 +459,14 @@ public class Task {
     /**
      * @return the timeout for task to send response.  After this timeout, the task will be re-queued
      */
-    public int getResponseTimeoutSeconds() {
+    public long getResponseTimeoutSeconds() {
         return responseTimeoutSeconds;
     }
 
     /**
      * @param responseTimeoutSeconds - timeout for task to send response.  After this timeout, the task will be re-queued
      */
-    public void setResponseTimeoutSeconds(int responseTimeoutSeconds) {
+    public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
         this.responseTimeoutSeconds = responseTimeoutSeconds;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -74,7 +74,7 @@ public class TaskDef extends Auditable {
 	private int retryDelaySeconds = 60;
 
 	@ProtoField(id = 10)
-	private int responseTimeoutSeconds = ONE_HOUR;
+	private long responseTimeoutSeconds = ONE_HOUR;
 
 	@ProtoField(id = 11)
 	private Integer concurrentExecLimit;
@@ -236,7 +236,7 @@ public class TaskDef extends Auditable {
 	 *
 	 * @return the timeout for task to send response.  After this timeout, the task will be re-queued
 	 */
-	public int getResponseTimeoutSeconds() {
+	public long getResponseTimeoutSeconds() {
 		return responseTimeoutSeconds;
 	}
 
@@ -244,7 +244,7 @@ public class TaskDef extends Auditable {
 	 *
 	 * @param responseTimeoutSeconds - timeout for task to send response.  After this timeout, the task will be re-queued
 	 */
-	public void setResponseTimeoutSeconds(int responseTimeoutSeconds) {
+	public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
 		this.responseTimeoutSeconds = responseTimeoutSeconds;
 	}
 

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -144,8 +144,8 @@ public class CoreModule extends AbstractModule {
     @StringMapKey(TASK_TYPE_SUB_WORKFLOW)
     @Singleton
     @Named(TASK_MAPPERS_QUALIFIER)
-    public TaskMapper getSubWorkflowTaskMapper(ParametersUtils parametersUtils) {
-        return new SubWorkflowTaskMapper(parametersUtils);
+    public TaskMapper getSubWorkflowTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+        return new SubWorkflowTaskMapper(parametersUtils, metadataDAO);
     }
 
     @ProvidesIntoMap

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -448,9 +448,9 @@ public class DeciderService {
             return;
         }
 
-        long timeout = 1000 * taskDef.getTimeoutSeconds();
+        long timeout = 1000L * taskDef.getTimeoutSeconds();
         long now = System.currentTimeMillis();
-        long elapsedTime = now - (task.getStartTime() + (task.getStartDelayInSeconds() * 1000));
+        long elapsedTime = now - (task.getStartTime() + ((long)task.getStartDelayInSeconds() * 1000L));
 
         if (elapsedTime < timeout) {
             return;
@@ -494,7 +494,7 @@ public class DeciderService {
 
         logger.debug("Evaluating responseTimeOut for Task: {}, with Task Definition: {} ", task, taskDefinition);
 
-        long responseTimeout = 1000 * taskDefinition.getResponseTimeoutSeconds();
+        long responseTimeout = 1000L * taskDefinition.getResponseTimeoutSeconds();
         long now = System.currentTimeMillis();
         long noResponseTime = now - task.getUpdateTime();
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -84,7 +84,6 @@ public class DecisionTaskMapper implements TaskMapper {
         decisionTask.setWorkflowType(workflowInstance.getWorkflowName());
         decisionTask.setCorrelationId(workflowInstance.getCorrelationId());
         decisionTask.setScheduledTime(System.currentTimeMillis());
-        decisionTask.setEndTime(System.currentTimeMillis());
         decisionTask.getInputData().put("case", caseValue);
         decisionTask.getOutputData().put("caseOutput", Collections.singletonList(caseValue));
         decisionTask.setTaskId(taskId);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/EventTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/EventTaskMapper.java
@@ -61,7 +61,6 @@ public class EventTaskMapper implements TaskMapper {
         eventTask.setWorkflowType(workflowInstance.getWorkflowName());
         eventTask.setCorrelationId(workflowInstance.getCorrelationId());
         eventTask.setScheduledTime(System.currentTimeMillis());
-        eventTask.setEndTime(System.currentTimeMillis());
         eventTask.setInputData(eventTaskInput);
         eventTask.getInputData().put("sink", sink);
         eventTask.setTaskId(taskId);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,17 +83,16 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * <li>A check is performed that the next following task in the {@link WorkflowDef} is a {@link TaskType#JOIN}</li>
      * </ul>
      *
-     *
      * @param taskMapperContext: A wrapper class containing the {@link WorkflowTask}, {@link WorkflowDef}, {@link Workflow} and a string representation of the TaskId
      * @throws TerminateWorkflowException In case of:
-     *                            <ul>
-     *                            <li>
-     *                            When the task after {@link TaskType#FORK_JOIN_DYNAMIC} is not a {@link TaskType#JOIN}
-     *                            </li>
-     *                            <li>
-     *                            When the input parameters for the dynamic tasks are not of type {@link Map}
-     *                            </li>
-     *                            </ul>
+     *                                    <ul>
+     *                                    <li>
+     *                                    When the task after {@link TaskType#FORK_JOIN_DYNAMIC} is not a {@link TaskType#JOIN}
+     *                                    </li>
+     *                                    <li>
+     *                                    When the input parameters for the dynamic tasks are not of type {@link Map}
+     *                                    </li>
+     *                                    </ul>
      * @return: List of tasks in the following order:
      * <ul>
      * <li>
@@ -174,7 +173,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * @param workflowInstance: A instance of the {@link Workflow} which represents the workflow being executed.
      * @param taskId:           The string representation of {@link java.util.UUID} which will be set as the taskId.
      * @param dynForkTasks:     The list of dynamic forked tasks, the reference names of these tasks will be added to the forkDynamicTask
-     * @return: A new instance of {@link Task} representing a {@link SystemTaskType#FORK}
+     * @return A new instance of {@link Task} representing a {@link SystemTaskType#FORK}
      */
     @VisibleForTesting
     Task createDynamicForkTask(WorkflowTask taskToSchedule, Workflow workflowInstance, String taskId, List<WorkflowTask> dynForkTasks) {
@@ -204,7 +203,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * @param workflowInstance: A instance of the {@link Workflow} which represents the workflow being executed.
      * @param joinWorkflowTask: A instance of {@link WorkflowTask} which is of type {@link TaskType#JOIN}
      * @param joinInput:        The input which is set in the {@link Task#setInputData(Map)}
-     * @return: a new instance of {@link Task} representing a {@link SystemTaskType#JOIN}
+     * @return a new instance of {@link Task} representing a {@link SystemTaskType#JOIN}
      */
     @VisibleForTesting
     Task createJoinTask(Workflow workflowInstance, WorkflowTask joinWorkflowTask, HashMap<String, Object> joinInput) {
@@ -216,7 +215,6 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         joinTask.setWorkflowType(workflowInstance.getWorkflowName());
         joinTask.setCorrelationId(workflowInstance.getCorrelationId());
         joinTask.setScheduledTime(System.currentTimeMillis());
-        joinTask.setEndTime(System.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setTaskId(IDGenerator.generate());
         joinTask.setStatus(Task.Status.IN_PROGRESS);
@@ -231,7 +229,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * @param workflowInstance:     The instance of the {@link Workflow} which represents the workflow being executed.
      * @param dynamicForkTaskParam: The key representing the dynamic fork join json payload which is available in {@link WorkflowTask#getInputParameters()}
      * @throws TerminateWorkflowException : In case of input parameters of the dynamic fork tasks not represented as {@link Map}
-     * @return: a {@link Pair} representing the list of dynamic fork tasks in {@link Pair#getLeft()} and the input for the dynamic fork tasks in {@link Pair#getRight()}
+     * @return a {@link Pair} representing the list of dynamic fork tasks in {@link Pair#getLeft()} and the input for the dynamic fork tasks in {@link Pair#getRight()}
      */
     @SuppressWarnings("unchecked")
     @VisibleForTesting
@@ -261,7 +259,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * @param taskToSchedule:   The Task of type FORK_JOIN_DYNAMIC that needs to scheduled, which has the input parameters
      * @param workflowInstance: The instance of the {@link Workflow} which represents the workflow being executed.
      * @throws TerminateWorkflowException : In case of the {@link WorkflowTask#getInputParameters()} does not have a payload that contains the list of the dynamic tasks
-     * @return: {@link Pair} representing the list of dynamic fork tasks in {@link Pair#getLeft()} and the input for the dynamic fork tasks in {@link Pair#getRight()}
+     * @return {@link Pair} representing the list of dynamic fork tasks in {@link Pair#getLeft()} and the input for the dynamic fork tasks in {@link Pair#getRight()}
      */
     @VisibleForTesting
     Pair<List<WorkflowTask>, Map<String, Map<String, Object>>> getDynamicForkJoinTasksAndInput(WorkflowTask taskToSchedule, Workflow workflowInstance) throws TerminateWorkflowException {
@@ -294,8 +292,5 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
                 .collect(Collectors.toCollection(LinkedList::new));
 
         return new ImmutablePair<>(dynamicForkJoinWorkflowTasks, dynamicForkJoinTasksInput);
-
     }
-
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
@@ -65,7 +65,6 @@ public class JoinTaskMapper implements TaskMapper {
         joinTask.setCorrelationId(workflowInstance.getCorrelationId());
         joinTask.setWorkflowType(workflowInstance.getWorkflowName());
         joinTask.setScheduledTime(System.currentTimeMillis());
-        joinTask.setEndTime(System.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setTaskId(taskId);
         joinTask.setStatus(Task.Status.IN_PROGRESS);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -65,7 +65,6 @@ public class WaitTaskMapper implements TaskMapper {
         waitTask.setWorkflowType(workflowInstance.getWorkflowName());
         waitTask.setCorrelationId(workflowInstance.getCorrelationId());
         waitTask.setScheduledTime(System.currentTimeMillis());
-        waitTask.setEndTime(System.currentTimeMillis());
         waitTask.setInputData(waitTaskInput);
         waitTask.setTaskId(taskId);
         waitTask.setStatus(Task.Status.IN_PROGRESS);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -105,7 +105,7 @@ public class TestDeciderOutcomes {
         taskMappers.put("FORK_JOIN_DYNAMIC", new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO));
         taskMappers.put("USER_DEFINED", new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("SIMPLE", new SimpleTaskMapper(parametersUtils));
-        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils));
+        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -130,7 +130,7 @@ public class TestDeciderService {
         taskMappers.put("FORK_JOIN_DYNAMIC", new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO));
         taskMappers.put("USER_DEFINED", new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("SIMPLE", new SimpleTaskMapper(parametersUtils));
-        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils));
+        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -97,7 +97,7 @@ public class TestWorkflowExecutor {
         taskMappers.put("FORK_JOIN_DYNAMIC", new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO));
         taskMappers.put("USER_DEFINED", new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("SIMPLE", new SimpleTaskMapper(parametersUtils));
-        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils));
+        taskMappers.put("SUB_WORKFLOW", new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
 
@@ -177,7 +177,6 @@ public class TestWorkflowExecutor {
         task2.setWorkflowInstanceId(workflow.getWorkflowId());
         task2.setCorrelationId(workflow.getCorrelationId());
         task2.setScheduledTime(System.currentTimeMillis());
-        task2.setEndTime(System.currentTimeMillis());
         task2.setInputData(new HashMap<>());
         task2.setTaskId(IDGenerator.generate());
         task2.setStatus(Status.IN_PROGRESS);

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.core.execution.mapper;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -42,8 +54,7 @@ public class SubWorkflowTaskMapperTest {
     @Before
     public void setUp() {
         parametersUtils = mock(ParametersUtils.class);
-        metadataDAO = mock(MetadataDAO.class);
-        subWorkflowTaskMapper = new SubWorkflowTaskMapper(parametersUtils);
+        subWorkflowTaskMapper = new SubWorkflowTaskMapper(parametersUtils, metadataDAO);
         deciderService = mock(DeciderService.class);
     }
 
@@ -52,18 +63,18 @@ public class SubWorkflowTaskMapperTest {
     public void getMappedTasks() {
         //Given
         WorkflowDef workflowDef = new WorkflowDef();
-        Workflow  workflowInstance = new Workflow();
+        Workflow workflowInstance = new Workflow();
         workflowInstance.setWorkflowDefinition(workflowDef);
         WorkflowTask taskToSchedule = new WorkflowTask();
         SubWorkflowParams subWorkflowParams = new SubWorkflowParams();
         subWorkflowParams.setName("Foo");
         subWorkflowParams.setVersion(2);
         taskToSchedule.setSubWorkflowParam(subWorkflowParams);
-        Map<String,Object> taskInput = new HashMap<>();
+        Map<String, Object> taskInput = new HashMap<>();
 
         Map<String, Object> subWorkflowParamMap = new HashMap<>();
-        subWorkflowParamMap.put("name","FooWorkFlow");
-        subWorkflowParamMap.put("version",2);
+        subWorkflowParamMap.put("name", "FooWorkFlow");
+        subWorkflowParamMap.put("version", 2);
         when(parametersUtils.getTaskInputV2(anyMap(), any(Workflow.class), anyString(), any(TaskDef.class)))
                 .thenReturn(subWorkflowParamMap);
 

--- a/grpc/src/main/proto/model/task.proto
+++ b/grpc/src/main/proto/model/task.proto
@@ -40,7 +40,7 @@ message Task {
     bool retried = 16;
     bool executed = 17;
     bool callback_from_worker = 18;
-    int32 response_timeout_seconds = 19;
+    int64 response_timeout_seconds = 19;
     string workflow_instance_id = 20;
     string workflow_type = 21;
     string task_id = 22;

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -26,7 +26,7 @@ message TaskDef {
     TaskDef.TimeoutPolicy timeout_policy = 7;
     TaskDef.RetryLogic retry_logic = 8;
     int32 retry_delay_seconds = 9;
-    int32 response_timeout_seconds = 10;
+    int64 response_timeout_seconds = 10;
     int32 concurrent_exec_limit = 11;
     map<string, google.protobuf.Value> input_template = 12;
     int32 rate_limit_per_frequency = 14;

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -175,7 +175,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 	public void updateTask(Task task) {
 
 		task.setUpdateTime(System.currentTimeMillis());
-		if (task.getStatus() != null && task.getStatus().isTerminal()) {
+		if (task.getStatus() != null && task.getStatus().isTerminal() && task.getEndTime() == 0) {
 			task.setEndTime(System.currentTimeMillis());
 		}
 


### PR DESCRIPTION
- Changed responseTimeoutSeconds type to `long` from `int` to avoid overflows.
- For a `SUB_WORKFLOW` task spawned from a dynamic fork task, the sub workflow version and definition needs to be pulled in from the DAO.
- Do not update end time if it is already set, only set end time for tasks in terminal state.