### PR TITLE
Feature/add workflow completion listener al

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -67,7 +67,7 @@ public class WorkflowDef extends Auditable {
 	private boolean restartable = true;
 
 	@ProtoField(id = 10)
-	private boolean terminalWorkflowListenerEnabled = false;
+	private boolean workflowStatusListenerEnabled = false;
 
 	/**
 	 * @return the name
@@ -208,16 +208,16 @@ public class WorkflowDef extends Auditable {
 	 *
 	 * @return true is workflow listener will be invoked when workflow gets into a terminal state
 	 */
-	public boolean isTerminalWorkflowListenerEnabled() {
-		return terminalWorkflowListenerEnabled;
+	public boolean isWorkflowStatusListenerEnabled() {
+		return workflowStatusListenerEnabled;
 	}
 
 	/**
 	 * Specify if workflow listener is enabled to invoke a callback for completed or terminated workflows
-	 * @param terminalWorkflowListenerEnabled
+	 * @param workflowStatusListenerEnabled
 	 */
-	public void setTerminalWorkflowListenerEnabled(boolean terminalWorkflowListenerEnabled) {
-		this.terminalWorkflowListenerEnabled = terminalWorkflowListenerEnabled;
+	public void setWorkflowStatusListenerEnabled(boolean workflowStatusListenerEnabled) {
+		this.workflowStatusListenerEnabled = workflowStatusListenerEnabled;
 	}
 
 	public String key(){
@@ -306,7 +306,7 @@ public class WorkflowDef extends Auditable {
 				.add("failureWorkflow", failureWorkflow)
 				.add("schemaVersion", schemaVersion)
 				.add("restartable", restartable)
-				.add("terminalWorkflowListenerEnabled", terminalWorkflowListenerEnabled)
+				.add("workflowStatusListenerEnabled", workflowStatusListenerEnabled)
 				.toString();
 	}
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -18,6 +18,11 @@
  */
 package com.netflix.conductor.common.metadata.workflow;
 
+import com.github.vmg.protogen.annotations.ProtoField;
+import com.github.vmg.protogen.annotations.ProtoMessage;
+import com.google.common.base.MoreObjects;
+import com.netflix.conductor.common.metadata.Auditable;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -25,11 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import com.github.vmg.protogen.annotations.ProtoField;
-import com.github.vmg.protogen.annotations.ProtoMessage;
-import com.google.common.base.MoreObjects;
-import com.netflix.conductor.common.metadata.Auditable;
 
 /**
  * @author Viren
@@ -65,6 +65,9 @@ public class WorkflowDef extends Auditable {
 	//By default a workflow is restartable
 	@ProtoField(id = 9)
 	private boolean restartable = true;
+
+	@ProtoField(id = 10)
+	private boolean terminalWorkflowListenerEnabled = false;
 
 	/**
 	 * @return the name
@@ -201,6 +204,22 @@ public class WorkflowDef extends Auditable {
 		this.schemaVersion = schemaVersion;
 	}
 
+	/**
+	 *
+	 * @return true is workflow listener will be invoked when workflow gets into a terminal state
+	 */
+	public boolean isTerminalWorkflowListenerEnabled() {
+		return terminalWorkflowListenerEnabled;
+	}
+
+	/**
+	 * Specify if workflow listener is enabled to invoke a callback for completed or terminated workflows
+	 * @param terminalWorkflowListenerEnabled
+	 */
+	public void setTerminalWorkflowListenerEnabled(boolean terminalWorkflowListenerEnabled) {
+		this.terminalWorkflowListenerEnabled = terminalWorkflowListenerEnabled;
+	}
+
 	public String key(){
 		return getKey(name, version);
 	}
@@ -287,6 +306,7 @@ public class WorkflowDef extends Auditable {
 				.add("failureWorkflow", failureWorkflow)
 				.add("schemaVersion", schemaVersion)
 				.add("restartable", restartable)
+				.add("terminalWorkflowListenerEnabled", terminalWorkflowListenerEnabled)
 				.toString();
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -540,7 +540,7 @@ public class WorkflowExecutor {
         queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());    //remove from the sweep queue
         logger.debug("Removed workflow {} from decider queue", wf.getWorkflowId());
 
-        if(wf.getWorkflowDefinition().isTerminalWorkflowListenerEnabled()) {
+        if(wf.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
             workflowStatusListener.onWorkflowCompleted(wf);
         }
     }
@@ -638,7 +638,7 @@ public class WorkflowExecutor {
         // Send to atlas
         Monitors.recordWorkflowTermination(workflow.getWorkflowName(), workflow.getStatus(), workflow.getOwnerApp());
 
-        if(workflow.getWorkflowDefinition().isTerminalWorkflowListenerEnabled()) {
+        if(workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
             workflowStatusListener.onWorkflowTerminated(workflow);
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -90,6 +90,8 @@ public class WorkflowExecutor {
     private final MetadataMapperService metadataMapperService;
     private final ParametersUtils parametersUtils;
 
+    private WorkflowStatusListener workflowStatusListener;
+
     private int activeWorkerLastPollInSecs;
 
     public static final String DECIDER_QUEUE = "_deciderQueue";
@@ -103,6 +105,7 @@ public class WorkflowExecutor {
             QueueDAO queueDAO,
             MetadataMapperService metadataMapperService,
             ParametersUtils parametersUtils,
+            WorkflowStatusListener workflowStatusListener,
             Configuration config
     ) {
         this.deciderService = deciderService;
@@ -113,6 +116,7 @@ public class WorkflowExecutor {
         this.metadataMapperService = metadataMapperService;
         this.activeWorkerLastPollInSecs = config.getIntProperty("tasks.active.worker.lastpoll", 10);
         this.parametersUtils = parametersUtils;
+        this.workflowStatusListener = workflowStatusListener;
     }
 
     /**
@@ -535,6 +539,10 @@ public class WorkflowExecutor {
         Monitors.recordWorkflowCompletion(workflow.getWorkflowName(), workflow.getEndTime() - workflow.getStartTime(), wf.getOwnerApp());
         queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());    //remove from the sweep queue
         logger.debug("Removed workflow {} from decider queue", wf.getWorkflowId());
+
+        if(wf.getWorkflowDefinition().isTerminalWorkflowListenerEnabled()) {
+            workflowStatusListener.onWorkflowCompleted(wf);
+        }
     }
 
     public void terminateWorkflow(String workflowId, String reason) {
@@ -629,6 +637,10 @@ public class WorkflowExecutor {
 
         // Send to atlas
         Monitors.recordWorkflowTermination(workflow.getWorkflowName(), workflow.getStatus(), workflow.getOwnerApp());
+
+        if(workflow.getWorkflowDefinition().isTerminalWorkflowListenerEnabled()) {
+            workflowStatusListener.onWorkflowTerminated(workflow);
+        }
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
@@ -1,0 +1,14 @@
+package com.netflix.conductor.core.execution;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * Default implementation for the workflow status listener
+ *
+ */
+public class WorkflowExecutorModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(WorkflowStatusListener.class).to(WorkflowStatusListenerStub.class);//default implementation
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListener.java
@@ -1,0 +1,12 @@
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.run.Workflow;
+
+/**
+ * Listener for the completed and terminated workflows
+ *
+ */
+public interface WorkflowStatusListener {
+    void onWorkflowCompleted(Workflow workflow);
+    void onWorkflowTerminated(Workflow workflow);
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListenerStub.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListenerStub.java
@@ -1,0 +1,24 @@
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.run.Workflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stub listener default implementation
+ */
+public class WorkflowStatusListenerStub implements WorkflowStatusListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WorkflowStatusListenerStub.class);
+
+    @Override
+    public void onWorkflowCompleted(Workflow workflow) {
+        LOG.debug("Workflow {} is completed", workflow.toString());
+    }
+
+    @Override
+    public void onWorkflowTerminated(Workflow workflow) {
+        LOG.debug("Workflow {} is terminated", workflow.toString());
+    }
+
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListenerStub.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowStatusListenerStub.java
@@ -13,12 +13,12 @@ public class WorkflowStatusListenerStub implements WorkflowStatusListener {
 
     @Override
     public void onWorkflowCompleted(Workflow workflow) {
-        LOG.debug("Workflow {} is completed", workflow.toString());
+        LOG.debug("Workflow {} is completed", workflow.getWorkflowId());
     }
 
     @Override
     public void onWorkflowTerminated(Workflow workflow) {
-        LOG.debug("Workflow {} is terminated", workflow.toString());
+        LOG.debug("Workflow {} is terminated", workflow.getWorkflowId());
     }
 
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -68,6 +68,8 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -79,6 +81,7 @@ public class TestWorkflowExecutor {
     private ExecutionDAO executionDAO;
     private MetadataDAO metadataDAO;
     private QueueDAO queueDAO;
+    private WorkflowStatusListener workflowStatusListener;
 
     @Before
     public void init() {
@@ -86,6 +89,7 @@ public class TestWorkflowExecutor {
         executionDAO = mock(ExecutionDAO.class);
         metadataDAO = mock(MetadataDAO.class);
         queueDAO = mock(QueueDAO.class);
+        workflowStatusListener = mock(WorkflowStatusListener.class);
         ExternalPayloadStorageUtils externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         ObjectMapper objectMapper = new ObjectMapper();
         ParametersUtils parametersUtils = new ParametersUtils();
@@ -103,7 +107,8 @@ public class TestWorkflowExecutor {
 
         DeciderService deciderService = new DeciderService(parametersUtils, queueDAO, externalPayloadStorageUtils, taskMappers);
         MetadataMapperService metadataMapperService = new MetadataMapperService(metadataDAO);
-        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, metadataMapperService, parametersUtils, config);
+        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, executionDAO, queueDAO, metadataMapperService,
+                parametersUtils, workflowStatusListener, config);
     }
 
     @Test
@@ -266,8 +271,63 @@ public class TestWorkflowExecutor {
         assertEquals(1, updateWorkflowCalledCounter.get());
         assertEquals(1, updateTasksCalledCounter.get());
         assertEquals(1, removeQueueEntryCalledCounter.get());
+
+        verify(workflowStatusListener, times(0)).onWorkflowCompleted(any(Workflow.class));
+
+        def.setTerminalWorkflowListenerEnabled(true);
+        workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        workflowExecutor.completeWorkflow(workflow);
+        verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTerminatedWorkflow() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("test");
+
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowDefinition(def);
+        workflow.setWorkflowId("1");
+        workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        workflow.setOwnerApp("junit_test");
+        workflow.setStartTime(10L);
+        workflow.setEndTime(100L);
+        workflow.setOutput(Collections.EMPTY_MAP);
+
+        when(executionDAO.getWorkflow(anyString(), anyBoolean())).thenReturn(workflow);
+
+        AtomicInteger updateWorkflowCalledCounter = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            updateWorkflowCalledCounter.incrementAndGet();
+            return null;
+        }).when(executionDAO).updateWorkflow(any());
+
+        AtomicInteger updateTasksCalledCounter = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            updateTasksCalledCounter.incrementAndGet();
+            return null;
+        }).when(executionDAO).updateTasks(any());
+
+        AtomicInteger removeQueueEntryCalledCounter = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            removeQueueEntryCalledCounter.incrementAndGet();
+            return null;
+        }).when(queueDAO).remove(anyString(), anyString());
+
+        workflowExecutor.terminateWorkflow("workflowId", "reason");
+        assertEquals(Workflow.WorkflowStatus.TERMINATED, workflow.getStatus());
+        assertEquals(1, updateWorkflowCalledCounter.get());
+        assertEquals(1, removeQueueEntryCalledCounter.get());
+
+        verify(workflowStatusListener, times(0)).onWorkflowTerminated(any(Workflow.class));
+
+        def.setTerminalWorkflowListenerEnabled(true);
+        workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        workflowExecutor.completeWorkflow(workflow);
+        verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));
+    }
+    
     @Test
     public void testGetFailedTasksToRetry() {
         //setup

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -274,7 +274,7 @@ public class TestWorkflowExecutor {
 
         verify(workflowStatusListener, times(0)).onWorkflowCompleted(any(Workflow.class));
 
-        def.setTerminalWorkflowListenerEnabled(true);
+        def.setWorkflowStatusListenerEnabled(true);
         workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
         workflowExecutor.completeWorkflow(workflow);
         verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));
@@ -322,7 +322,7 @@ public class TestWorkflowExecutor {
 
         verify(workflowStatusListener, times(0)).onWorkflowTerminated(any(Workflow.class));
 
-        def.setTerminalWorkflowListenerEnabled(true);
+        def.setWorkflowStatusListenerEnabled(true);
         workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
         workflowExecutor.completeWorkflow(workflow);
         verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1013,7 +1013,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.isRestartable() );
-        to.setTerminalWorkflowListenerEnabled( from.isTerminalWorkflowListenerEnabled() );
+        to.setWorkflowStatusListenerEnabled( from.isWorkflowStatusListenerEnabled() );
         return to.build();
     }
 
@@ -1032,7 +1032,7 @@ public abstract class AbstractProtoMapper {
         to.setFailureWorkflow( from.getFailureWorkflow() );
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.getRestartable() );
-        to.setTerminalWorkflowListenerEnabled( from.getTerminalWorkflowListenerEnabled() );
+        to.setWorkflowStatusListenerEnabled( from.getWorkflowStatusListenerEnabled() );
         return to;
     }
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1013,6 +1013,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.isRestartable() );
+        to.setTerminalWorkflowListenerEnabled( from.isTerminalWorkflowListenerEnabled() );
         return to.build();
     }
 
@@ -1031,6 +1032,7 @@ public abstract class AbstractProtoMapper {
         to.setFailureWorkflow( from.getFailureWorkflow() );
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.getRestartable() );
+        to.setTerminalWorkflowListenerEnabled( from.getTerminalWorkflowListenerEnabled() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflowdef.proto
+++ b/grpc/src/main/proto/model/workflowdef.proto
@@ -18,4 +18,5 @@ message WorkflowDef {
     string failure_workflow = 7;
     int32 schema_version = 8;
     bool restartable = 9;
+    bool terminal_workflow_listener_enabled = 10;
 }

--- a/grpc/src/main/proto/model/workflowdef.proto
+++ b/grpc/src/main/proto/model/workflowdef.proto
@@ -18,5 +18,5 @@ message WorkflowDef {
     string failure_workflow = 7;
     int32 schema_version = 8;
     bool restartable = 9;
-    bool terminal_workflow_listener_enabled = 10;
+    bool workflow_status_listener_enabled = 10;
 }

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -7,7 +7,7 @@ import com.netflix.conductor.contribs.http.HttpTask;
 import com.netflix.conductor.contribs.http.RestClientManager;
 import com.netflix.conductor.contribs.json.JsonJqTransform;
 import com.netflix.conductor.core.config.Configuration;
-import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import com.netflix.conductor.core.execution.WorkflowExecutorModule;
 import com.netflix.conductor.core.utils.DummyPayloadStorage;
 import com.netflix.conductor.core.utils.S3PayloadStorage;
 import com.netflix.conductor.dao.RedisWorkflowModule;
@@ -91,6 +91,8 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         }
 
         modules.add(new ElasticSearchV5Module());
+
+        modules.add(new WorkflowExecutorModule());
 
         if (configuration.getJerseyEnabled()) {
             modules.add(new JerseyModule());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
@@ -19,6 +19,8 @@ import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.common.utils.JsonMapperProvider;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.CoreModule;
+import com.netflix.conductor.core.execution.WorkflowStatusListenerStub;
+import com.netflix.conductor.core.execution.WorkflowStatusListener;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
@@ -59,6 +61,8 @@ public class TestModule extends AbstractModule {
         bind(ExecutionDAO.class).to(RedisExecutionDAO.class);
         bind(QueueDAO.class).to(DynoQueueDAO.class);
         bind(IndexDAO.class).to(MockIndexDAO.class);
+
+        bind(WorkflowStatusListener.class).to(WorkflowStatusListenerStub.class);
 
         install(new CoreModule());
         bind(UserTask.class).asEagerSingleton();


### PR DESCRIPTION
Adding a listener for when workflow gets to a COMPLETED or TERMINATED state.
This listener could be redefined in projects that use or inherit conductor library with some custom implementation as needed.

WorkflowDefinition has a flag to trigger these listeners so that we do not trigger these for every workflow.