### PR TITLE
Donot return task ack failed

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
+++ b/client/src/main/java/com/netflix/conductor/client/task/WorkflowTaskCoordinator.java
@@ -355,7 +355,6 @@ public class WorkflowTaskCoordinator {
 	private void execute(Worker worker, Task task) {
 		String taskType = task.getTaskDefName();
 		try {
-
 			if(!worker.preAck(task)) {
 				logger.debug("Worker decided not to ack the task {}, taskId = {}", taskType, task.getTaskId());
 				return;
@@ -363,15 +362,13 @@ public class WorkflowTaskCoordinator {
 
 			if (!taskClient.ack(task.getTaskId(), worker.getIdentity())) {
 				WorkflowTaskMetrics.incrementTaskAckFailedCount(worker.getTaskDefName());
-				logger.error("Ack failed for {}, taskId = {}", taskType, task.getTaskId());
-				returnTask(worker, task);
 				return;
 			}
+			logger.debug("Ack successful for {}, taskId = {}", taskType, task.getTaskId());
 
 		} catch (Exception e) {
 			logger.error(String.format("ack exception for task %s, taskId = %s in worker - %s", task.getTaskDefName(), task.getTaskId(), worker.getIdentity()), e);
 			WorkflowTaskMetrics.incrementTaskAckErrorCount(worker.getTaskDefName(), e);
-			returnTask(worker, task);
 			return;
 		}
 

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -152,7 +152,16 @@ public class TaskService {
     public String ackTaskReceived(String taskId, String workerId) {
         ServiceUtils.checkNotNullOrEmpty(taskId, "TaskId cannot be null or empty.");
         LOGGER.debug("Ack received for task: {} from worker: {}", taskId, workerId);
-        return String.valueOf(executionService.ackTaskReceived(taskId));
+        boolean ackResult;
+        try {
+            ackResult = executionService.ackTaskReceived(taskId);
+        } catch (Exception e) {
+            // safe to ignore exception here, since the task will not be processed by the worker due to ack failure
+            // The task will eventually be available to be polled again after the unack timeout
+            LOGGER.error("Exception when trying to ack task {} from worker {}", taskId, workerId, e);
+            ackResult = false;
+        }
+        return String.valueOf(ackResult);
     }
 
     /**

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -7,7 +7,6 @@ import com.netflix.conductor.contribs.http.HttpTask;
 import com.netflix.conductor.contribs.http.RestClientManager;
 import com.netflix.conductor.contribs.json.JsonJqTransform;
 import com.netflix.conductor.core.config.Configuration;
-import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
 import com.netflix.conductor.core.utils.DummyPayloadStorage;
 import com.netflix.conductor.core.utils.S3PayloadStorage;
 import com.netflix.conductor.dao.RedisWorkflowModule;
@@ -54,7 +53,7 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
     }
 
     private List<AbstractModule> selectModulesToLoad() {
-        Configuration.DB database = null;
+        Configuration.DB database;
         List<AbstractModule> modules = new ArrayList<>();
 
         try {


### PR DESCRIPTION
Do not return the task from the client to the server if the ack fails or throws an exception. The task will be available to be polled again in this case after the unack timeout. 
The catch all in the task service ensures that even if the ack fails on the server side due to an exception with the queueDAO, the client sees an ack failure and does not process the task.