### PR TITLE
Change UpdateTask resource to produce text/plain

### DIFF
--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -102,6 +102,7 @@ public class TaskResource {
 
 	@POST
 	@ApiOperation("Update a task")
+	@Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
 	public String updateTask(TaskResult taskResult) {
 		return taskService.updateTask(taskResult);
 	}


### PR DESCRIPTION
UpdateTask produced the task-id as string. As the json producer does not quote the string
correctly, json consumer will fail, as the id is taken as literal. Changing the producer to text/plain should fix this problem. However to avoid breaking changes, application/json is still produced.