### PR TITLE
remove fallback to default domain

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/PollData.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/PollData.java
@@ -1,8 +1,4 @@
-package com.netflix.conductor.common.metadata.tasks;
-
-import com.github.vmg.protogen.annotations.*;
-
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,19 +13,26 @@ import com.github.vmg.protogen.annotations.*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.conductor.common.metadata.tasks;
+
+import com.github.vmg.protogen.annotations.ProtoField;
+import com.github.vmg.protogen.annotations.ProtoMessage;
+
+import java.util.Objects;
+
 @ProtoMessage
 public class PollData {
 	@ProtoField(id = 1)
-	String queueName;
+	private String queueName;
 
 	@ProtoField(id = 2)
-	String domain;
+	private String domain;
 
 	@ProtoField(id = 3)
-	String workerId;
+	private String workerId;
 
 	@ProtoField(id = 4)
-	long lastPollTime;
+	private long lastPollTime;
 	
 	public PollData() {
 		super();
@@ -68,45 +71,20 @@ public class PollData {
 		this.lastPollTime = lastPollTime;
 	}
 
-	
 	@Override
-	public synchronized int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((domain == null) ? 0 : domain.hashCode());
-		result = prime * result + (int) (lastPollTime ^ (lastPollTime >>> 32));
-		result = prime * result + ((queueName == null) ? 0 : queueName.hashCode());
-		result = prime * result + ((workerId == null) ? 0 : workerId.hashCode());
-		return result;
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		PollData pollData = (PollData) o;
+		return getLastPollTime() == pollData.getLastPollTime() &&
+				Objects.equals(getQueueName(), pollData.getQueueName()) &&
+				Objects.equals(getDomain(), pollData.getDomain()) &&
+				Objects.equals(getWorkerId(), pollData.getWorkerId());
 	}
 
 	@Override
-	public synchronized boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		PollData other = (PollData) obj;
-		if (domain == null) {
-			if (other.domain != null)
-				return false;
-		} else if (!domain.equals(other.domain))
-			return false;
-		if (lastPollTime != other.lastPollTime)
-			return false;
-		if (queueName == null) {
-			if (other.queueName != null)
-				return false;
-		} else if (!queueName.equals(other.queueName))
-			return false;
-		if (workerId == null) {
-			if (other.workerId != null)
-				return false;
-		} else if (!workerId.equals(other.workerId))
-			return false;
-		return true;
+	public int hashCode() {
+		return Objects.hash(getQueueName(), getDomain(), getWorkerId(), getLastPollTime());
 	}
 
 	@Override

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -1858,6 +1858,8 @@ public abstract class AbstractWorkflowServiceTest {
         assertEquals(2, workflow.getTasks().size());
 
         task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
+        assertNull(task);
+        task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker", "domain12");
         assertNotNull(task);
         assertEquals("junit_task_1", task.getTaskType());
 


### PR DESCRIPTION
Removed the fallback to the default domain if an active domain is not found.
Changed this such that it falls back to the lowest priority domain specified in the list.