### PR TITLE
Feature/allow ui on localhost only

### DIFF
--- a/ui/src/server.js
+++ b/ui/src/server.js
@@ -39,7 +39,7 @@ class Main {
   };
 
   startServer = app => {
-    const server = app.listen(process.env.NODE_PORT || 5000, process.env.NODE_HOST || 'localhost', function () {
+    const server = app.listen(process.env.NODE_PORT || 5000, process.env.NODE_HOST || "0.0.0.0", function () {
       const { address, port } = server.address();
       log.info('Workflow UI listening at http://%s:%s', address, port);
       if (process.send) {

--- a/ui/src/server.js
+++ b/ui/src/server.js
@@ -39,7 +39,7 @@ class Main {
   };
 
   startServer = app => {
-    const server = app.listen(process.env.NODE_PORT || 5000, () => {
+    const server = app.listen(process.env.NODE_PORT || 5000, 'localhost', function () {
       const { address, port } = server.address();
       log.info('Workflow UI listening at http://%s:%s', address, port);
       if (process.send) {

--- a/ui/src/server.js
+++ b/ui/src/server.js
@@ -39,7 +39,7 @@ class Main {
   };
 
   startServer = app => {
-    const server = app.listen(process.env.NODE_PORT || 5000, 'localhost', function () {
+    const server = app.listen(process.env.NODE_PORT || 5000, process.env.NODE_HOST || 'localhost', function () {
       const { address, port } = server.address();
       log.info('Workflow UI listening at http://%s:%s', address, port);
       if (process.send) {


### PR DESCRIPTION
In some cases when you have apache in front of the application, you don't want users to bypass it and hit IP address of the application directly. Using NODE_HOST="localhost"  would allow to enforce it if needed.
By default, it's still wide open for "0.0.0.0" like it used to be.