### PR TITLE
Added missing "https" for ElasticSearch Rest

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -96,11 +96,13 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
 
     private final String indexName;
     private final String logIndexPrefix;
+    private final String clusterHealthColor;
     private String logIndexName;
     private final ObjectMapper objectMapper;
     private final RestHighLevelClient elasticSearchClient;
     private final RestClient elasticSearchAdminClient;
     private final ExecutorService executorService;
+
 
     static {
         SIMPLE_DATE_FORMAT.setTimeZone(GMT);
@@ -114,6 +116,7 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
         this.elasticSearchClient = new RestHighLevelClient(lowLevelRestClient);
         this.indexName = config.getIndexName();
         this.logIndexPrefix = config.getTasklogIndexName();
+        this.clusterHealthColor = config.getClusterHealthColor();
 
         // Set up a workerpool for performing async operations.
         int corePoolSize = 6;
@@ -129,7 +132,7 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
 
     @Override
     public void setup() throws Exception {
-        waitForGreenCluster();
+        waitForHealthyCluster();
 
         try {
             initIndex();
@@ -165,9 +168,9 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
      * Waits for the ES cluster to become green.
      * @throws Exception If there is an issue connecting with the ES cluster.
      */
-    private void waitForGreenCluster() throws Exception {
+    private void waitForHealthyCluster() throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("wait_for_status", "green");
+        params.put("wait_for_status", this.clusterHealthColor);
         params.put("timeout", "30s");
 
         elasticSearchAdminClient.performRequest("GET", "/_cluster/health", params);

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -16,6 +16,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_URL_PROPERTY_NAME = "workflow.elasticsearch.url";
     String ELASTIC_SEARCH_URL_DEFAULT_VALUE = "localhost:9300";
 
+    String ELASTIC_SEARCH_HEALTH_COLOR_PROPERTY_NAME = "workflow.elasticsearch.cluster.health.color";
+    String ELASTIC_SEARCH_HEALTH_COLOR_DEFAULT_VALUE = "green";
+
     String ELASTIC_SEARCH_INDEX_NAME_PROPERTY_NAME = "workflow.elasticsearch.index.name";
     String ELASTIC_SEARCH_INDEX_NAME_DEFAULT_VALUE = "conductor";
 
@@ -51,7 +54,7 @@ public interface ElasticSearchConfiguration extends Configuration {
         String[] hosts = clusterAddress.split(",");
 
         return Arrays.stream(hosts).map( host ->
-           (host.startsWith("http://") || host.startsWith("tcp://")) ? URI.create(host) : URI.create("tcp://" + host)
+           (host.startsWith("http://") || host.startsWith("https://") || host.startsWith("tcp://")) ? URI.create(host) : URI.create("tcp://" + host)
         ).collect(Collectors.toList());
     }
 
@@ -61,6 +64,10 @@ public interface ElasticSearchConfiguration extends Configuration {
 
     default String getTasklogIndexName() {
         return getProperty(TASK_LOG_INDEX_NAME_PROPERTY_NAME, TASK_LOG_INDEX_NAME_DEFAULT_VALUE);
+    }
+
+    default String getClusterHealthColor() {
+        return getProperty(ELASTIC_SEARCH_HEALTH_COLOR_PROPERTY_NAME, ELASTIC_SEARCH_HEALTH_COLOR_DEFAULT_VALUE);
     }
 
     default String getEmbeddedDataPath() {


### PR DESCRIPTION
Added missing "https" for ElasticSearch Rest.  Made the ElasticSearch cluster color configurable.  This defaults to "green" but you can set "workflow.elasticsearch.cluster.health.color" to yellow.  This allows Conductor to work with AWS ElasticSearch clusters with 1 node that never change to green.