### PR TITLE
adds missing binding for redis cluster module

### DIFF
--- a/server/src/main/java/com/netflix/conductor/server/RedisClusterModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/RedisClusterModule.java
@@ -2,12 +2,16 @@ package com.netflix.conductor.server;
 
 import com.google.inject.AbstractModule;
 
+import com.google.inject.name.Names;
+import com.netflix.conductor.dyno.DynoShardSupplierProvider;
 import com.netflix.conductor.dyno.DynomiteConfiguration;
+import com.netflix.conductor.dyno.RedisQueuesProvider;
 import com.netflix.conductor.dyno.SystemPropertiesDynomiteConfiguration;
 import com.netflix.conductor.jedis.ConfigurationHostSupplierProvider;
 import com.netflix.conductor.jedis.RedisClusterJedisProvider;
 import com.netflix.dyno.connectionpool.HostSupplier;
 
+import com.netflix.dyno.queues.ShardSupplier;
 import redis.clients.jedis.JedisCommands;
 
 public class RedisClusterModule extends AbstractModule {
@@ -16,5 +20,10 @@ public class RedisClusterModule extends AbstractModule {
         bind(HostSupplier.class).toProvider(ConfigurationHostSupplierProvider.class);
         bind(DynomiteConfiguration.class).to(SystemPropertiesDynomiteConfiguration.class);
         bind(JedisCommands.class).toProvider(RedisClusterJedisProvider.class);
+        bind(JedisCommands.class)
+                .annotatedWith(Names.named(RedisQueuesProvider.READ_CLIENT_INJECTION_NAME))
+                .toProvider(RedisClusterJedisProvider.class)
+                .asEagerSingleton();
+        bind(ShardSupplier.class).toProvider(DynoShardSupplierProvider.class);
     }
 }


### PR DESCRIPTION
- JedisCommands with READ_CLIENT_INJECTION_NAME
- Shard Supplier

@cyzhao This is dev tested with redis cluster setup and executed a workflow successfully