### PR TITLE
conductor ConductorHttpClient methods now return errors

### DIFF
--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -49,7 +49,7 @@ func (c *ConductorHttpClient) GetWorkflowDef(workflowName string, version int) (
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {
         log.Println("Error while trying to Get Workflow Definition", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -60,7 +60,7 @@ func (c *ConductorHttpClient) CreateWorkflowDef(workflowDefBody string) (string,
     outputString, err := c.httpClient.Post(url, nil, nil, workflowDefBody)
     if err != nil {
         log.Println("Error while trying to Create Workflow Definition", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -71,7 +71,7 @@ func (c *ConductorHttpClient) UpdateWorkflowDefs(workflowDefsBody string) (strin
     outputString, err := c.httpClient.Put(url, nil, nil, workflowDefsBody)
     if err != nil {
         log.Println("Error while trying to Update Workflow Definitions", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -82,7 +82,7 @@ func (c *ConductorHttpClient) GetAllWorkflowDefs() (string, error) {
     outputString, err := c.httpClient.Get(url, nil, nil)
     if err != nil {
         log.Println("Error while trying to Get All Workflow Definitions", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -100,7 +100,7 @@ func (c *ConductorHttpClient) UnRegisterWorkflowDef(workflowDefName string, vers
 
     if err != nil {
         log.Println("Error while trying to Unregister Workflow Definition", workflowDefName, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -111,7 +111,7 @@ func (c *ConductorHttpClient) GetTaskDef(taskDefName string) (string, error) {
     outputString, err := c.httpClient.Get(url, nil, nil)
     if err != nil {
         log.Println("Error while trying to Get Task Definition", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -122,7 +122,7 @@ func (c *ConductorHttpClient) RegisterTaskDefs(taskDefsMeta string) (string, err
     outputString, err := c.httpClient.Post(url, nil, nil, taskDefsMeta)
     if err != nil {
         log.Println("Error while trying to Register Task Definitions", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -133,7 +133,7 @@ func (c *ConductorHttpClient) UpdateTaskDef(taskDefMeta string) (string, error) 
     outputString, err := c.httpClient.Put(url, nil, nil, taskDefMeta)
     if err != nil {
         log.Println("Error while trying to Update Task Definition", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -144,7 +144,7 @@ func (c *ConductorHttpClient) UnRegisterTaskDef(taskDefName string) (string, err
     outputString, err := c.httpClient.Delete(url, nil, nil, "")
     if err != nil {
         log.Println("Error while trying to Unregister Task Definition", taskDefName, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -155,7 +155,7 @@ func (c *ConductorHttpClient) GetAllTaskDefs() (string, error) {
     outputString, err := c.httpClient.Get(url, nil, nil)
     if err != nil {
         log.Println("Error while trying to Get All Task Definitions", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -171,7 +171,7 @@ func (c *ConductorHttpClient) GetTask(taskId string) (string, error) {
     outputString, err := c.httpClient.Get(url, nil, nil)
     if err != nil {
         log.Println("Error while trying to Get Task", taskId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -182,7 +182,7 @@ func (c *ConductorHttpClient) UpdateTask(taskBody string) (string, error) {
     outputString, err := c.httpClient.Post(url, nil, nil, taskBody)
     if err != nil {
         log.Println("Error while trying to Update Task", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -194,7 +194,7 @@ func (c *ConductorHttpClient) PollForTask(taskType string, workerid string) (str
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {
         log.Println("Error while trying to Poll For Task taskType:", taskType, ",workerid:", workerid, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -219,7 +219,7 @@ func (c *ConductorHttpClient) GetAllTasksInQueue() (string, error) {
     outputString, err := c.httpClient.Get(url, nil, nil)
     if err != nil {
         log.Println("Error while trying to Get All Tasks in Queue", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -230,7 +230,7 @@ func (c *ConductorHttpClient) RemoveTaskFromQueue(taskType string, taskId string
     outputString, err := c.httpClient.Delete(url, nil, nil, "")
     if err != nil {
         log.Println("Error while trying to Delete Task taskType:", taskType, ",taskId:", taskId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -241,7 +241,7 @@ func (c *ConductorHttpClient) GetTaskQueueSizes(taskNames string) (string, error
     outputString, err := c.httpClient.Post(url, nil, nil, taskNames)
     if err != nil {
         log.Println("Error while trying to Get Task Queue Sizes", err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -262,7 +262,7 @@ func (c *ConductorHttpClient) GetWorkflow(workflowId string, includeTasks bool) 
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {
         log.Println("Error while trying to Get Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -286,7 +286,7 @@ func (c *ConductorHttpClient) GetRunningWorkflows(workflowName string, version i
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {
         log.Println("Error while trying to Get Running Workflows", workflowName, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -313,7 +313,7 @@ func (c *ConductorHttpClient) StartWorkflow(workflowName string, version int, co
     outputString, err := c.httpClient.Post(url, params, headers, inputJson)
     if err != nil {
         log.Println("Error while trying to Start Workflow", workflowName, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -331,7 +331,7 @@ func (c *ConductorHttpClient) TerminateWorkflow(workflowId string, reason string
     outputString, err := c.httpClient.Delete(url, params, nil, "")
     if err != nil {
         log.Println("Error while trying to Terminate Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -342,7 +342,7 @@ func (c *ConductorHttpClient) PauseWorkflow(workflowId string) (string, error) {
     outputString, err := c.httpClient.Put(url, nil, nil, "")
     if err != nil {
         log.Println("Error while trying to Pause Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -353,7 +353,7 @@ func (c *ConductorHttpClient) ResumeWorkflow(workflowId string) (string, error) 
     outputString, err := c.httpClient.Put(url, nil, nil, "")
     if err != nil {
         log.Println("Error while trying to Resume Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -365,7 +365,7 @@ func (c *ConductorHttpClient) SkipTaskFromWorkflow(workflowId string, taskRefere
     outputString, err := c.httpClient.Put(url, nil, nil, skipTaskRequestBody)
     if err != nil {
         log.Println("Error while trying to Skip Task From Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -380,7 +380,7 @@ func (c *ConductorHttpClient) RerunWorkflow(workflowId string, rerunWorkflowRequ
     outputString, err := c.httpClient.Post(url, nil, nil, rerunWorkflowRequest)
     if err != nil {
         log.Println("Error while trying to Rerun Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }
@@ -392,7 +392,7 @@ func (c *ConductorHttpClient) RestartWorkflow(workflowId string) (string, error)
     outputString, err := c.httpClient.Post(url, nil, nil, "")
     if err != nil {
         log.Println("Error while trying to Restart Completed Workflow", workflowId, err)
-        return "", nil
+        return "", err
     } else {
         return outputString, nil
     }


### PR DESCRIPTION
Previously, the ConductorHttpClient methods were all returning `nil` instead of the error.