### PR TITLE
fix(py-client): proper naming for task def update function

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -18,6 +18,7 @@ import requests
 import json
 import sys
 import socket
+import warnings
 
 
 hostname = socket.gethostname()
@@ -145,6 +146,15 @@ class MetadataClient(BaseClient):
     def registerTaskDefs(self, listOfTaskDefObj):
         url = self.makeUrl('taskdefs')
         return self.post(url, None, listOfTaskDefObj)
+
+    def registerTaskDef(self, taskDefObj):
+        """registerTaskDef is deprecated since PUT /metadata/taskdefs does not
+        register but updates a task definition. Use updateTaskDef function 
+        instead.
+        """
+        warnings.warn(self.registerTaskDef.__doc__, DeprecationWarning)
+        url = self.makeUrl('taskdefs')
+        self.put(url, None, taskDefObj)
 
     def updateTaskDef(self, taskDefObj):
         url = self.makeUrl('taskdefs')

--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -146,7 +146,7 @@ class MetadataClient(BaseClient):
         url = self.makeUrl('taskdefs')
         return self.post(url, None, listOfTaskDefObj)
 
-    def registerTaskDef(self, taskDefObj):
+    def updateTaskDef(self, taskDefObj):
         url = self.makeUrl('taskdefs')
         self.put(url, None, taskDefObj)
 


### PR DESCRIPTION
Naming of the _registerTaskDef_ function is misleading since `PUT /metadata/taskdefs` [updates a task definition](https://netflix.github.io/conductor/runtime/#task-workflow-metadata). Proper name should be _updateTaskDef_