### PR TITLE
Change WorkflowDef default schema version to 2

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -74,8 +74,8 @@ public class WorkflowDef extends Auditable {
 	private String failureWorkflow;
 
 	@ProtoField(id = 8)
-    @Min(value = 1, message = "workflowDef schemaVersion: ${validatedValue} should be >= {value}")
-    private int schemaVersion = 1;
+    @Min(value = 2, message = "workflowDef schemaVersion: ${validatedValue} should be >= {value}")
+    private int schemaVersion = 2;
 
 	//By default a workflow is restartable
 	@ProtoField(id = 9)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -74,7 +75,8 @@ public class WorkflowDef extends Auditable {
 	private String failureWorkflow;
 
 	@ProtoField(id = 8)
-    @Min(value = 2, message = "workflowDef schemaVersion: ${validatedValue} should be >= {value}")
+    @Min(value = 2, message = "workflowDef schemaVersion: {value} is only supported")
+	@Max(value = 2, message = "workflowDef schemaVersion: {value} is only supported")
     private int schemaVersion = 2;
 
 	//By default a workflow is restartable

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
@@ -318,7 +318,7 @@ public class WorkflowDefTest {
 		workflowDef.setSchemaVersion(3);
 		workflowDef.setName("test_env");
 
-		WorkflowTask workflowTask = new WorkflowTask();//name is null
+		WorkflowTask workflowTask = new WorkflowTask();
 
 		workflowTask.setName("t1");
 		workflowTask.setWorkflowTaskType(TaskType.SIMPLE);

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
@@ -110,7 +110,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowDefConstraints() {
         WorkflowDef workflowDef = new WorkflowDef();//name is null
-        workflowDef.setSchemaVersion(1);
+        workflowDef.setSchemaVersion(2);
 
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();
@@ -128,7 +128,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowDefConstraintsWithMultipleEnvVariable() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
-		workflowDef.setSchemaVersion(1);
+		workflowDef.setSchemaVersion(2);
 		workflowDef.setName("test_env");
 
 		WorkflowTask workflowTask_1 = new WorkflowTask();
@@ -167,7 +167,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowDefConstraintsSingleEnvVariable() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
-		workflowDef.setSchemaVersion(1);
+		workflowDef.setSchemaVersion(2);
 		workflowDef.setName("test_env");
 
 		WorkflowTask workflowTask_1 = new WorkflowTask();
@@ -194,7 +194,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowDefConstraintsDualEnvVariable() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
-		workflowDef.setSchemaVersion(1);
+		workflowDef.setSchemaVersion(2);
 		workflowDef.setName("test_env");
 
 		WorkflowTask workflowTask_1 = new WorkflowTask();
@@ -223,7 +223,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowDefConstraintsWithMapAsInputParam() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
-		workflowDef.setSchemaVersion(1);
+		workflowDef.setSchemaVersion(2);
 		workflowDef.setName("test_env");
 
 		WorkflowTask workflowTask_1 = new WorkflowTask();
@@ -310,5 +310,34 @@ public class WorkflowDefTest {
 		result.forEach(e -> validationErrors.add(e.getMessage()));
 
 		assertTrue(validationErrors.contains("key: blabla input parameter value: is null or empty"));
+	}
+
+	@Test
+	public void testWorkflowSchemaVersion1() {
+		WorkflowDef workflowDef = new WorkflowDef();//name is null
+		workflowDef.setSchemaVersion(1);
+		workflowDef.setName("test_env");
+
+		WorkflowTask workflowTask = new WorkflowTask();//name is null
+
+		workflowTask.setName("t1");
+		workflowTask.setWorkflowTaskType(TaskType.SIMPLE);
+		workflowTask.setTaskReferenceName("t1");
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("blabla", "");
+		workflowTask.setInputParameters(map);
+
+		workflowDef.getTasks().add(workflowTask);
+
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		Validator validator = factory.getValidator();
+		Set<ConstraintViolation<Object>> result = validator.validate(workflowDef);
+		assertEquals(2, result.size());
+
+		List<String> validationErrors = new ArrayList<>();
+		result.forEach(e -> validationErrors.add(e.getMessage()));
+
+		assertTrue(validationErrors.contains("workflowDef schemaVersion: 1 should be >= 2"));
 	}
 }

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
@@ -315,7 +315,7 @@ public class WorkflowDefTest {
 	@Test
 	public void testWorkflowSchemaVersion1() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
-		workflowDef.setSchemaVersion(1);
+		workflowDef.setSchemaVersion(3);
 		workflowDef.setName("test_env");
 
 		WorkflowTask workflowTask = new WorkflowTask();//name is null
@@ -338,6 +338,6 @@ public class WorkflowDefTest {
 		List<String> validationErrors = new ArrayList<>();
 		result.forEach(e -> validationErrors.add(e.getMessage()));
 
-		assertTrue(validationErrors.contains("workflowDef schemaVersion: 1 should be >= 2"));
+		assertTrue(validationErrors.contains("workflowDef schemaVersion: 2 is only supported"));
 	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
@@ -44,9 +44,9 @@ public class DecisionTaskMapperTest {
         parametersUtils = new ParametersUtils();
 
         ip1 = new HashMap<>();
-        ip1.put("p1", "workflow.input.param1");
-        ip1.put("p2", "workflow.input.param2");
-        ip1.put("case", "workflow.input.case");
+        ip1.put("p1", "${workflow.input.param1}");
+        ip1.put("p2", "${workflow.input.param2}");
+        ip1.put("case", "${workflow.input.case}");
 
         task1 = new WorkflowTask();
         task1.setName("Test1");
@@ -152,8 +152,8 @@ public class DecisionTaskMapperTest {
         Workflow workflowInstance = new Workflow();
         workflowInstance.setWorkflowDefinition(new WorkflowDef());
         Map<String, Object> workflowInput = new HashMap<>();
-        workflowInput.put("p1", "workflow.input.param1");
-        workflowInput.put("p2", "workflow.input.param2");
+        workflowInput.put("param1", "test1");
+        workflowInput.put("param2", "test2");
         workflowInput.put("case", "0");
         workflowInstance.setInput(workflowInput);
 

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -267,7 +267,7 @@ public class MetadataServiceTest{
     public void testRegisterWorkflowDef() {
         WorkflowDef workflowDef = new WorkflowDef();
         workflowDef.setName("somename");
-        workflowDef.setSchemaVersion(5);
+        workflowDef.setSchemaVersion(2);
         List<WorkflowTask> tasks = new ArrayList<>();
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setTaskReferenceName("hello");


### PR DESCRIPTION
Description:
Change WorkflowDef default schema version to 2.

Implications:
This require changes in way you define input parameters for WorkflowTask. For schema version 1 you don't need to pass $ for input parameter expression resolution but for schema version 2 you need to pass in following format ${workflow.input...} for mapping.
```
WorkflowTask workflowTask = new WorkflowTask();
        Map<String, Object> ip1 = new HashMap<>();
        if (schemaVersion <= 1) {
            ip1.put("p1", "workflow.input.param1");
            ip1.put("p2", "workflow.input.param2");
        } else {
            ip1.put("p1", "${workflow.input.param1}");
            ip1.put("p2", "${workflow.input.param2}");
        }
workflowTask.setInputParameters(ip1);
```
