### PR TITLE
Redis Authentication Support

### DIFF
--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -67,8 +67,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -189,8 +189,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -311,8 +311,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -443,8 +443,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -565,8 +565,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -687,8 +687,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -817,8 +817,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -947,8 +947,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [
@@ -1077,8 +1077,8 @@
             "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.0-rc4",
-            "requested": "2.0.0-rc4"
+            "locked": "2.0.0-rc5",
+            "requested": "2.0.0-rc5"
         },
         "com.netflix.servo:servo-core": {
             "firstLevelTransitive": [

--- a/redis-persistence/src/main/java/com/netflix/conductor/jedis/ConfigurationHostSupplierProvider.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/jedis/ConfigurationHostSupplierProvider.java
@@ -51,6 +51,12 @@ public class ConfigurationHostSupplierProvider implements Provider<HostSupplier>
             String host = hostConfigValues[0];
             int port = Integer.parseInt(hostConfigValues[1]);
             String rack = hostConfigValues[2];
+
+            if (hostConfigValues.length >= 4) {
+                String password = hostConfigValues[3];
+                return new Host(host, port, rack, Host.Status.Up, null, password);
+            }
+
             return new Host(host, port, rack, Host.Status.Up);
         }).collect(Collectors.toList());
 

--- a/redis-persistence/src/test/java/com/netflix/conductor/jedis/ConfigurationHostSupplierProviderTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/jedis/ConfigurationHostSupplierProviderTest.java
@@ -1,0 +1,98 @@
+package com.netflix.conductor.jedis;
+
+import com.netflix.conductor.dyno.SystemPropertiesDynomiteConfiguration;
+import com.netflix.dyno.connectionpool.Host;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigurationHostSupplierProviderTest {
+
+    private TestPropertiesDynomiteConfiguration configuration;
+    private ConfigurationHostSupplierProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        configuration = new TestPropertiesDynomiteConfiguration();
+        provider = new ConfigurationHostSupplierProvider(configuration);
+    }
+
+    @Test
+    public void getHost() throws Exception {
+        configuration.setProperty("workflow.dynomite.cluster.hosts", "dyno1:8102:us-east-1c");
+
+        List<Host> hosts = provider.get().getHosts();
+
+        Assert.assertEquals(1, hosts.size());
+        Host firstHost = hosts.get(0);
+        Assert.assertEquals("dyno1", firstHost.getHostName());
+        Assert.assertEquals(8102, firstHost.getPort());
+        Assert.assertEquals("us-east-1c", firstHost.getRack());
+        Assert.assertTrue(firstHost.isUp());
+    }
+
+    @Test
+    public void getMultipleHosts() throws Exception {
+        configuration.setProperty("workflow.dynomite.cluster.hosts",
+            "dyno1:8102:us-east-1c;dyno2:8103:us-east-1c");
+
+        List<Host> hosts = provider.get().getHosts();
+
+        Assert.assertEquals(2, hosts.size());
+        Host firstHost = hosts.get(0);
+        Assert.assertEquals("dyno1", firstHost.getHostName());
+        Assert.assertEquals(8102, firstHost.getPort());
+        Assert.assertEquals("us-east-1c", firstHost.getRack());
+        Assert.assertTrue(firstHost.isUp());
+        Host secondHost = hosts.get(1);
+        Assert.assertEquals("dyno2", secondHost.getHostName());
+        Assert.assertEquals(8103, secondHost.getPort());
+        Assert.assertEquals("us-east-1c", secondHost.getRack());
+        Assert.assertTrue(secondHost.isUp());
+    }
+
+    @Test
+    public void getAuthenticatedHost() throws Exception {
+        configuration
+            .setProperty("workflow.dynomite.cluster.hosts", "redis1:6432:us-east-1c:password");
+
+        List<Host> hosts = provider.get().getHosts();
+
+        Assert.assertEquals(1, hosts.size());
+        Host firstHost = hosts.get(0);
+        Assert.assertEquals("redis1", firstHost.getHostName());
+        Assert.assertEquals(6432, firstHost.getPort());
+        Assert.assertEquals("us-east-1c", firstHost.getRack());
+        Assert.assertEquals("password", firstHost.getPassword());
+        Assert.assertTrue(firstHost.isUp());
+    }
+
+    private static class TestPropertiesDynomiteConfiguration extends
+        SystemPropertiesDynomiteConfiguration {
+
+        private Properties prop;
+
+        TestPropertiesDynomiteConfiguration() {
+            prop = new Properties();
+        }
+
+        @Override
+        public String getProperty(String key, String defaultValue) {
+            return prop.getOrDefault(key, defaultValue).toString();
+        }
+
+        @Override
+        public Map<String, Object> getAll() {
+            return (Map) prop;
+        }
+
+        public void setProperty(String key, String value) {
+            prop.setProperty(key, value);
+        }
+    }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -26,6 +26,10 @@ format is host:port:rack separated by semicolon
 for AWS Elasticache Redis (cluster mode enabled) the format is configuration_endpoint:port:us-east-1e. The region in this case does not matter
 `workflow.dynomite.cluster.hosts=host1:8102:us-east-1c;host2:8102:us-east-1d;host3:8102:us-east-1e`
 
+#### Redis authentication
+An optional 4th colon-delimited field can be appended to the cluster definition to specify the password for Redis authentication.
+`workflow.dynomite.cluster.hosts=host1:8102:us-east-1c:password`
+
 ### Dynomite cluster name
 `workflow.dynomite.cluster.name=dyno_cluster_name`
 

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -136,7 +136,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -495,7 +495,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -854,7 +854,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -1213,7 +1213,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -1642,7 +1642,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -2001,7 +2001,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -2360,7 +2360,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -2719,7 +2719,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -3086,7 +3086,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -3453,7 +3453,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [
@@ -3820,7 +3820,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.runtime:health-api": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -206,7 +206,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.eureka:eureka-client": {
             "firstLevelTransitive": [
@@ -670,7 +670,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.eureka:eureka-client": {
             "firstLevelTransitive": [
@@ -1134,7 +1134,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.eureka:eureka-client": {
             "firstLevelTransitive": [
@@ -1598,7 +1598,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
             ],
-            "locked": "2.0.0-rc4"
+            "locked": "2.0.0-rc5"
         },
         "com.netflix.eureka:eureka-client": {
             "firstLevelTransitive": [

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -9,7 +9,7 @@ ext {
     revCassandraUnit = '3.5.0.1'
     revCommonsLang3 = '3.0'
     revCommonsIo = '2.4'
-    revDynoQueues = '2.0.0-rc4'
+    revDynoQueues = '2.0.0-rc5'
     revElasticSearch5 = '5.6.8'
     revElasticSearch5Client = '5.6.8'
     revElasticSearch6 = '6.5.1'


### PR DESCRIPTION
This updates Conductor to use changes in the `dyno` library to connect to Redis instances requiring password authentication.  It does so by parsing an optional 4th colon-delimited string from `workflow.dynomite.cluster.hosts` to set the password on the underlying `Jedis` client. (shown below)

I'm looking for any feedback to support getting this change merged.


---

See Netflix/dyno#244 for the underlying changes, included as transitive dependency with `dyno-queues:2.0.0-rc5` upgrade.

https://github.com/Netflix/dyno/blob/v1.6.5/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java#L80-L93
