### PR TITLE
ConductorWorker execute function error is now handled

### DIFF
--- a/client/go/conductorworker.go
+++ b/client/go/conductorworker.go
@@ -49,12 +49,13 @@ func (c *ConductorWorker) Execute(t *task.Task, executeFunction func(t *task.Tas
 	taskResult, err := executeFunction(t)
 	if err != nil {
 		log.Println("Error Executing task:", err.Error())
-		return
+		taskResult.Status = task.FAILED
+    taskResult.ReasonForIncompletion = err.Error()
 	}
 
 	taskResultJsonString, err := taskResult.ToJSONString()
 	if err != nil {
-		log.Println(err)
+		log.Println(err.Error())
 		log.Println("Error Forming TaskResult JSON body")
 		return
 	}


### PR DESCRIPTION
Previously, when an non-nil error value was returned from the `executeFunction`, the conductorworker was returning early, before sending an update to conductor that the task failed.

In this PR, I modified the `Execute` method to properly handle errors