### PR TITLE
(fix): Allow caseParam or caseExpression as required for Decision task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
+++ b/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
@@ -83,8 +83,9 @@ public @interface WorkflowTaskTypeConstraint {
 
         private boolean isDecisionTaskValid(WorkflowTask workflowTask, ConstraintValidatorContext context) {
             boolean valid = true;
-            if (workflowTask.getCaseValueParam() == null){
-                String message = String.format(PARAM_REQUIRED_STRING_FORMAT, "caseValueParam", TaskType.DECISION, workflowTask.getName());
+            if (workflowTask.getCaseValueParam() == null && workflowTask.getCaseExpression() == null){
+                String message = String.format(PARAM_REQUIRED_STRING_FORMAT, "caseValueParam or caseExpression", TaskType.DECISION,
+                    workflowTask.getName());
                 context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
                 valid = false;
             }
@@ -93,7 +94,8 @@ public @interface WorkflowTaskTypeConstraint {
                 context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
                 valid = false;
             }
-            else if (workflowTask.getDecisionCases() != null && (workflowTask.getDecisionCases().size() == 0)){
+            else if ((workflowTask.getDecisionCases() != null || workflowTask.getCaseExpression() != null) &&
+                (workflowTask.getDecisionCases().size() == 0)){
                 String message = String.format("decisionCases should have atleast one task for taskType: %s taskName: %s", TaskType.DECISION, workflowTask.getName());
                 context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
                 valid = false;

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -134,7 +134,34 @@ public class WorkflowTaskTypeConstraintTest {
         result.forEach(e -> validationErrors.add(e.getMessage()));
 
         assertTrue(validationErrors.contains("decisionCases should have atleast one task for taskType: DECISION taskName: encode"));
-        assertTrue(validationErrors.contains("caseValueParam field is required for taskType: DECISION taskName: encode"));
+        assertTrue(validationErrors.contains("caseValueParam or caseExpression field is required for taskType: DECISION taskName: encode"));
+    }
+
+    @Test
+    public void testWorkflowTaskTypeDecisionWithCaseParam() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("DECISION");
+        workflowTask.setCaseExpression("$.valueCheck == null ? 'true': 'false'");
+
+        ConstraintMapping mapping = config.createConstraintMapping();
+
+        mapping.type(WorkflowTask.class)
+            .constraint(new WorkflowTaskTypeConstraintDef());
+
+        Validator validator = config.addMapping(mapping)
+            .buildValidatorFactory()
+            .getValidator();
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(1, result.size());
+
+        List<String> validationErrors = new ArrayList<>();
+
+        result.forEach(e -> validationErrors.add(e.getMessage()));
+
+        assertTrue(validationErrors.contains("decisionCases should have atleast one task for taskType: DECISION taskName: encode"));
     }
 
     @Test


### PR DESCRIPTION
Description:

Previous validation required caseParam field to be set for DECISION task which broke the Workflow task using caseExpression field in Decision Task. This PR fixes the validation by making caseParam or caseExpression as required.