### PR TITLE
Fixed the behavior of the ES6 DAO to be the same as ES5 DAO

### DIFF
--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
@@ -565,6 +565,8 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
                 .must(QueryBuilders.rangeQuery("endTime").lt(LocalDate.now().minusDays(archiveTtlDays).toString()))
                 .should(QueryBuilders.termQuery("status", "COMPLETED"))
                 .should(QueryBuilders.termQuery("status", "FAILED"))
+                .should(QueryBuilders.termQuery("status", "TIMED_OUT"))
+                .should(QueryBuilders.termQuery("status", "TERMINATED"))
                 .mustNot(QueryBuilders.existsQuery("archived"))
                 .minimumShouldMatch(1);
         SearchRequestBuilder s = elasticSearchClient.prepareSearch(indexName)

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
@@ -700,6 +700,8 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
                 .must(QueryBuilders.rangeQuery("endTime").lt(LocalDate.now().minusDays(archiveTtlDays).toString()))
                 .should(QueryBuilders.termQuery("status", "COMPLETED"))
                 .should(QueryBuilders.termQuery("status", "FAILED"))
+                .should(QueryBuilders.termQuery("status", "TIMED_OUT"))
+                .should(QueryBuilders.termQuery("status", "TERMINATED"))
                 .mustNot(QueryBuilders.existsQuery("archived"))
                 .minimumShouldMatch(1);
 


### PR DESCRIPTION
As the ES5 DAO code was updated in master recently, but ES6 was not, I am filling this gap by this pull request to keep the consistent behavior across them.