### PR TITLE
Adds HTTP TaskTimeouts

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -146,7 +146,14 @@ public class HttpTask extends WorkflowSystemTask {
 	 * Note: protected access is so that tasks extended from this task can re-use this to make http calls
 	 */
 	protected HttpResponse httpCall(Input input) throws Exception {
-		Client client = rcm.getClient(input);
+		Client client = rcm.getClient();
+
+		if(input.connectionTimeOut != null ) {
+			client.setConnectTimeout(input.connectionTimeOut);
+		}
+		if(input.readTimeOut != null ) {
+			client.setReadTimeout(input.readTimeOut);
+		}
 
 		if(input.oauthConsumerKey != null) {
 			logger.info("Configuring OAuth filter");
@@ -296,6 +303,12 @@ public class HttpTask extends WorkflowSystemTask {
 
 		private String oauthConsumerSecret;
 
+		private  Integer connectionTimeOut;
+
+		private Integer  readTimeOut;
+
+
+
 		/**
 		 * @return the method
 		 */
@@ -431,5 +444,29 @@ public class HttpTask extends WorkflowSystemTask {
 		public void setAppName(String appName) {
 			this.appName = appName;
 		}
+
+
+		/**
+		 * @return the connectionTimeOut
+		 */
+		public Integer getConnectionTimeOut() {
+			return connectionTimeOut;
+		}
+
+		/**
+		 * @return the readTimeOut
+		 */
+		public Integer getReadTimeOut() {
+			return readTimeOut;
+		}
+
+		public void setConnectionTimeOut(Integer connectionTimeOut) {
+			this.connectionTimeOut = connectionTimeOut;
+		}
+
+		public void setReadTimeOut(Integer readTimeOut) {
+			this.readTimeOut = readTimeOut;
+		}
+
 	}
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -146,15 +146,15 @@ public class HttpTask extends WorkflowSystemTask {
 	 * Note: protected access is so that tasks extended from this task can re-use this to make http calls
 	 */
 	protected HttpResponse httpCall(Input input) throws Exception {
-		Client client = rcm.getClient();
+		Client client = rcm.getClient(input);
 
 		if(input.connectionTimeOut != null ) {
 			client.setConnectTimeout(input.connectionTimeOut);
 		}
+
 		if(input.readTimeOut != null ) {
 			client.setReadTimeout(input.readTimeOut);
 		}
-
 		if(input.oauthConsumerKey != null) {
 			logger.info("Configuring OAuth filter");
 			OAuthParameters params = new OAuthParameters().consumerKey(input.oauthConsumerKey).signatureMethod("HMAC-SHA1").version("1.0");

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/RestClientManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/RestClientManager.java
@@ -47,7 +47,7 @@ public class RestClientManager {
 		this.defaultConnectTimeout = config.getIntProperty(HTTP_TASK_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
 	}
 
-	public Client getClient() {
+	public Client getClient(Input input) {
 		Client client = threadLocalClient.get();
 		client.setReadTimeout(defaultReadTimeout);
 		client.setConnectTimeout(defaultConnectTimeout);

--- a/contribs/src/test/java/com/netflix/conductor/contribs/http/TestRestClientManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/http/TestRestClientManager.java
@@ -16,7 +16,7 @@ public class TestRestClientManager {
     Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_READ_TIMEOUT),
                                                   Mockito.eq(RestClientManager.DEFAULT_READ_TIMEOUT))).thenReturn(170);
     RestClientManager clientManager = new RestClientManager(mockConfiguration);
-    Client client =  clientManager.getClient();
+    Client client =  clientManager.getClient(null);
     Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.readTimeout"),170);
     Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.connectTimeout"),200);
   }
@@ -30,10 +30,10 @@ public class TestRestClientManager {
     Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_READ_TIMEOUT),
                                                   Mockito.eq(RestClientManager.DEFAULT_READ_TIMEOUT))).thenReturn(170);
     RestClientManager clientManager = new RestClientManager(mockConfiguration);
-    Client client =  clientManager.getClient();
+    Client client =  clientManager.getClient(null);
     client.setReadTimeout(90);
     client.setConnectTimeout(90);
-    client =  clientManager.getClient();
+    client =  clientManager.getClient(null);
     Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.readTimeout"),170);
     Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.connectTimeout"),200);
   }
@@ -42,9 +42,9 @@ public class TestRestClientManager {
   public void differentObjectsForDifferentThreads() throws InterruptedException {
     Configuration mockConfiguration = Mockito.mock(Configuration.class);
     RestClientManager clientManager = new RestClientManager(mockConfiguration);
-    final Client client = clientManager.getClient();
+    final Client client = clientManager.getClient(null);
     final StringBuilder result= new StringBuilder();
-    Thread t1 = new Thread(()-> {Client client1 =clientManager.getClient();
+    Thread t1 = new Thread(()-> {Client client1 =clientManager.getClient(null);
     if(client1!=client) {
       result.append("different");
     }
@@ -58,8 +58,8 @@ public class TestRestClientManager {
   public void sameObjectForSameThread() throws InterruptedException {
     Configuration mockConfiguration = Mockito.mock(Configuration.class);
     RestClientManager clientManager = new RestClientManager(mockConfiguration);
-    Client client1 = clientManager.getClient();
-    Client client2 = clientManager.getClient();
+    Client client1 = clientManager.getClient(null);
+    Client client2 = clientManager.getClient(null);
     Assert.assertTrue(client1==client2);
     Assert.assertTrue(client1!=null);
   }

--- a/contribs/src/test/java/com/netflix/conductor/contribs/http/TestRestClientManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/http/TestRestClientManager.java
@@ -1,0 +1,68 @@
+package com.netflix.conductor.contribs.http;
+
+import com.netflix.conductor.core.config.Configuration;
+import com.sun.jersey.api.client.Client;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestRestClientManager {
+
+  @Test
+  public void setConfigFromConfiguration() {
+    Configuration mockConfiguration = Mockito.mock(Configuration.class);
+    Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_CONNECT_TIMEOUT),
+                                                  Mockito.eq(RestClientManager.DEFAULT_CONNECT_TIMEOUT))).thenReturn(200);
+    Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_READ_TIMEOUT),
+                                                  Mockito.eq(RestClientManager.DEFAULT_READ_TIMEOUT))).thenReturn(170);
+    RestClientManager clientManager = new RestClientManager(mockConfiguration);
+    Client client =  clientManager.getClient();
+    Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.readTimeout"),170);
+    Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.connectTimeout"),200);
+  }
+
+
+  @Test
+  public void clientDefaultsSetWhenRequestedAgain() {
+    Configuration mockConfiguration = Mockito.mock(Configuration.class);
+    Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_CONNECT_TIMEOUT),
+                                                  Mockito.eq(RestClientManager.DEFAULT_CONNECT_TIMEOUT))).thenReturn(200);
+    Mockito.when(mockConfiguration.getIntProperty(Mockito.eq(RestClientManager.HTTP_TASK_READ_TIMEOUT),
+                                                  Mockito.eq(RestClientManager.DEFAULT_READ_TIMEOUT))).thenReturn(170);
+    RestClientManager clientManager = new RestClientManager(mockConfiguration);
+    Client client =  clientManager.getClient();
+    client.setReadTimeout(90);
+    client.setConnectTimeout(90);
+    client =  clientManager.getClient();
+    Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.readTimeout"),170);
+    Assert.assertEquals(client.getProperties().get("com.sun.jersey.client.property.connectTimeout"),200);
+  }
+
+  @Test
+  public void differentObjectsForDifferentThreads() throws InterruptedException {
+    Configuration mockConfiguration = Mockito.mock(Configuration.class);
+    RestClientManager clientManager = new RestClientManager(mockConfiguration);
+    final Client client = clientManager.getClient();
+    final StringBuilder result= new StringBuilder();
+    Thread t1 = new Thread(()-> {Client client1 =clientManager.getClient();
+    if(client1!=client) {
+      result.append("different");
+    }
+    } );
+    t1.start();
+    t1.join();
+    Assert.assertEquals(result.toString(),"different");
+  }
+
+  @Test
+  public void sameObjectForSameThread() throws InterruptedException {
+    Configuration mockConfiguration = Mockito.mock(Configuration.class);
+    RestClientManager clientManager = new RestClientManager(mockConfiguration);
+    Client client1 = clientManager.getClient();
+    Client client2 = clientManager.getClient();
+    Assert.assertTrue(client1==client2);
+    Assert.assertTrue(client1!=null);
+  }
+
+
+}

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -133,7 +133,7 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
             });
         }
 
-        new HttpTask(new RestClientManager(), configuration);
+        new HttpTask(new RestClientManager(configuration), configuration);
         new JsonJqTransform();
         modules.add(new ServerModule());
 


### PR DESCRIPTION
1) Adds ReadTimeout and connection timeout to HTTP Tasks. 
     We take the parameters from HTTP input. If they are not present,  then timeouts from config are used. 
2) I have removed the input parameter in the RestManager.getClient method as it is an unused parameter. 
3)  RestManager.getClient uses threadlocal to create clients as we are modying the client object from various threads currently. 
         