### PR TITLE
Invalid sha1 integrity

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7502,9 +7502,9 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lazy-debug-legacy": {
-      "version": "0.0.1",
+      "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/lazy-debug/-/lazy-debug-0.0.3.tgz",
-      "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE=",
+      "integrity": "sha1-gswqb03PNvrPDHp5RoV7/2KCisc=",
       "dev": true
     },
     "lazystream": {


### PR DESCRIPTION
Fix for npm install issue (https://github.com/Netflix/conductor/issues/1054)