### PR TITLE
Idempotent workflows

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -115,6 +115,9 @@ public class Workflow extends Auditable{
     @ProtoField(id = 21)
 	private String externalOutputPayloadStoragePath;
 
+    @ProtoField(id = 22)
+    private String userDefinedId;
+
 	public Workflow(){
 
 	}
@@ -412,6 +415,14 @@ public class Workflow extends Auditable{
 	 */
 	public void setExternalOutputPayloadStoragePath(String externalOutputPayloadStoragePath) {
 		this.externalOutputPayloadStoragePath = externalOutputPayloadStoragePath;
+	}
+
+	public String getUserDefinedId() {
+		return this.userDefinedId;
+	}
+
+	public void setUserDefinedId(String userDefinedId) {
+		this.userDefinedId = userDefinedId;
 	}
 
 	public Task getTaskByRefName(String refName) {

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -116,7 +116,7 @@ public class Workflow extends Auditable{
 	private String externalOutputPayloadStoragePath;
 
     @ProtoField(id = 22)
-    private String userDefinedId;
+    private String idempotencyKey;
 
 	public Workflow(){
 
@@ -417,12 +417,12 @@ public class Workflow extends Auditable{
 		this.externalOutputPayloadStoragePath = externalOutputPayloadStoragePath;
 	}
 
-	public String getUserDefinedId() {
-		return this.userDefinedId;
+	public String getIdempotencyKey() {
+		return this.idempotencyKey;
 	}
 
-	public void setUserDefinedId(String userDefinedId) {
-		this.userDefinedId = userDefinedId;
+	public void setIdempotencyKey(String idempotencyKey) {
+		this.idempotencyKey = idempotencyKey;
 	}
 
 	public Task getTaskByRefName(String refName) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParameters.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParameters.java
@@ -1,0 +1,106 @@
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import java.util.Map;
+
+public class StartWorkflowParameters {
+    String name;
+    Integer version;
+    WorkflowDef workflowDefinition;
+    Map<String, Object> workflowInput;
+    String externalInputPayloadStoragePath;
+    String correlationId;
+    String parentWorkflowId;
+    String parentWorkflowTaskId;
+    String event;
+    String userDefinedId;
+    Map<String, String> taskToDomain;
+
+
+    public StartWorkflowParameters(String name, Integer version, WorkflowDef workflowDefinition, Map<String, Object> workflowInput, String externalInputPayloadStoragePath, String correlationId, String parentWorkflowId, String parentWorkflowTaskId, String event, String userDefinedId, Map<String, String> taskToDomain) {
+        this.name = name;
+        this.version = version;
+        this.workflowDefinition = workflowDefinition;
+        this.workflowInput = workflowInput;
+        this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
+        this.correlationId = correlationId;
+        this.parentWorkflowId = parentWorkflowId;
+        this.parentWorkflowTaskId = parentWorkflowTaskId;
+        this.event = event;
+        this.userDefinedId = userDefinedId;
+        this.taskToDomain = taskToDomain;
+    }
+
+    public WorkflowDef getWorkflowDefinition() {
+        return workflowDefinition;
+    }
+
+    public void setWorkflowDefinition(WorkflowDef workflowDefinition) {
+        this.workflowDefinition = workflowDefinition;
+    }
+
+    public Map<String, Object> getWorkflowInput() {
+        return workflowInput;
+    }
+
+    public void setWorkflowInput(Map<String, Object> workflowInput) {
+        this.workflowInput = workflowInput;
+    }
+
+    public String getExternalInputPayloadStoragePath() {
+        return externalInputPayloadStoragePath;
+    }
+
+    public void setExternalInputPayloadStoragePath(String externalInputPayloadStoragePath) {
+        this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public String getParentWorkflowId() {
+        return parentWorkflowId;
+    }
+
+    public void setParentWorkflowId(String parentWorkflowId) {
+        this.parentWorkflowId = parentWorkflowId;
+    }
+
+    public String getParentWorkflowTaskId() {
+        return parentWorkflowTaskId;
+    }
+
+    public void setParentWorkflowTaskId(String parentWorkflowTaskId) {
+        this.parentWorkflowTaskId = parentWorkflowTaskId;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public void setEvent(String event) {
+        this.event = event;
+    }
+
+    public String getUserDefinedId() {
+        return userDefinedId;
+    }
+
+    public void setUserDefinedId(String userDefinedId) {
+        this.userDefinedId = userDefinedId;
+    }
+
+    public Map<String, String> getTaskToDomain() {
+        return taskToDomain;
+    }
+
+    public void setTaskToDomain(Map<String, String> taskToDomain) {
+        this.taskToDomain = taskToDomain;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParameters.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParameters.java
@@ -14,11 +14,11 @@ public class StartWorkflowParameters {
     String parentWorkflowId;
     String parentWorkflowTaskId;
     String event;
-    String userDefinedId;
+    String idempotencyKey;
     Map<String, String> taskToDomain;
 
 
-    public StartWorkflowParameters(String name, Integer version, WorkflowDef workflowDefinition, Map<String, Object> workflowInput, String externalInputPayloadStoragePath, String correlationId, String parentWorkflowId, String parentWorkflowTaskId, String event, String userDefinedId, Map<String, String> taskToDomain) {
+    public StartWorkflowParameters(String name, Integer version, WorkflowDef workflowDefinition, Map<String, Object> workflowInput, String externalInputPayloadStoragePath, String correlationId, String parentWorkflowId, String parentWorkflowTaskId, String event, String idempotencyKey, Map<String, String> taskToDomain) {
         this.name = name;
         this.version = version;
         this.workflowDefinition = workflowDefinition;
@@ -28,7 +28,7 @@ public class StartWorkflowParameters {
         this.parentWorkflowId = parentWorkflowId;
         this.parentWorkflowTaskId = parentWorkflowTaskId;
         this.event = event;
-        this.userDefinedId = userDefinedId;
+        this.idempotencyKey = idempotencyKey;
         this.taskToDomain = taskToDomain;
     }
 
@@ -88,12 +88,12 @@ public class StartWorkflowParameters {
         this.event = event;
     }
 
-    public String getUserDefinedId() {
-        return userDefinedId;
+    public String getIdempotencyKey() {
+        return idempotencyKey;
     }
 
-    public void setUserDefinedId(String userDefinedId) {
-        this.userDefinedId = userDefinedId;
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
     }
 
     public Map<String, String> getTaskToDomain() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParametersBuilder.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParametersBuilder.java
@@ -14,7 +14,7 @@ public class StartWorkflowParametersBuilder {
     private String parentWorkflowId;
     private String parentWorkflowTaskId;
     private String event;
-    private String userDefinedId;
+    private String idempotencyKey;
     private Map<String, String> taskToDomain;
 
     public static StartWorkflowParametersBuilder newBuilder() {
@@ -56,8 +56,8 @@ public class StartWorkflowParametersBuilder {
         return this;
     }
 
-    public StartWorkflowParametersBuilder setUserDefinedId(String userDefinedId) {
-        this.userDefinedId = userDefinedId;
+    public StartWorkflowParametersBuilder setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
         return this;
     }
 
@@ -77,6 +77,6 @@ public class StartWorkflowParametersBuilder {
     }
 
     public StartWorkflowParameters createStartWorkflowParameters() {
-        return new StartWorkflowParameters(name, version, workflowDefinition, workflowInput, externalInputPayloadStoragePath, correlationId, parentWorkflowId, parentWorkflowTaskId, event, userDefinedId, taskToDomain);
+        return new StartWorkflowParameters(name, version, workflowDefinition, workflowInput, externalInputPayloadStoragePath, correlationId, parentWorkflowId, parentWorkflowTaskId, event, idempotencyKey, taskToDomain);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParametersBuilder.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/StartWorkflowParametersBuilder.java
@@ -1,0 +1,82 @@
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import java.util.Map;
+
+public class StartWorkflowParametersBuilder {
+    private String name;
+    private Integer version;
+    private WorkflowDef workflowDefinition;
+    private Map<String, Object> workflowInput;
+    private String externalInputPayloadStoragePath;
+    private String correlationId;
+    private String parentWorkflowId;
+    private String parentWorkflowTaskId;
+    private String event;
+    private String userDefinedId;
+    private Map<String, String> taskToDomain;
+
+    public static StartWorkflowParametersBuilder newBuilder() {
+        return new StartWorkflowParametersBuilder();
+    }
+
+    public StartWorkflowParametersBuilder setWorkflowDefinition(WorkflowDef workflowDefinition) {
+        this.workflowDefinition = workflowDefinition;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setWorkflowInput(Map<String, Object> workflowInput) {
+        this.workflowInput = workflowInput;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setExternalInputPayloadStoragePath(String externalInputPayloadStoragePath) {
+        this.externalInputPayloadStoragePath = externalInputPayloadStoragePath;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setParentWorkflowId(String parentWorkflowId) {
+        this.parentWorkflowId = parentWorkflowId;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setParentWorkflowTaskId(String parentWorkflowTaskId) {
+        this.parentWorkflowTaskId = parentWorkflowTaskId;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setEvent(String event) {
+        this.event = event;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setUserDefinedId(String userDefinedId) {
+        this.userDefinedId = userDefinedId;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setTaskToDomain(Map<String, String> taskToDomain) {
+        this.taskToDomain = taskToDomain;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public StartWorkflowParametersBuilder setVersion(Integer version) {
+        this.version = version;
+        return this;
+    }
+
+    public StartWorkflowParameters createStartWorkflowParameters() {
+        return new StartWorkflowParameters(name, version, workflowDefinition, workflowInput, externalInputPayloadStoragePath, correlationId, parentWorkflowId, parentWorkflowTaskId, event, userDefinedId, taskToDomain);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -158,7 +158,7 @@ public class WorkflowExecutor {
                 startWorkflowParameters.getParentWorkflowId(),
                 startWorkflowParameters.getParentWorkflowTaskId(),
                 startWorkflowParameters.getEvent(),
-                startWorkflowParameters.getUserDefinedId(),
+                startWorkflowParameters.getIdempotencyKey(),
                 startWorkflowParameters.getTaskToDomain()
         );
     }
@@ -173,7 +173,7 @@ public class WorkflowExecutor {
             String parentWorkflowId,
             String parentWorkflowTaskId,
             String event,
-            String userDefinedId,
+            String idempotencyKey,
             Map<String, String> taskToDomain
     ) {
         workflowDefinition = metadataMapperService.populateTaskDefinitions(workflowDefinition);
@@ -198,7 +198,7 @@ public class WorkflowExecutor {
         workflow.setUpdateTime(null);
         workflow.setEvent(event);
         workflow.setTaskToDomain(taskToDomain);
-        workflow.setUserDefinedId(userDefinedId);
+        workflow.setIdempotencyKey(idempotencyKey);
 
         workflow.setInput(workflowInput);
         if (workflow.getInput() != null) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -22,6 +22,7 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
+import com.netflix.conductor.core.execution.StartWorkflowParametersBuilder;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -57,7 +58,15 @@ public class SubWorkflow extends WorkflowSystemTask {
 		String correlationId = workflow.getCorrelationId();
 		
 		try {
-			String subWorkflowId = provider.startWorkflow(name, version, wfInput, null, correlationId, workflow.getWorkflowId(), task.getTaskId(), null, workflow.getTaskToDomain());
+			String subWorkflowId = provider.startWorkflow(name, version, StartWorkflowParametersBuilder.newBuilder()
+					.setWorkflowInput(wfInput)
+					.setCorrelationId(correlationId)
+					.setParentWorkflowId(workflow.getWorkflowId())
+					.setParentWorkflowTaskId(task.getTaskId())
+					.setTaskToDomain(workflow.getTaskToDomain())
+					.createStartWorkflowParameters()
+			);
+
 			task.getOutputData().put(SUB_WORKFLOW_ID, subWorkflowId);
 			task.getInputData().put(SUB_WORKFLOW_ID, subWorkflowId);
 			task.setStatus(Status.IN_PROGRESS);

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -318,7 +318,7 @@ public class ExecutionDAOFacade {
 
     public void obtainLockForWorkflow(Workflow workflow) {
         if (!executionDAO.obtainLockForWorkflow(workflow)) {
-            throw new ApplicationException(ApplicationException.Code.CONFLICT, "A workflow is already running with the same UserDefinedID");
+            throw new ApplicationException(ApplicationException.Code.CONFLICT, "A workflow is already running with the same idempotencyKey");
         }
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -142,17 +142,7 @@ public class ExecutionDAOFacade {
      * @return the id of the created workflow
      */
     public String createWorkflow(Workflow workflow) {
-        if (!executionDAO.obtainLockForWorkflow(workflow)) {
-            throw new ApplicationException(ApplicationException.Code.CONFLICT, "A workflow is already running with the same UserDefinedID");
-        }
-
-        try {
-            executionDAO.createWorkflow(workflow);
-        } catch (Exception ex) {
-            executionDAO.releaseLockForWorkflow(workflow);
-            throw ex;
-        }
-
+        executionDAO.createWorkflow(workflow);
         indexDAO.indexWorkflow(workflow);
         return workflow.getWorkflowId();
     }
@@ -320,5 +310,15 @@ public class ExecutionDAOFacade {
 
     public List<TaskExecLog> getTaskExecutionLogs(String taskId) {
         return indexDAO.getTaskExecutionLogs(taskId);
+    }
+
+    public void releaseLockForWorkflow(Workflow workflow) {
+        executionDAO.releaseLockForWorkflow(workflow);
+    }
+
+    public void obtainLockForWorkflow(Workflow workflow) {
+        if (!executionDAO.obtainLockForWorkflow(workflow)) {
+            throw new ApplicationException(ApplicationException.Code.CONFLICT, "A workflow is already running with the same UserDefinedID");
+        }
     }
 }

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -275,7 +275,7 @@ public interface ExecutionDAO {
 	}
 
 	default boolean obtainLockForWorkflow(Workflow workflow) {
-	    return false;
+	    return true;
 	}
 
 	default void releaseLockForWorkflow(Workflow workflow) {

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -270,7 +270,7 @@ public interface ExecutionDAO {
 
 	List<PollData> getPollData(String taskDefName);
 
-	default String getWorkflowIdByUserDefinedId(String workflowType, String userDefinedId) {
+	default String getWorkflowIdByIdempotencyKey(String workflowType, String idempotencyKey) {
 	    return null;
 	}
 

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -270,4 +270,15 @@ public interface ExecutionDAO {
 
 	List<PollData> getPollData(String taskDefName);
 
+	default String getWorkflowIdByUserDefinedId(String workflowType, String userDefinedId) {
+	    return null;
+	}
+
+	default boolean obtainLockForWorkflow(Workflow workflow) {
+	    return false;
+	}
+
+	default void releaseLockForWorkflow(Workflow workflow) {
+
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -64,7 +64,7 @@ public interface WorkflowService {
      * @return the id of the workflow instance that can be use for tracking.
      */
     String startWorkflow(@NotEmpty(message = "Workflow name cannot be null or empty") String name, Integer version,
-                                String correlationId, String userDefinedId, Map<String, Object> input);
+                                String correlationId, String idempotencyKey, Map<String, Object> input);
 
     /**
      * Lists workflows for the given correlation id.

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -64,7 +64,7 @@ public interface WorkflowService {
      * @return the id of the workflow instance that can be use for tracking.
      */
     String startWorkflow(@NotEmpty(message = "Workflow name cannot be null or empty") String name, Integer version,
-                                String correlationId, Map<String, Object> input);
+                                String correlationId, String userDefinedId, Map<String, Object> input);
 
     /**
      * Lists workflows for the given correlation id.

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -128,7 +128,7 @@ public class WorkflowServiceImpl implements WorkflowService {
      * @return the id of the workflow instance that can be use for tracking.
      */
     @Service
-    public String startWorkflow(String name, Integer version, String correlationId, String userDefinedId, Map<String, Object> input) {
+    public String startWorkflow(String name, Integer version, String correlationId, String idempotencyKey, Map<String, Object> input) {
         WorkflowDef workflowDef = metadataService.getWorkflowDef( name, version );
         if (workflowDef == null) {
             throw new ApplicationException( ApplicationException.Code.NOT_FOUND, String.format( "No such workflow found by name: %s, version: %d", name, version ) );
@@ -136,7 +136,7 @@ public class WorkflowServiceImpl implements WorkflowService {
         return workflowExecutor.startWorkflow(workflowDef.getName(), workflowDef.getVersion(), StartWorkflowParametersBuilder.newBuilder()
                 .setCorrelationId(correlationId)
                 .setWorkflowInput(input)
-                .setUserDefinedId(userDefinedId)
+                .setIdempotencyKey(idempotencyKey)
                 .createStartWorkflowParameters()
         );
     }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -29,6 +29,7 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.execution.StartWorkflowParametersBuilder;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.service.utils.ServiceUtils;
 
@@ -106,13 +107,13 @@ public class WorkflowServiceImpl implements WorkflowService {
                     taskToDomain
             );
         } else {
-            return workflowExecutor.startWorkflow(
-                    workflowDef,
-                    input,
-                    externalInputPayloadStoragePath,
-                    correlationId,
-                    null,
-                    taskToDomain
+            return workflowExecutor.startWorkflow(StartWorkflowParametersBuilder.newBuilder()
+                    .setWorkflowDefinition(workflowDef)
+                    .setWorkflowInput(input)
+                    .setExternalInputPayloadStoragePath(externalInputPayloadStoragePath)
+                    .setCorrelationId(correlationId)
+                    .setTaskToDomain(taskToDomain)
+                    .createStartWorkflowParameters()
             );
         }
     }
@@ -127,12 +128,17 @@ public class WorkflowServiceImpl implements WorkflowService {
      * @return the id of the workflow instance that can be use for tracking.
      */
     @Service
-    public String startWorkflow(String name, Integer version, String correlationId, Map<String, Object> input) {
+    public String startWorkflow(String name, Integer version, String correlationId, String userDefinedId, Map<String, Object> input) {
         WorkflowDef workflowDef = metadataService.getWorkflowDef( name, version );
         if (workflowDef == null) {
             throw new ApplicationException( ApplicationException.Code.NOT_FOUND, String.format( "No such workflow found by name: %s, version: %d", name, version ) );
         }
-        return workflowExecutor.startWorkflow( workflowDef.getName(), workflowDef.getVersion(), correlationId, input, null );
+        return workflowExecutor.startWorkflow(workflowDef.getName(), workflowDef.getVersion(), StartWorkflowParametersBuilder.newBuilder()
+                .setCorrelationId(correlationId)
+                .setWorkflowInput(input)
+                .setUserDefinedId(userDefinedId)
+                .createStartWorkflowParameters()
+        );
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -30,6 +30,8 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.ValidationModule;
 import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.execution.StartWorkflowParameters;
+import com.netflix.conductor.core.execution.StartWorkflowParametersBuilder;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.interceptors.ServiceInterceptor;
 import org.junit.Before;
@@ -104,7 +106,7 @@ public class WorkflowServiceTest {
         try{
             Map<String, Object> input = new HashMap<>();
             input.put("1", "abc");
-            workflowService.startWorkflow(null, 1, "abc", input);
+            workflowService.startWorkflow(null, 1, "abc", "u123", input);
         } catch (ConstraintViolationException ex){
             assertEquals(1, ex.getConstraintViolations().size());
             Set<String> messages = getConstraintViolationMessages(ex.getConstraintViolations());
@@ -145,9 +147,8 @@ public class WorkflowServiceTest {
         String workflowID = "w112";
 
         when(mockMetadata.getWorkflowDef(anyString(), anyInt())).thenReturn(workflowDef);
-        when(mockWorkflowExecutor.startWorkflow(anyString(), anyInt(), anyString(),
-                anyMapOf(String.class, Object.class), any(String.class))).thenReturn(workflowID);
-        assertEquals("w112", workflowService.startWorkflow("test", 1, "c123", input));
+        when(mockWorkflowExecutor.startWorkflow(anyString(), anyInt(), any(StartWorkflowParameters.class))).thenReturn(workflowID);
+        assertEquals("w112", workflowService.startWorkflow("test", 1, "c123", "u123", input));
     }
 
     @Test(expected = ApplicationException.class)
@@ -158,7 +159,7 @@ public class WorkflowServiceTest {
             Map<String, Object> input = new HashMap<>();
             input.put("1", "abc");
 
-            workflowService.startWorkflow("test", 1, "c123", input);
+            workflowService.startWorkflow("test", 1, "c123", "u123",input);
         } catch (ApplicationException ex) {
             String message = "No such workflow found by name: test, version: 1";
             assertEquals(message, ex.getMessage());

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -932,8 +932,8 @@ public abstract class AbstractProtoMapper {
         if (from.getExternalOutputPayloadStoragePath() != null) {
             to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         }
-        if (from.getUserDefinedId() != null) {
-            to.setUserDefinedId( from.getUserDefinedId() );
+        if (from.getIdempotencyKey() != null) {
+            to.setIdempotencyKey( from.getIdempotencyKey() );
         }
         return to.build();
     }
@@ -970,7 +970,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
-        to.setUserDefinedId( from.getUserDefinedId() );
+        to.setIdempotencyKey( from.getIdempotencyKey() );
         return to;
     }
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -932,6 +932,9 @@ public abstract class AbstractProtoMapper {
         if (from.getExternalOutputPayloadStoragePath() != null) {
             to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         }
+        if (from.getUserDefinedId() != null) {
+            to.setUserDefinedId( from.getUserDefinedId() );
+        }
         return to.build();
     }
 
@@ -967,6 +970,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
+        to.setUserDefinedId( from.getUserDefinedId() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflow.proto
+++ b/grpc/src/main/proto/model/workflow.proto
@@ -38,5 +38,5 @@ message Workflow {
     WorkflowDef workflow_definition = 19;
     string external_input_payload_storage_path = 20;
     string external_output_payload_storage_path = 21;
-    string user_defined_id = 22;
+    string idempotency_key = 22;
 }

--- a/grpc/src/main/proto/model/workflow.proto
+++ b/grpc/src/main/proto/model/workflow.proto
@@ -38,4 +38,5 @@ message Workflow {
     WorkflowDef workflow_definition = 19;
     string external_input_payload_storage_path = 20;
     string external_output_payload_storage_path = 21;
+    string user_defined_id = 22;
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -77,8 +77,9 @@ public class WorkflowResource {
     public String startWorkflow(@PathParam("name") String name,
                                 @QueryParam("version") Integer version,
                                 @QueryParam("correlationId") String correlationId,
+                                @QueryParam("userDefinedId") String userDefinedId,
                                 Map<String, Object> input) {
-        return workflowService.startWorkflow(name, version, correlationId, input);
+        return workflowService.startWorkflow(name, version, correlationId, userDefinedId, input);
     }
 
     @GET

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -77,9 +77,9 @@ public class WorkflowResource {
     public String startWorkflow(@PathParam("name") String name,
                                 @QueryParam("version") Integer version,
                                 @QueryParam("correlationId") String correlationId,
-                                @QueryParam("userDefinedId") String userDefinedId,
+                                @QueryParam("idempotencyKey") String idempotencyKey,
                                 Map<String, Object> input) {
-        return workflowService.startWorkflow(name, version, correlationId, userDefinedId, input);
+        return workflowService.startWorkflow(name, version, correlationId, idempotencyKey, input);
     }
 
     @GET

--- a/jersey/src/test/java/com/netflix/conductor/server/resources/WorkflowResourceTest.java
+++ b/jersey/src/test/java/com/netflix/conductor/server/resources/WorkflowResourceTest.java
@@ -72,8 +72,8 @@ public class WorkflowResourceTest {
         Map<String, Object> input = new HashMap<>();
         input.put("1", "abc");
         String workflowID = "w112";
-        when(mockWorkflowService.startWorkflow(anyString(), anyInt(), anyString(), anyMapOf(String.class, Object.class))).thenReturn(workflowID);
-        assertEquals("w112", workflowResource.startWorkflow("test1", 1, "c123", input));
+        when(mockWorkflowService.startWorkflow(anyString(), anyInt(), anyString(), anyString(), anyMapOf(String.class, Object.class))).thenReturn(workflowID);
+        assertEquals("w112", workflowResource.startWorkflow("test1", 1, "c123", "u123", input));
     }
 
     @Test

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -383,7 +383,6 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 			String key = nsKey(WORKFLOW_DEF_TO_WORKFLOWS, workflow.getWorkflowName(), dateStr(workflow.getCreateTime()));
 			dynoClient.srem(key, workflowId);
 			dynoClient.srem(nsKey(CORR_ID_TO_WORKFLOWS, workflow.getCorrelationId()), workflowId);
-			dynoClient.hdel(nsKey(USER_DEFINED_ID_TO_WORKFLOW_ID, workflow.getWorkflowName()), workflow.getUserDefinedId());
 			dynoClient.srem(nsKey(PENDING_WORKFLOWS, workflow.getWorkflowName()), workflowId);
 
 			// Remove the object
@@ -514,10 +513,6 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 			if (workflow.getCorrelationId() != null) {
 				// Add to list of workflows for a correlationId
 				dynoClient.sadd(nsKey(CORR_ID_TO_WORKFLOWS, workflow.getCorrelationId()), workflow.getWorkflowId());
-			}
-
-			if (workflow.getUserDefinedId() != null) {
-			    dynoClient.hset(nsKey(USER_DEFINED_ID_TO_WORKFLOW_ID, workflow.getWorkflowName()), workflow.getUserDefinedId(), workflow.getWorkflowId());
 			}
 		}
 		// Add or remove from the pending workflows


### PR DESCRIPTION
This merge request introduces idempotent workflows in Conductor, as per what have been discussed with @apanicker-nflx in this [issue](https://github.com/Netflix/conductor/issues/989).

Idempotency Keys of workflows can be defined in `startWorfklow` API call. The new parameter is optional, so this change should not impact users how are not using this new feature.

Idempotency feature works now with only Redis backend, there is no implementation yet for Cassandra or MySql, but can be easily added by implementing three functions `ExecutionDAO#getWorkflowIdByIdempotencyKey`, `ExecutionDAO#obtainLockForWorkflow` and `ExecutionDAO#releaseLockForWorkflow`.

The merge request is missing tests for the new feature, I'm willing to do them just if I get an 'Ack' on the merge request.

Workflow Bulk APIs have not been tested yet. Also, "Start a new workflow with StartWorkflowRequest" was not supported yet.

Here's a sample of API respose when there is another WF running with the same idempotency key:
```
curl -X POST  -H 'Content-Type: application/json' -d '{}' http://localhost:8080/api/workflow/test_small_wf\?correlationId\=some_id\&idempotencyKey\=my_unique_key
{"code":"CONFLICT","message":"A workflow is already running with the same idempotencyKey","retryable":false,"instance":"C02SK0JQFVH6"}
```

Thanks!