### PR TITLE
rollback workflow to previous state if new task creation/enqueuing fails

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
@@ -302,8 +302,8 @@ public class CassandraExecutionDAO extends CassandraBaseDAO implements Execution
             List<Task> tasks = workflow.getTasks();
             workflow.setTasks(new LinkedList<>());
             String payload = toJson(workflow);
-            recordCassandraDaoRequests("createWorkflow", "n/a", workflow.getWorkflowName());
-            recordCassandraDaoPayloadSize("createWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
+            recordCassandraDaoRequests("updateWorkflow", "n/a", workflow.getWorkflowName());
+            recordCassandraDaoPayloadSize("updateWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
             session.execute(updateWorkflowStatement.bind(payload, UUID.fromString(workflow.getWorkflowId())));
             workflow.setTasks(tasks);
             return workflow.getWorkflowId();
@@ -324,9 +324,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO implements Execution
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
                 ResultSet resultSet = session.execute(deleteWorkflowStatement.bind(UUID.fromString(workflowId), DEFAULT_SHARD_ID));
-                if (resultSet.wasApplied()) {
-                    removed = true;
-                }
+                removed = resultSet.wasApplied();
             } catch (Exception e) {
                 Monitors.error(CLASS_NAME, "removeWorkflow");
                 String errorMsg = String.format("Failed to remove workflow: %s", workflowId);

--- a/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
@@ -223,7 +223,7 @@ public abstract class ClientBase {
         try (InputStream inputStream = payloadStorage.download(externalStorageLocation.getUri())) {
             return objectMapper.readValue(inputStream, Map.class);
         } catch (IOException e) {
-            String errorMsg = String.format("Unable to download payload frome external storage location: %s", path);
+            String errorMsg = String.format("Unable to download payload from external storage location: %s", path);
             logger.error(errorMsg, e);
             throw new ConductorClientException(errorMsg, e);
         }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/RestClientManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/RestClientManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * 
- */
 package com.netflix.conductor.contribs.http;
 
-import com.netflix.conductor.core.config.Configuration;
-import javax.inject.Singleton;
-
 import com.netflix.conductor.contribs.http.HttpTask.Input;
+import com.netflix.conductor.core.config.Configuration;
 import com.sun.jersey.api.client.Client;
+
+import javax.inject.Singleton;
 
 /**
  * @author Viren
- * Provider for Jersey Client.  This class provides an 
+ * Provider for Jersey Client.
+ * This class provides a default {@link Client} which can be configured or extended as needed.
  */
 @Singleton
 public class RestClientManager {
@@ -42,7 +40,7 @@ public class RestClientManager {
 	private final int defaultConnectTimeout;
 
 	public RestClientManager(Configuration config) {
-		this.threadLocalClient = ThreadLocal.withInitial(()->Client.create());
+		this.threadLocalClient = ThreadLocal.withInitial(Client::create);
 		this.defaultReadTimeout =config.getIntProperty(HTTP_TASK_READ_TIMEOUT, DEFAULT_READ_TIMEOUT);
 		this.defaultConnectTimeout = config.getIntProperty(HTTP_TASK_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
 	}
@@ -53,5 +51,4 @@ public class RestClientManager {
 		client.setConnectTimeout(defaultConnectTimeout);
 		return client;
 	}
-
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -235,7 +235,7 @@ public class DeciderService {
                 taskToSchedule = workflowDef.getNextTask(taskToSchedule.getTaskReferenceName());
             }
 
-            //In case of a new workflow a the first non-skippable task will be scheduled
+            //In case of a new workflow, the first non-skippable task will be scheduled
             return getTasksToBeScheduled(workflow, taskToSchedule, 0);
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -24,11 +24,11 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.events.ScriptEvaluator;
 import com.netflix.conductor.core.execution.SystemTaskType;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.ScriptException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -114,7 +114,7 @@ public class DecisionTaskMapper implements TaskMapper {
      *
      * @param taskToSchedule: The decision task that has the case expression to be evaluated.
      * @param taskInput:      the input which has the values that will be used in evaluating the case expression.
-     * @return: A String representation of the evaluated result
+     * @return A String representation of the evaluated result
      */
     @VisibleForTesting
     String getEvaluatedCaseValue(WorkflowTask taskToSchedule, Map<String, Object> taskInput) {
@@ -127,8 +127,9 @@ public class DecisionTaskMapper implements TaskMapper {
                 Object returnValue = ScriptEvaluator.eval(expression, taskInput);
                 caseValue = (returnValue == null) ? "null" : returnValue.toString();
             } catch (ScriptException e) {
-                logger.error(e.getMessage(), e);
-                throw new RuntimeException("Error while evaluating the script " + expression, e);
+                String errorMsg = String.format("Error while evaluating script: %s", expression);
+                logger.error(errorMsg, e);
+                throw new TerminateWorkflowException(errorMsg);
             }
 
         } else {//In case of no case expression, get the caseValueParam and treat it as a string representation of caseValue

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Lambda.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Lambda.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.core.execution.tasks;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -8,8 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Singleton;
-import javax.script.ScriptException;
 import java.util.Map;
 
 
@@ -45,13 +55,6 @@ public class Lambda extends WorkflowSystemTask {
         super(TASK_NAME);
         logger.info(TASK_NAME + " task initialized...");
     }
-
-    @Override
-    public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
-
-
-    }
-
 
     @Override
     public boolean execute(Workflow workflow, Task task, WorkflowExecutor executor) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.core.execution.tasks;
 
@@ -55,7 +55,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 			wfInput = input;
 		}
 		String correlationId = workflow.getCorrelationId();
-		
+
 		try {
 			String subWorkflowId = provider.startWorkflow(name, version, wfInput, null, correlationId, workflow.getWorkflowId(), task.getTaskId(), null, workflow.getTaskToDomain());
 			task.getOutputData().put(SUB_WORKFLOW_ID, subWorkflowId);
@@ -64,21 +64,21 @@ public class SubWorkflow extends WorkflowSystemTask {
 		} catch (Exception e) {
 			task.setStatus(Status.FAILED);
 			task.setReasonForIncompletion(e.getMessage());
-			logger.error(e.getMessage(), e);
+			logger.error("Error starting sub workflow: {} from workflow: {}", name, workflow.getWorkflowId(), e);
 		}
 	}
-	
+
 	@Override
 	public boolean execute(Workflow workflow, Task task, WorkflowExecutor provider) {
 		String workflowId = (String) task.getOutputData().get(SUB_WORKFLOW_ID);
 		if (workflowId == null) {
 			workflowId = (String) task.getInputData().get(SUB_WORKFLOW_ID);	//Backward compatibility
 		}
-		
+
 		if(StringUtils.isEmpty(workflowId)) {
 			return false;
 		}
-		
+
 		Workflow subWorkflow = provider.getWorkflow(workflowId, false);
 		WorkflowStatus subWorkflowStatus = subWorkflow.getStatus();
 		if(!subWorkflowStatus.isTerminal()){
@@ -93,14 +93,14 @@ public class SubWorkflow extends WorkflowSystemTask {
 		}
 		return true;
 	}
-	
+
 	@Override
 	public void cancel(Workflow workflow, Task task, WorkflowExecutor provider) {
 		String workflowId = (String) task.getOutputData().get(SUB_WORKFLOW_ID);
 		if(workflowId == null) {
 			workflowId = (String) task.getInputData().get(SUB_WORKFLOW_ID);	//Backward compatibility
 		}
-		
+
 		if(StringUtils.isEmpty(workflowId)) {
 			return;
 		}
@@ -108,7 +108,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 		subWorkflow.setStatus(WorkflowStatus.TERMINATED);
 		provider.terminateWorkflow(subWorkflow, "Parent workflow has been terminated with status " + workflow.getStatus(), null);
 	}
-	
+
 	@Override
 	public boolean isAsync() {
 		return false;


### PR DESCRIPTION
- Removing all the new tasks created if creation/enqueuing of a task fails, essentially resetting workflow state.
- If exception is thrown during starting a new workflow, remove this workflow from the database before propagating the exception back in the response.
- Terminate the workflow with failure, if script evaluation fails in a decision task.
- Cleaned up some logs.
