### PR TITLE
Limit configuration for worker queue size of Async Index Dao

### DIFF
--- a/es5-persistence/README.md
+++ b/es5-persistence/README.md
@@ -17,6 +17,8 @@ If using the `http` or `https`, then conductor will use the REST transport proto
 Defaults to `conductor`
 * `workflow.elasticsearch.tasklog.index.name` - The name of the task log index.
 Defaults to `task_log`
+* `workflow.elasticsearch.async.dao.worker.queue.size=100` - Worker Queue size used in executor service for async methods in IndexDao 
+Defaults to `100`
 
 ### Embedded Configuration
 

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -136,11 +136,12 @@ public class ElasticSearchDAOV5 implements IndexDAO {
         int corePoolSize = 6;
         int maximumPoolSize = 12;
         long keepAliveTime = 1L;
+        int workerQueueSize = config.getAsyncWorkerQueueSize();
         this.executorService = new ThreadPoolExecutor(corePoolSize,
             maximumPoolSize,
             keepAliveTime,
             TimeUnit.MINUTES,
-            new LinkedBlockingQueue<>());
+            new LinkedBlockingQueue<>(workerQueueSize));
     }
 
     @Override

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -124,11 +124,12 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
         int corePoolSize = 6;
         int maximumPoolSize = 12;
         long keepAliveTime = 1L;
+        int workerQueueSize = config.getAsyncWorkerQueueSize();
         this.executorService = new ThreadPoolExecutor(corePoolSize,
                 maximumPoolSize,
                 keepAliveTime,
                 TimeUnit.MINUTES,
-                new LinkedBlockingQueue<>());
+                new LinkedBlockingQueue<>(workerQueueSize));
 
     }
 

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -44,7 +44,11 @@ public interface ElasticSearchConfiguration extends Configuration {
     String EMBEDDED_SETTINGS_FILE_DEFAULT_VALUE = "embedded-es.yml";
 
     String ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.archive.search.batchSize";
+
+    String ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE = "workflow.elasticsearch.async.dao.worker.queue.size";
+
     int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
+    int DEFAULT_ASYNC_WORKER_QUEUE_SIZE = 100;
 
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
@@ -107,6 +111,10 @@ public interface ElasticSearchConfiguration extends Configuration {
         return elasticSearchInstanceType;
     }
 
+    default int getAsyncWorkerQueueSize() {
+       return  getIntProperty(ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE, DEFAULT_ASYNC_WORKER_QUEUE_SIZE);
+    }
+    
     enum ElasticSearchInstanceType {
         MEMORY, EXTERNAL
     }

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -44,10 +44,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String EMBEDDED_SETTINGS_FILE_DEFAULT_VALUE = "embedded-es.yml";
 
     String ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.archive.search.batchSize";
+    int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
 
     String ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE = "workflow.elasticsearch.async.dao.worker.queue.size";
-
-    int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
     int DEFAULT_ASYNC_WORKER_QUEUE_SIZE = 100;
 
     default String getURL() {
@@ -111,10 +110,6 @@ public interface ElasticSearchConfiguration extends Configuration {
         return elasticSearchInstanceType;
     }
 
-    default int getAsyncWorkerQueueSize() {
-       return  getIntProperty(ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE, DEFAULT_ASYNC_WORKER_QUEUE_SIZE);
-    }
-    
     enum ElasticSearchInstanceType {
         MEMORY, EXTERNAL
     }
@@ -122,5 +117,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     default int getArchiveSearchBatchSize() {
         return getIntProperty(ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME,
             ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE);
+    }
+
+    default int getAsyncWorkerQueueSize() {
+        return  getIntProperty(ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE, DEFAULT_ASYNC_WORKER_QUEUE_SIZE);
     }
 }

--- a/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/TestElasticSearchConfiguration.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/TestElasticSearchConfiguration.java
@@ -1,0 +1,14 @@
+package com.netflix.conductor.elasticsearch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestElasticSearchConfiguration {
+
+	@Test
+	public void testAsyncWorkerQueueSize() {
+		ElasticSearchConfiguration es = new SystemPropertiesElasticSearchConfiguration();
+		int workerQueueSize = es.getAsyncWorkerQueueSize();
+		Assert.assertEquals(workerQueueSize, 100);
+	}
+}

--- a/es6-persistence/README.md
+++ b/es6-persistence/README.md
@@ -46,6 +46,8 @@ If using the `http` or `https`, then conductor will use the REST transport proto
 Defaults to `conductor`
 * `workflow.elasticsearch.tasklog.index.name` - The name of the task log index.
 Defaults to `task_log`
+* `workflow.elasticsearch.async.dao.worker.queue.size` - Worker Queue size used in executor service for async methods in IndexDao 
+Defaults to `100`
 
 ### Embedded Configuration
 

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
@@ -151,7 +151,9 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
         this.logIndexPrefix = this.indexPrefix + "_" + LOG_DOC_TYPE;
         this.messageIndexPrefix = this.indexPrefix + "_" + MSG_DOC_TYPE;
         this.eventIndexPrefix = this.indexPrefix + "_" + EVENT_DOC_TYPE;
-        this.executorService = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.MINUTES, new LinkedBlockingQueue<>());
+        int workerQueueSize = config.getAsyncWorkerQueueSize();
+
+        this.executorService = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.MINUTES, new LinkedBlockingQueue<>(workerQueueSize));
     }
 
     @Override

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
@@ -150,9 +150,10 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
         this.logIndexPrefix = this.indexPrefix + "_" + LOG_DOC_TYPE;
         this.messageIndexPrefix = this.indexPrefix + "_" + MSG_DOC_TYPE;
         this.eventIndexPrefix = this.indexPrefix + "_" + EVENT_DOC_TYPE;
+        int workerQueueSize = config.getAsyncWorkerQueueSize();
 
         // Set up a workerpool for performing async operations.
-        this.executorService = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.MINUTES, new LinkedBlockingQueue<>());
+        this.executorService = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.MINUTES, new LinkedBlockingQueue<>(workerQueueSize));
     }
 
     @Override

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -46,6 +46,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.archive.search.batchSize";
     int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
 
+    String ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE = "workflow.elasticsearch.async.dao.worker.queue.size";
+    int DEFAULT_ASYNC_WORKER_QUEUE_SIZE = 100;
+
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
     }
@@ -114,5 +117,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     default int getArchiveSearchBatchSize() {
         return getIntProperty(ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME,
             ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE);
+    }
+
+    default int getAsyncWorkerQueueSize() {
+        return  getIntProperty(ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE, DEFAULT_ASYNC_WORKER_QUEUE_SIZE);
     }
 }

--- a/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/TestElasticSearchConfiguration.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/TestElasticSearchConfiguration.java
@@ -1,0 +1,14 @@
+package com.netflix.conductor.elasticsearch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestElasticSearchConfiguration {
+
+	@Test
+	public void testAsyncWorkerQueueSize() {
+		ElasticSearchConfiguration es = new SystemPropertiesElasticSearchConfiguration();
+		int workerQueueSize = es.getAsyncWorkerQueueSize();
+		Assert.assertEquals(workerQueueSize, 100);
+	}
+}


### PR DESCRIPTION
Issue: 

The executor service used in async functions of Indexdao's has workerQueue Size as unbounded. 
new LinkedBlockingQueue<>() -> This creates a blocking queue size of Integer.MAX_VALUE. 

During high throughput, tasks are queued in the Linkedblocking queue due to which memory is exhausted. This is causing GC issues. 


Following are the changes. 

1. I am limiting the size to 100 by default
2. Read from configuration if this needs to be changed. 

@cyzhao @apanicker-nflx @mashurex @kishorebanala  
