### PR TITLE
Remove validation of empty strings.

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
@@ -56,12 +56,6 @@ public class ConstraintParamUtil {
     private static List<String> extractParamPathComponentsFromString(String key, String value, String taskName, WorkflowDef workflow) {
         ArrayList<String> errorList = new ArrayList<>();
 
-        if (StringUtils.isEmpty(value)) {
-            String message = String.format( "key: %s input parameter value: is null or empty", key);
-            errorList.add(message);
-            return errorList;
-        }
-
         String[] values = value.split( "(?=\\$\\{)|(?<=\\})" );
 
         for (int i = 0; i < values.length; i++)

--- a/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
@@ -56,6 +56,12 @@ public class ConstraintParamUtil {
     private static List<String> extractParamPathComponentsFromString(String key, String value, String taskName, WorkflowDef workflow) {
         ArrayList<String> errorList = new ArrayList<>();
 
+        if (value == null) {
+            String message = String.format("key: %s input parameter value: is null", key);
+            errorList.add(message);
+            return errorList;
+        }
+
         String[] values = value.split( "(?=\\$\\{)|(?<=\\})" );
 
         for (int i = 0; i < values.length; i++)

--- a/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
@@ -175,7 +175,29 @@ public class ConstraintParamUtilTest {
         workflowDef.setTasks(tasks);
 
         List<String> results = ConstraintParamUtil.validateInputParam(inputParam,"task_1", workflowDef);
-        assertEquals(results.size(), 1);
+        assertEquals(results.size(), 0);
+    }
+
+    @Test
+    public void testExtractParamPathComponentsWithListInputParamWithEmptyString() {
+        WorkflowDef workflowDef = constructWorkflowDef();
+
+        WorkflowTask workflowTask_1 = new WorkflowTask();
+        workflowTask_1.setName("task_1");
+        workflowTask_1.setTaskReferenceName("task_1");
+        workflowTask_1.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        Map<String, Object> inputParam = new HashMap<>();
+        inputParam.put("taskId", new String[] {""});
+        workflowTask_1.setInputParameters(inputParam);
+
+        List<WorkflowTask> tasks = new ArrayList<>();
+        tasks.add(workflowTask_1);
+
+        workflowDef.setTasks(tasks);
+
+        List<String> results = ConstraintParamUtil.validateInputParam(inputParam,"task_1", workflowDef);
+        assertEquals(results.size(), 0);
     }
 
     @Test

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
@@ -284,7 +284,7 @@ public class WorkflowDefTest {
 
 
 	@Test
-	public void testWorkflowTaskInputParamValueInvalid() {
+	public void testWorkflowTaskEmptyStringInputParamValue() {
 		WorkflowDef workflowDef = new WorkflowDef();//name is null
 		workflowDef.setSchemaVersion(2);
 		workflowDef.setName("test_env");
@@ -297,6 +297,31 @@ public class WorkflowDefTest {
 
 		Map<String, Object> map = new HashMap<>();
 		map.put("blabla", "");
+		workflowTask.setInputParameters(map);
+
+		workflowDef.getTasks().add(workflowTask);
+
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		Validator validator = factory.getValidator();
+		Set<ConstraintViolation<Object>> result = validator.validate(workflowDef);
+		assertEquals(0, result.size());
+	}
+
+	@Test
+	public void testWorkflowTasklistInputParamWithEmptyString() {
+		WorkflowDef workflowDef = new WorkflowDef();//name is null
+		workflowDef.setSchemaVersion(2);
+		workflowDef.setName("test_env");
+
+		WorkflowTask workflowTask = new WorkflowTask();//name is null
+
+		workflowTask.setName("t1");
+		workflowTask.setWorkflowTaskType(TaskType.SIMPLE);
+		workflowTask.setTaskReferenceName("t1");
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("blabla", "");
+		map.put("foo", new String[]{""});
 		workflowTask.setInputParameters(map);
 
 		workflowDef.getTasks().add(workflowTask);

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowDefTest.java
@@ -304,12 +304,7 @@ public class WorkflowDefTest {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		Validator validator = factory.getValidator();
 		Set<ConstraintViolation<Object>> result = validator.validate(workflowDef);
-		assertEquals(1, result.size());
-
-		List<String> validationErrors = new ArrayList<>();
-		result.forEach(e -> validationErrors.add(e.getMessage()));
-
-		assertTrue(validationErrors.contains("key: blabla input parameter value: is null or empty"));
+		assertEquals(0, result.size());
 	}
 
 	@Test
@@ -333,7 +328,7 @@ public class WorkflowDefTest {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		Validator validator = factory.getValidator();
 		Set<ConstraintViolation<Object>> result = validator.validate(workflowDef);
-		assertEquals(2, result.size());
+		assertEquals(1, result.size());
 
 		List<String> validationErrors = new ArrayList<>();
 		result.forEach(e -> validationErrors.add(e.getMessage()));


### PR DESCRIPTION
Hi everyone. This PR is motivated by the conversation that we had in issue #1115. 

It seems that there is a validation step in the code that doesn't allow empty strings to be input parameters. However, I don't see why we should not have empty strings as input parameters. It was possible before, and it resulted in errors for me in an updated version of conductor.

I ran the unit tests but didn't define and execute a workflow with empty strings as input parameters after my changes (yet...)