### PR TITLE
Fixes compilation for ES6 configuration

### DIFF
--- a/es6-persistence/dependencies.lock
+++ b/es6-persistence/dependencies.lock
@@ -1,121 +1,471 @@
 {
     "compile": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -125,134 +475,622 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
         },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "1.7.25",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "compileClasspath": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -262,134 +1100,622 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
         },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "1.7.25",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "default": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -399,15 +1725,153 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
         },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "1.7.25",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "jacocoAgent": {
@@ -416,127 +1880,530 @@
         }
     },
     "jacocoAnt": {
+        "org.jacoco:org.jacoco.agent": {
+            "locked": "0.8.1",
+            "transitive": [
+                "org.jacoco:org.jacoco.ant"
+            ]
+        },
         "org.jacoco:org.jacoco.ant": {
             "locked": "0.8.1"
+        },
+        "org.jacoco:org.jacoco.core": {
+            "locked": "0.8.1",
+            "transitive": [
+                "org.jacoco:org.jacoco.ant",
+                "org.jacoco:org.jacoco.report"
+            ]
+        },
+        "org.jacoco:org.jacoco.report": {
+            "locked": "0.8.1",
+            "transitive": [
+                "org.jacoco:org.jacoco.ant"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "6.0",
+            "transitive": [
+                "org.jacoco:org.jacoco.core",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "6.0",
+            "transitive": [
+                "org.jacoco:org.jacoco.core"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "6.0",
+            "transitive": [
+                "org.jacoco:org.jacoco.core"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "6.0",
+            "transitive": [
+                "org.jacoco:org.jacoco.core",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "6.0",
+            "transitive": [
+                "org.jacoco:org.jacoco.core"
+            ]
         }
     },
     "runtime": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -546,134 +2413,622 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
         },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "1.7.25",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "runtimeClasspath": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -683,134 +3038,624 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
         },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "1.7.25",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "testCompile": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "junit:junit": {
             "locked": "4.12",
             "requested": "4.12"
         },
+        "log4j:log4j": {
+            "locked": "1.2.17",
+            "transitive": [
+                "org.slf4j:slf4j-log4j12"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.2",
@@ -818,7 +3663,11 @@
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -828,142 +3677,654 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit",
+                "org.awaitility:awaitility",
+                "org.hamcrest:hamcrest-library"
+            ]
+        },
+        "org.hamcrest:hamcrest-library": {
+            "locked": "1.3",
+            "transitive": [
+                "org.awaitility:awaitility"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
         },
         "org.mockito:mockito-core": {
             "locked": "1.10.19",
             "requested": "1.10.19"
         },
+        "org.objenesis:objenesis": {
+            "locked": "2.6",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.8.0-alpha1"
+            "locked": "1.8.0-alpha1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api",
+                "org.slf4j:slf4j-log4j12"
+            ]
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.8.0-alpha1",
             "requested": "1.8.0-alpha1"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "testCompileClasspath": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "junit:junit": {
             "locked": "4.12",
             "requested": "4.12"
         },
+        "log4j:log4j": {
+            "locked": "1.2.17",
+            "transitive": [
+                "org.slf4j:slf4j-log4j12"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.2",
@@ -971,7 +4332,11 @@
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -981,142 +4346,654 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit",
+                "org.awaitility:awaitility",
+                "org.hamcrest:hamcrest-library"
+            ]
+        },
+        "org.hamcrest:hamcrest-library": {
+            "locked": "1.3",
+            "transitive": [
+                "org.awaitility:awaitility"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
         },
         "org.mockito:mockito-core": {
             "locked": "1.10.19",
             "requested": "1.10.19"
         },
+        "org.objenesis:objenesis": {
+            "locked": "2.6",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.8.0-alpha1"
+            "locked": "1.8.0-alpha1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api",
+                "org.slf4j:slf4j-log4j12"
+            ]
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.8.0-alpha1",
             "requested": "1.8.0-alpha1"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "testRuntime": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "junit:junit": {
             "locked": "4.12",
             "requested": "4.12"
         },
+        "log4j:log4j": {
+            "locked": "1.2.17",
+            "transitive": [
+                "org.slf4j:slf4j-log4j12"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.2",
@@ -1124,7 +5001,11 @@
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -1134,142 +5015,654 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit",
+                "org.awaitility:awaitility",
+                "org.hamcrest:hamcrest-library"
+            ]
+        },
+        "org.hamcrest:hamcrest-library": {
+            "locked": "1.3",
+            "transitive": [
+                "org.awaitility:awaitility"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
         },
         "org.mockito:mockito-core": {
             "locked": "1.10.19",
             "requested": "1.10.19"
         },
+        "org.objenesis:objenesis": {
+            "locked": "2.6",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.8.0-alpha1"
+            "locked": "1.8.0-alpha1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api",
+                "org.slf4j:slf4j-log4j12"
+            ]
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.8.0-alpha1",
             "requested": "1.8.0-alpha1"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     },
     "testRuntimeClasspath": {
+        "aopalliance:aopalliance": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.inject:guice"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-core": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.amazonaws:aws-java-sdk-kms": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
+            "locked": "1.11.86",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
+            ]
+        },
+        "com.amazonaws:jmespath-java": {
+            "locked": "1.11.86",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-kms",
+                "com.amazonaws:aws-java-sdk-s3"
+            ]
+        },
+        "com.carrotsearch:hppc": {
+            "locked": "0.7.1",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.7.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
+            "locked": "2.8.6",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.8.6"
+                "com.netflix.conductor:conductor-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
+            "locked": "2.7.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "com.amazonaws:jmespath-java",
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.7.5"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.8.6",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.6",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.3.4",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
         },
         "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
+            "locked": "2.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
+            ]
+        },
+        "com.github.spullara.mustache.java:compiler": {
+            "locked": "0.9.3",
+            "transitive": [
+                "org.elasticsearch.plugin:lang-mustache-client"
+            ]
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "2.0.2",
+            "transitive": [
+                "com.github.rholder:guava-retrying"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "19.0",
+            "transitive": [
+                "com.github.rholder:guava-retrying",
+                "com.google.inject:guice",
+                "com.netflix.servo:servo-core"
+            ]
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.inject:guice": {
-            "firstLevelTransitive": [
+            "locked": "4.1.0",
+            "transitive": [
+                "com.google.inject.extensions:guice-multibindings",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
+            ]
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
+            "locked": "3.5.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
+            ]
         },
         "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
+            "locked": "2.2.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
+            ]
         },
         "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
+            ]
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
+            "locked": "0.12.17",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
+            ]
         },
         "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
+            "locked": "0.68.0",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
+            ]
         },
         "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
+            "locked": "0.3.1",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
+            ]
+        },
+        "com.tdunning:t-digest": {
+            "locked": "3.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "com.vividsolutions:jts": {
+            "locked": "1.13",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.4",
             "requested": "2.4"
         },
+        "commons-logging:commons-logging": {
+            "locked": "1.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.10.6.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty3-client"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.13.Final",
+            "transitive": [
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
         "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
+            "locked": "1.2.2",
+            "transitive": [
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
+            ]
+        },
+        "javax.el:javax.el-api": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
         },
         "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
+            "locked": "1",
+            "transitive": [
+                "com.google.inject:guice",
                 "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "2.0.1.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.5",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "junit:junit": {
             "locked": "4.12",
             "requested": "4.12"
         },
+        "log4j:log4j": {
+            "locked": "1.2.17",
+            "transitive": [
+                "org.slf4j:slf4j-log4j12"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path"
+            ]
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            ]
+        },
+        "org.apache.httpcomponents:httpasyncclient": {
+            "locked": "4.1.2",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.2",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore-nio": {
+            "locked": "4.4.5",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-client"
+            ]
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-core",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.apache.logging.log4j:log4j-core": {
             "locked": "2.9.1",
-            "requested": "2.9.1"
+            "requested": "2.9.1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.apache.lucene:lucene-analyzers-common": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-backward-codecs": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-core": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-grouping": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-highlighter": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-join": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-memory": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-misc": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queries": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-queryparser": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-sandbox": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial-extras": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-spatial3d": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.apache.lucene:lucene-suggest": {
+            "locked": "7.5.0",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.2",
@@ -1277,7 +5670,11 @@
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.plugin:reindex-client"
+            ]
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
             "locked": "6.5.1",
@@ -1287,23 +5684,183 @@
             "locked": "6.5.1",
             "requested": "6.5.1"
         },
+        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
+            ]
+        },
+        "org.elasticsearch.plugin:lang-mustache-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:parent-join-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:percolator-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:reindex-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty3-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
+        "org.elasticsearch.plugin:transport-netty4-client": {
+            "locked": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:transport"
+            ]
+        },
         "org.elasticsearch:elasticsearch": {
             "locked": "6.5.1",
-            "requested": "6.5.1"
+            "requested": "6.5.1",
+            "transitive": [
+                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+                "org.elasticsearch.client:transport",
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
+        },
+        "org.elasticsearch:jna": {
+            "locked": "4.4.0-1",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client",
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.elasticsearch:securesm": {
+            "locked": "1.2",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.glassfish:javax.el": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit",
+                "org.awaitility:awaitility",
+                "org.hamcrest:hamcrest-library"
+            ]
+        },
+        "org.hamcrest:hamcrest-library": {
+            "locked": "1.3",
+            "transitive": [
+                "org.awaitility:awaitility"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "6.0.13.Final",
+            "transitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.3.2.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.locationtech.spatial4j:spatial4j": {
+            "locked": "0.6",
+            "transitive": [
+                "org.elasticsearch.plugin:aggs-matrix-stats-client",
+                "org.elasticsearch.plugin:lang-mustache-client",
+                "org.elasticsearch.plugin:parent-join-client",
+                "org.elasticsearch.plugin:percolator-client",
+                "org.elasticsearch.plugin:reindex-client",
+                "org.elasticsearch.plugin:transport-netty3-client",
+                "org.elasticsearch.plugin:transport-netty4-client"
+            ]
         },
         "org.mockito:mockito-core": {
             "locked": "1.10.19",
             "requested": "1.10.19"
         },
+        "org.objenesis:objenesis": {
+            "locked": "2.6",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.3",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.8.0-alpha1"
+            "locked": "1.8.0-alpha1",
+            "transitive": [
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.servo:servo-core",
+                "com.netflix.spectator:spectator-api",
+                "org.slf4j:slf4j-log4j12"
+            ]
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.8.0-alpha1",
             "requested": "1.8.0-alpha1"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
+            "transitive": [
+                "org.elasticsearch:elasticsearch"
+            ]
+        },
+        "software.amazon.ion:ion-java": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.amazonaws:aws-java-sdk-core"
+            ]
         }
     }
 }

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java
@@ -141,7 +141,7 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
 
         this.objectMapper = objectMapper;
         this.elasticSearchAdminClient = restClientBuilder.build();
-        this.elasticSearchClient = new RestHighLevelClient(restClientBuilder.build());
+        this.elasticSearchClient = new RestHighLevelClient(restClientBuilder);
         this.clusterHealthColor = config.getClusterHealthColor();
 
         this.indexPrefix = config.getIndexName();


### PR DESCRIPTION
Addresses #1147 

When Gradle is reconfigured to compile against the `conductor-es6-persistence` module, the project fails to compile as follows:

```
| => ../gradlew clean build -x test

> Configure project :
Inferred project: conductor, version: 2.13.0-SNAPSHOT
Publication nebula not found in project :.

> Task :conductor-es6-persistence:compileJava FAILED
/path-to-conductor/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java:144: error: incompatible types: RestClient cannot be converted to RestClientBuilder
        this.elasticSearchClient = new RestHighLevelClient(restClientBuilder.build());
                                                                                  ^
Note: /path-to-conductor/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchRestDAOV6.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
1 error

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':conductor-es6-persistence:compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 1s
14 actionable tasks: 10 executed, 4 up-to-date
```

This fix corrects the parameter type for what looks to be a regression introduced in [0185374](https://github.com/Netflix/conductor/commit/01853744137d16589aca393a6f5b8839b18a23df#diff-6ed804e9ea3968d4a4431792a26d0accR144)

This can be tested using the [**es6-compile-fix-test**](https://github.com/davidwadden/conductor/tree/es6-compile-fix-test) branch in my fork.