### PR TITLE
Adds kafka task

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
@@ -40,7 +40,6 @@ public enum TaskType {
     public static final String TASK_TYPE_LAMBDA= "LAMBDA";
     public static final String TASK_TYPE_EXCLUSIVE_JOIN = "EXCLUSIVE_JOIN";
     public static final String TASK_TYPE_TERMINATE = "TERMINATE";
-    public static final String TASK_TYPE_EXLCUSIVE_JOIN = "EXCLUSIVE_JOIN";
     public static final String TASK_TYPE_KAFKA_PUBLISH = "KAFKA_PUBLISH";
     
     private boolean isSystemTask;

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
@@ -18,7 +18,8 @@ public enum TaskType {
     HTTP(true),
     LAMBDA(true),
     EXCLUSIVE_JOIN(true),
-    TERMINATE(true);
+    TERMINATE(true),
+    KAFKA_PUBLISH(true);
 
     /**
      * TaskType constants representing each of the possible enumeration values.
@@ -39,6 +40,8 @@ public enum TaskType {
     public static final String TASK_TYPE_LAMBDA= "LAMBDA";
     public static final String TASK_TYPE_EXCLUSIVE_JOIN = "EXCLUSIVE_JOIN";
     public static final String TASK_TYPE_TERMINATE = "TERMINATE";
+    public static final String TASK_TYPE_EXLCUSIVE_JOIN = "EXCLUSIVE_JOIN";
+    public static final String TASK_TYPE_KAFKA_PUBLISH = "KAFKA_PUBLISH";
     
     private boolean isSystemTask;
 

--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	compileOnly "javax.ws.rs:jsr311-api:${revJsr311Api}"
 	compile "io.swagger:swagger-jaxrs:${revSwagger}"
 
+	compile "org.apache.kafka:kafka-clients:2.2.0"
+
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
@@ -5,7 +5,6 @@ import com.netflix.conductor.core.config.Configuration;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.LongSerializer;
 
 import java.util.Objects;
 import java.util.Properties;
@@ -14,10 +13,12 @@ public class KafkaProducerManager {
 
 	public static final String KAFKA_PUBLISH_REQUEST_TIMEOUT_MS = "kafka.publish.request.timeout.ms";
 	public static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
-	public String defaultRequestTimeOut = "100";
+	public static final String DEFAULT_REQUEST_TIMEOUT = "100";
+
+	public final String requestTimeoutConfig;
 
 	public KafkaProducerManager(Configuration configuration) {
-		this.defaultRequestTimeOut = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, defaultRequestTimeOut);
+		this.requestTimeoutConfig = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_TIMEOUT);
 	}
 
 
@@ -37,7 +38,7 @@ public class KafkaProducerManager {
 
 		configProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, input.getKeySerializer());
 
-		String requestTimeoutMs = defaultRequestTimeOut;
+		String requestTimeoutMs = requestTimeoutConfig;
 
 		if (Objects.nonNull(input.getRequestTimeoutMs())) {
 			requestTimeoutMs = String.valueOf(input.getRequestTimeoutMs());

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
@@ -1,0 +1,50 @@
+package com.netflix.conductor.contribs.kafka;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.core.config.Configuration;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongSerializer;
+
+import java.util.Objects;
+import java.util.Properties;
+
+public class KafkaProducerManager {
+
+	public static final String KAFKA_PUBLISH_REQUEST_TIMEOUT_MS = "kafka.publish.request.timeout.ms";
+	public static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+	public String defaultRequestTimeOut = "100";
+
+	public KafkaProducerManager(Configuration configuration) {
+		this.defaultRequestTimeOut = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, defaultRequestTimeOut);
+	}
+
+
+	public Producer getProducer(KafkaPublishTask.Input input) {
+
+		Properties configProperties = getProducerProperties(input);
+		Producer producer = new KafkaProducer<String, String>(configProperties);
+		return producer;
+
+	}
+
+	@VisibleForTesting
+	Properties getProducerProperties(KafkaPublishTask.Input input) {
+
+		Properties configProperties = new Properties();
+		configProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, input.getBootStrapServers());
+
+		configProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, input.getKeySerializer());
+
+		String requestTimeoutMs = defaultRequestTimeOut;
+
+		if (Objects.nonNull(input.getRequestTimeoutMs())) {
+			requestTimeoutMs = String.valueOf(input.getRequestTimeoutMs());
+		}
+
+		configProperties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+		configProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, STRING_SERIALIZER);
+		return configProperties;
+	}
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -117,8 +117,8 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 		}
 	}
 
-	private void markTaskAsFailed(Task task, String missingBootStrapServers) {
-		task.setReasonForIncompletion(missingBootStrapServers);
+	private void markTaskAsFailed(Task task, String reasonForIncompletion) {
+		task.setReasonForIncompletion(reasonForIncompletion);
 		task.setStatus(Task.Status.FAILED);
 	}
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -1,0 +1,271 @@
+package com.netflix.conductor.contribs.kafka;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+@Singleton
+public class KafkaPublishTask extends WorkflowSystemTask {
+
+	public static final String REQUEST_PARAMETER_NAME = "kafka_request";
+	public static final String NAME = "KAFKA_PUBLISH";
+	static final String MISSING_REQUEST = "Missing Kafka request. Task input MUST have a '" + REQUEST_PARAMETER_NAME + "' key with KafkaTask.Input as value. See documentation for KafkaTask for required input parameters";
+	private static final Logger logger = LoggerFactory.getLogger(KafkaPublishTask.class);
+	public static final String MISSING_BOOT_STRAP_SERVERS = "No boot strap servers specified";
+	public static final String MISSING_KAFKA_TOPIC = "Missing Kafka topic. See documentation for KafkaTask for required input parameters";
+	public static final String MISSING_KAFKA_BODY = "Missing Kafka body.  See documentation for KafkaTask for required input parameters";
+	public static final String FAILED_TO_INVOKE = "Failed to invoke kafka task due to: ";
+	protected ObjectMapper om = objectMapper();
+	protected Configuration config;
+	private String requestParameter;
+	KafkaProducerManager producerManager;
+
+
+	@Inject
+	public KafkaPublishTask(Configuration config, KafkaProducerManager clientManager) {
+		super(NAME);
+		this.config = config;
+		this.requestParameter = REQUEST_PARAMETER_NAME;
+		this.producerManager = clientManager;
+		logger.info("KafkaTask initialized...");
+	}
+
+	private static ObjectMapper objectMapper() {
+		final ObjectMapper om = new ObjectMapper();
+		om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		om.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+		om.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+		om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+		om.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+		return om;
+	}
+
+	@Override
+	public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
+
+		long taskStartMillis = Instant.now().toEpochMilli();
+		task.setWorkerId(config.getServerId());
+		Object request = task.getInputData().get(requestParameter);
+
+		if (Objects.isNull(request)) {
+			task.setReasonForIncompletion(MISSING_REQUEST);
+			task.setStatus(Task.Status.FAILED);
+			return;
+		}
+
+		KafkaPublishTask.Input input = om.convertValue(request, KafkaPublishTask.Input.class);
+
+		if (StringUtils.isBlank(input.getBootStrapServers())) {
+			task.setReasonForIncompletion(MISSING_BOOT_STRAP_SERVERS);
+			task.setStatus(Task.Status.FAILED);
+			return;
+		}
+
+		if (StringUtils.isBlank(input.getTopic())) {
+			task.setReasonForIncompletion(MISSING_KAFKA_TOPIC);
+			task.setStatus(Task.Status.FAILED);
+			return;
+		}
+
+		if (Objects.isNull(input.getValue())) {
+			task.setReasonForIncompletion(MISSING_KAFKA_BODY);
+			task.setStatus(Task.Status.FAILED);
+			return;
+		}
+
+		try {
+			Future<RecordMetadata> recordMetaDataFuture = kafkaPublish(input);
+			try {
+				recordMetaDataFuture.get();
+				task.setStatus(Task.Status.COMPLETED);
+				long timeTakenToCompleteTask = Instant.now().toEpochMilli() - taskStartMillis;
+				logger.info("Published message {}, Time taken {}", input, timeTakenToCompleteTask);
+
+			} catch (ExecutionException ec) {
+				logger.error("Failed to invoke kafka task - execution exception {}", ec);
+				task.setStatus(Task.Status.FAILED);
+				task.setReasonForIncompletion(FAILED_TO_INVOKE + ec.getMessage());
+			}
+		} catch (Exception e) {
+			logger.error(String.format("Failed to invoke kafka task for input {} - unknown exception: {}", input), e);
+			task.setStatus(Task.Status.FAILED);
+			task.setReasonForIncompletion(FAILED_TO_INVOKE + e.getMessage());
+		}
+	}
+
+	/**
+	 * @param input Kafka Request
+	 * @return Future for execution.
+	 */
+	 private Future<RecordMetadata> kafkaPublish(KafkaPublishTask.Input input) throws Exception {
+
+		long startPublishingEpochMillis = Instant.now().toEpochMilli();
+
+		Producer producer = producerManager.getProducer(input);
+
+		long timeTakenToCreateProducer = Instant.now().toEpochMilli() - startPublishingEpochMillis;
+
+		logger.info("Time taken getting producer {}", timeTakenToCreateProducer);
+
+		Object key = getKey(input);
+
+		Iterable<Header> headers = input.getHeaders().entrySet().stream()
+				.map(header -> new RecordHeader(header.getKey(), String.valueOf(header.getValue()).getBytes()))
+				.collect(Collectors.toList());
+		ProducerRecord rec = new ProducerRecord(input.getTopic(), null,
+				null, key, om.writeValueAsString(input.getValue()), headers);
+
+		Future send = producer.send(rec);
+		producer.close();
+
+		long timeTakenToPublish = Instant.now().toEpochMilli() - startPublishingEpochMillis;
+		logger.info("Time taken publishing {}", timeTakenToPublish);
+
+		return send;
+	}
+
+	@VisibleForTesting
+	Object getKey(Input input) {
+
+		String keySerializer = input.getKeySerializer();
+
+		if (LongSerializer.class.getCanonicalName().equals(keySerializer)) {
+			return Long.parseLong(String.valueOf(input.getKey()));
+		} else if (IntegerSerializer.class.getCanonicalName().equals(keySerializer)) {
+			return Integer.parseInt(String.valueOf(input.getKey()));
+		} else {
+			return String.valueOf(input.getKey());
+		}
+
+	}
+
+	@Override
+	public boolean execute(Workflow workflow, Task task, WorkflowExecutor executor) {
+		return false;
+	}
+
+	@Override
+	public void cancel(Workflow workflow, Task task, WorkflowExecutor executor) {
+		task.setStatus(Task.Status.CANCELED);
+	}
+
+	@Override
+	public boolean isAsync() {
+		return true;
+	}
+
+
+	public static class Input {
+
+		public static final String STRING_SERIALIZER = StringSerializer.class.getCanonicalName();
+		private Map<String, Object> headers = new HashMap<>();
+
+		private String bootStrapServers;
+
+		private Object key;
+
+		private Object value;
+
+		private Integer requestTimeoutMs;
+
+		private String topic;
+
+		private String keySerializer = STRING_SERIALIZER;
+
+		public Map<String, Object> getHeaders() {
+			return headers;
+		}
+
+		public void setHeaders(Map<String, Object> headers) {
+			this.headers = headers;
+		}
+
+		public String getBootStrapServers() {
+			return bootStrapServers;
+		}
+
+		public void setBootStrapServers(String bootStrapServers) {
+			this.bootStrapServers = bootStrapServers;
+		}
+
+		public Object getKey() {
+			return key;
+		}
+
+		public void setKey(Object key) {
+			this.key = key;
+		}
+
+		public Object getValue() {
+			return value;
+		}
+
+		public void setValue(Object value) {
+			this.value = value;
+		}
+
+		public Integer getRequestTimeoutMs() {
+			return requestTimeoutMs;
+		}
+
+		public void setRequestTimeoutMs(Integer requestTimeoutMs) {
+			this.requestTimeoutMs = requestTimeoutMs;
+		}
+
+		public String getTopic() {
+			return topic;
+		}
+
+		public void setTopic(String topic) {
+			this.topic = topic;
+		}
+
+		public String getKeySerializer() {
+			return keySerializer;
+		}
+
+		public void setKeySerializer(String keySerializer) {
+			this.keySerializer = keySerializer;
+		}
+
+		@Override
+		public String toString() {
+			return "Input{" +
+					"headers=" + headers +
+					", bootStrapServers='" + bootStrapServers + '\'' +
+					", value=" + value +
+					", requestTimeoutMs=" + requestTimeoutMs +
+					", topic='" + topic + '\'' +
+					", keySerializer='" + keySerializer + '\'' +
+					'}';
+		}
+	}
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
@@ -1,0 +1,27 @@
+package com.netflix.conductor.contribs.kafka;
+
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class TestKafkaProducerManager {
+
+
+	@Test
+	public void testRequestTimeoutSet() {
+
+		KafkaProducerManager manager = new KafkaProducerManager(new SystemPropertiesConfiguration());
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setTopic("testTopic");
+		input.setValue("TestMessage");
+		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		input.setBootStrapServers("servers");
+		Properties props = manager.getProducerProperties(input);
+		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "100");
+
+	}
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
@@ -1,10 +1,12 @@
 package com.netflix.conductor.contribs.kafka;
 
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Properties;
 
@@ -12,7 +14,7 @@ public class TestKafkaProducerManager {
 
 
 	@Test
-	public void testRequestTimeoutSet() {
+	public void testRequestTimeoutSetFromDefault() {
 
 		KafkaProducerManager manager = new KafkaProducerManager(new SystemPropertiesConfiguration());
 		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
@@ -22,6 +24,38 @@ public class TestKafkaProducerManager {
 		input.setBootStrapServers("servers");
 		Properties props = manager.getProducerProperties(input);
 		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "100");
+
+	}
+
+	@Test
+	public void testRequestTimeoutSetFromInput() {
+
+		KafkaProducerManager manager = new KafkaProducerManager(new SystemPropertiesConfiguration());
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setTopic("testTopic");
+		input.setValue("TestMessage");
+		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		input.setBootStrapServers("servers");
+		input.setRequestTimeoutMs(200);
+		Properties props = manager.getProducerProperties(input);
+		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "200");
+
+	}
+
+	@Test
+	public void testRequestTimeoutSetFromConfig() {
+
+
+		Configuration configuration =  Mockito.mock(Configuration.class);
+		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.request.timeout.ms"),Mockito.eq("100"))).thenReturn("150");
+		KafkaProducerManager manager = new KafkaProducerManager(configuration);
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setTopic("testTopic");
+		input.setValue("TestMessage");
+		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		input.setBootStrapServers("servers");
+		Properties props = manager.getProducerProperties(input);
+		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "150");
 
 	}
 }

--- a/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaPublishTask.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaPublishTask.java
@@ -1,0 +1,169 @@
+package com.netflix.conductor.contribs.kafka;
+
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class TestKafkaPublishTask {
+
+	@Test
+	public void missingRequest_Fail() {
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		Task task = new Task();
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.FAILED, task.getStatus());
+	}
+
+	@Test
+	public void missingValue_Fail() {
+
+		Task task = new Task();
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setBootStrapServers("localhost:9092");
+		input.setTopic("testTopic");
+
+		task.getInputData().put(KafkaPublishTask.REQUEST_PARAMETER_NAME, input);
+
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.FAILED, task.getStatus());
+	}
+
+	@Test
+	public void missingBootStrapServers_Fail() {
+
+		Task task = new Task();
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+
+
+		Map<String, Object> value = new HashMap<>();
+		input.setValue(value);
+		input.setTopic("testTopic");
+
+		task.getInputData().put(KafkaPublishTask.REQUEST_PARAMETER_NAME, input);
+
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.FAILED, task.getStatus());
+	}
+
+
+	@Test
+	public void kafkaPublishExecutionException_Fail() throws ExecutionException, InterruptedException {
+
+		Task task = getTask();
+
+		KafkaProducerManager producerManager = Mockito.mock(KafkaProducerManager.class);
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), producerManager);
+
+		Producer producer = Mockito.mock(Producer.class);
+
+		Mockito.when(producerManager.getProducer(Mockito.any())).thenReturn(producer);
+		Future publishingFuture = Mockito.mock(Future.class);
+		Mockito.when(producer.send(Mockito.any())).thenReturn(publishingFuture);
+
+		ExecutionException executionException = Mockito.mock(ExecutionException.class);
+
+
+		Mockito.when(executionException.getMessage()).thenReturn("Execution exception");
+		Mockito.when(publishingFuture.get()).thenThrow(executionException);
+
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.FAILED, task.getStatus());
+		Assert.assertEquals("Failed to invoke kafka task due to: Execution exception", task.getReasonForIncompletion());
+	}
+
+
+	@Test
+	public void kafkaPublishUnknownException_Fail() throws ExecutionException, InterruptedException {
+
+		Task task = getTask();
+
+		KafkaProducerManager producerManager = Mockito.mock(KafkaProducerManager.class);
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), producerManager);
+
+		Producer producer = Mockito.mock(Producer.class);
+
+		Mockito.when(producerManager.getProducer(Mockito.any())).thenReturn(producer);
+		Mockito.when(producer.send(Mockito.any())).thenThrow(new RuntimeException("Unknown exception"));
+
+
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.FAILED, task.getStatus());
+		Assert.assertEquals("Failed to invoke kafka task due to: Unknown exception", task.getReasonForIncompletion());
+	}
+
+	@Test
+	public void kafkaPublishSuccess_Completed() throws ExecutionException, InterruptedException {
+
+		Task task = getTask();
+
+		KafkaProducerManager producerManager = Mockito.mock(KafkaProducerManager.class);
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), producerManager);
+
+		Producer producer = Mockito.mock(Producer.class);
+
+		Mockito.when(producerManager.getProducer(Mockito.any())).thenReturn(producer);
+		Mockito.when(producer.send(Mockito.any())).thenReturn(Mockito.mock(Future.class));
+
+
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.COMPLETED, task.getStatus());
+	}
+
+	private Task getTask() {
+		Task task = new Task();
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setBootStrapServers("localhost:9092");
+
+		Map<String, Object> value = new HashMap<>();
+
+		value.put("input_key1", "value1");
+		value.put("input_key2", 45.3d);
+
+		input.setValue(value);
+		input.setTopic("testTopic");
+		task.getInputData().put(KafkaPublishTask.REQUEST_PARAMETER_NAME, input);
+		return task;
+	}
+
+	@Test
+	public void integerSerializer_integerObject() {
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setKeySerializer(IntegerSerializer.class.getCanonicalName());
+		input.setKey(String.valueOf(Integer.MAX_VALUE));
+		Assert.assertEquals(kPublishTask.getKey(input), new Integer(Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void longSerializer_longObject() {
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		input.setKey(String.valueOf(Long.MAX_VALUE));
+		Assert.assertEquals(kPublishTask.getKey(input), new Long(Long.MAX_VALUE));
+	}
+
+	@Test
+	public void noSerializer_StringObject() {
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), new KafkaProducerManager(new SystemPropertiesConfiguration()));
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setKey("testStringKey");
+		Assert.assertEquals(kPublishTask.getKey(input), "testStringKey");
+	}
+
+}

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -208,4 +208,12 @@ public class CoreModule extends AbstractModule {
         return new TerminateTaskMapper(parametersUtils);
     }
 
+    @ProvidesIntoMap
+    @StringMapKey(TASK_TYPE_KAFKA_PUBLISH)
+    @Singleton
+    @Named(TASK_MAPPERS_QUALIFIER)
+    public TaskMapper getKafkaPublishTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+        return new KafkaPublishTaskMapper(parametersUtils, metadataDAO);
+    }
+
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
@@ -1,0 +1,76 @@
+package com.netflix.conductor.core.execution.mapper;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ParametersUtils;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import com.netflix.conductor.dao.MetadataDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class KafkaPublishTaskMapper implements TaskMapper  {
+	public static final Logger logger = LoggerFactory.getLogger(KafkaPublishTaskMapper.class);
+
+	private final ParametersUtils parametersUtils;
+	private final MetadataDAO metadataDAO;
+
+	public KafkaPublishTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+		this.parametersUtils = parametersUtils;
+		this.metadataDAO = metadataDAO;
+	}
+
+	/**
+	 * This method maps a {@link WorkflowTask} of type {@link TaskType#KAFKA_PUBLISH}
+	 * to a {@link Task} in a {@link Task.Status#SCHEDULED} state
+	 *
+	 * @param taskMapperContext: A wrapper class containing the {@link WorkflowTask}, {@link WorkflowDef}, {@link Workflow} and a string representation of the TaskId
+	 * @return a List with just one Kafka task
+	 * @throws TerminateWorkflowException In case if the task definition does not exist
+	 */
+	@Override
+	public List<Task> getMappedTasks(TaskMapperContext taskMapperContext) throws TerminateWorkflowException {
+
+		logger.debug("TaskMapperContext {} in KafkaPublishTaskMapper", taskMapperContext);
+
+		WorkflowTask taskToSchedule = taskMapperContext.getTaskToSchedule();
+		Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
+		String taskId = taskMapperContext.getTaskId();
+		int retryCount = taskMapperContext.getRetryCount();
+
+		TaskDef taskDefinition = Optional.ofNullable(taskMapperContext.getTaskDefinition())
+				.orElseGet(() -> Optional.ofNullable(metadataDAO.getTaskDef(taskToSchedule.getName()))
+						.orElseThrow(() -> {
+							String reason = String.format("Invalid task specified. Cannot find task by name %s in the task definitions", taskToSchedule.getName());
+							return new TerminateWorkflowException(reason);
+						}));
+
+		Map<String, Object> input = parametersUtils.getTaskInputV2(taskToSchedule.getInputParameters(), workflowInstance, taskId, taskDefinition);
+
+		Task kafkaPublishTask = new Task();
+		kafkaPublishTask.setTaskType(taskToSchedule.getType());
+		kafkaPublishTask.setTaskDefName(taskToSchedule.getName());
+		kafkaPublishTask.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
+		kafkaPublishTask.setWorkflowInstanceId(workflowInstance.getWorkflowId());
+		kafkaPublishTask.setWorkflowType(workflowInstance.getWorkflowName());
+		kafkaPublishTask.setCorrelationId(workflowInstance.getCorrelationId());
+		kafkaPublishTask.setScheduledTime(System.currentTimeMillis());
+		kafkaPublishTask.setTaskId(taskId);
+		kafkaPublishTask.setInputData(input);
+		kafkaPublishTask.setStatus(Task.Status.SCHEDULED);
+		kafkaPublishTask.setRetryCount(retryCount);
+		kafkaPublishTask.setCallbackAfterSeconds(taskToSchedule.getStartDelay());
+		kafkaPublishTask.setWorkflowTask(taskToSchedule);
+		kafkaPublishTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
+		kafkaPublishTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
+		return Collections.singletonList(kafkaPublishTask);
+	}
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapperTest.java
@@ -1,0 +1,103 @@
+package com.netflix.conductor.core.execution.mapper;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ParametersUtils;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.dao.MetadataDAO;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class KafkaPublishTaskMapperTest {
+
+	private ParametersUtils parametersUtils;
+	private MetadataDAO metadataDAO;
+
+	private KafkaPublishTaskMapper kafkaTaskMapper;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Before
+	public void setUp() {
+		parametersUtils = mock(ParametersUtils.class);
+		metadataDAO = mock(MetadataDAO.class);
+		kafkaTaskMapper = new KafkaPublishTaskMapper(parametersUtils, metadataDAO);
+	}
+
+	@Test
+	public void getMappedTasks() {
+		//Given
+		WorkflowTask taskToSchedule = new WorkflowTask();
+		taskToSchedule.setName("kafka_task");
+		taskToSchedule.setType(TaskType.KAFKA_PUBLISH.name());
+		taskToSchedule.setTaskDefinition(new TaskDef("kafka_task"));
+		String taskId = IDGenerator.generate();
+		String retriedTaskId = IDGenerator.generate();
+
+		Workflow workflow = new Workflow();
+		WorkflowDef workflowDef = new WorkflowDef();
+		workflow.setWorkflowDefinition(workflowDef);
+
+		TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+				.withWorkflowDefinition(workflowDef)
+				.withWorkflowInstance(workflow)
+				.withTaskDefinition(new TaskDef())
+				.withTaskToSchedule(taskToSchedule)
+				.withTaskInput(new HashMap<>())
+				.withRetryCount(0)
+				.withRetryTaskId(retriedTaskId)
+				.withTaskId(taskId)
+				.build();
+
+		//when
+		List<Task> mappedTasks = kafkaTaskMapper.getMappedTasks(taskMapperContext);
+
+		//Then
+		assertEquals(1, mappedTasks.size());
+		assertEquals(TaskType.KAFKA_PUBLISH.name(), mappedTasks.get(0).getTaskType());
+	}
+
+	@Test
+	public void taskDefNotGiven_ExceptionExpected() {
+		//Given
+		WorkflowTask taskToSchedule = new WorkflowTask();
+		taskToSchedule.setName("kafka_task");
+		taskToSchedule.setType(TaskType.KAFKA_PUBLISH.name());
+		String taskId = IDGenerator.generate();
+		String retriedTaskId = IDGenerator.generate();
+
+		Workflow workflow = new Workflow();
+		WorkflowDef workflowDef = new WorkflowDef();
+		workflow.setWorkflowDefinition(workflowDef);
+
+		TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+				.withWorkflowDefinition(workflowDef)
+				.withWorkflowInstance(workflow)
+				.withTaskToSchedule(taskToSchedule)
+				.withTaskInput(new HashMap<>())
+				.withRetryCount(0)
+				.withRetryTaskId(retriedTaskId)
+				.withTaskId(taskId)
+				.build();
+
+		//then
+		expectedException.expect(TerminateWorkflowException.class);
+		expectedException.expectMessage(String.format("Invalid task specified. Cannot find task by name %s in the task definitions", taskToSchedule.getName()));
+		//when
+		kafkaTaskMapper.getMappedTasks(taskMapperContext);
+	}
+}

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -491,7 +491,8 @@ The task expects an input parameter named ```kafka_request``` as part of the tas
 |name|description|
 |---|---|
 | bootStrapServers |bootStrapServers for connecting to given kafka.|
-|key| Serializer used for serializing the key published to kafka.  One of the following can be set : <br/> 1. org.apache.kafka.common.serialization.IntegerSerializer<br/>2. org.apache.kafka.common.serialization.LongSerializer<br/>3. org.apache.kafka.common.serialization.StringSerializer. <br/>Default is String serializer  |
+|key|Key to be published|
+|keySerializer | Serializer used for serializing the key published to kafka.  One of the following can be set : <br/> 1. org.apache.kafka.common.serialization.IntegerSerializer<br/>2. org.apache.kafka.common.serialization.LongSerializer<br/>3. org.apache.kafka.common.serialization.StringSerializer. <br/>Default is String serializer  |
 |value| Value published to kafka|
 |requestTimeoutMs| Request timeout while publishing to kafka. If this value is not given the value is read from the property `kafka.publish.request.timeout.ms`. If the property is not set the value defaults to 100 |
 |headers|A map of additional kafka headers to be sent along with the request.|

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -100,7 +100,6 @@ For SQS, use the **name** of the queue and NOT the URI.  Conductor looks up the 
 **Event Task Input**
 The input given to the event task is made available to the published message as payload.  e.g. if a message is put into SQS queue (sink is sqs) then the message payload will be the input to the task.
 
-**Example**
 **Event Task Output**
 
 `event_produced` Name of the event produced.

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -100,7 +100,7 @@ For SQS, use the **name** of the queue and NOT the URI.  Conductor looks up the 
 **Event Task Input**
 The input given to the event task is made available to the published message as payload.  e.g. if a message is put into SQS queue (sink is sqs) then the message payload will be the input to the task.
 
-
+**Example**
 **Event Task Output**
 
 `event_produced` Name of the event produced.
@@ -481,3 +481,44 @@ For example, if you have a decision where the first condition is met, you want t
   "optional": false
 }
 ```
+## Kafka Publish Task
+
+A kafka Publish task is used to push messages to another microservice via kafka
+
+**Parameters:**
+
+The task expects an input parameter named ```kafka_request``` as part of the task's input with the following details:
+
+|name|description|
+|---|---|
+| bootStrapServers |bootStrapServers for connecting to given kafka.|
+|key| Serializer used for serializing the key published to kafka.  One of the following can be set : <br/> 1. org.apache.kafka.common.serialization.IntegerSerializer<br/>2. org.apache.kafka.common.serialization.LongSerializer<br/>3. org.apache.kafka.common.serialization.StringSerializer. <br/>Default is String serializer  |
+|value| Value published to kafka|
+|requestTimeoutMs| Request timeout while publishing to kafka. If this value is not given the value is read from the property `kafka.publish.request.timeout.ms`. If the property is not set the value defaults to 100 |
+|headers|A map of additional kafka headers to be sent along with the request.|
+|topic|Topic to publish|
+
+
+**Kafka Task Output**
+
+Task status transitions to COMPLETED
+
+**Example**
+
+Task Input payload sample
+
+```json
+"kafka_request": {
+            "topic": "userTopic",
+            "value": "Message to publish",
+            "bootStrapServers":"localhost:9092",
+             "headers" :{
+              "x-Auth":"Auth-key"
+             },
+             "key":"123",
+             "keySerializer":"org.apache.kafka.common.serialization.IntegerSerializer"
+          }
+}
+```
+
+The task is marked as ```FAILED``` if the message could not be published to the Kafka queue. 

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -8,6 +8,8 @@ import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.contribs.http.HttpTask;
 import com.netflix.conductor.contribs.http.RestClientManager;
 import com.netflix.conductor.contribs.json.JsonJqTransform;
+import com.netflix.conductor.contribs.kafka.KafkaProducerManager;
+import com.netflix.conductor.contribs.kafka.KafkaPublishTask;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.WorkflowExecutorModule;
 import com.netflix.conductor.core.utils.DummyPayloadStorage;
@@ -127,6 +129,7 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         }
 
         new HttpTask(new RestClientManager(configuration), configuration);
+        new KafkaPublishTask(configuration, new KafkaProducerManager(configuration));
         new JsonJqTransform();
         modules.add(new ServerModule());
 

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -349,6 +349,64 @@ public abstract class AbstractWorkflowServiceTest {
     }
 
     @Test
+    public void testKafkaTaskDefTemplate() throws Exception {
+        System.setProperty("STACK_KAFKA", "test_kafka_topic");
+        TaskDef templatedTask = new TaskDef();
+        templatedTask.setName("templated_kafka_task");
+
+        Map<String, Object> kafkaRequest = new HashMap<>();
+        kafkaRequest.put("topic", "${STACK_KAFKA}");
+        kafkaRequest.put("bootStrapServers", "localhost:9092");
+
+        Map<String, Object> value = new HashMap<>();
+        value.put("inputPaths", Arrays.asList("${workflow.input.path1}", "${workflow.input.path2}"));
+        value.put("requestDetails", "${workflow.input.requestDetails}");
+        value.put("outputPath", "${workflow.input.outputPath}");
+        kafkaRequest.put("value", value);
+        templatedTask.getInputTemplate().put("kafka_request", kafkaRequest);
+        metadataService.registerTaskDef(Arrays.asList(templatedTask));
+
+        WorkflowDef templateWf = new WorkflowDef();
+        templateWf.setName("template_workflow_kafka");
+        WorkflowTask wft = new WorkflowTask();
+        wft.setName(templatedTask.getName());
+        wft.setWorkflowTaskType(TaskType.SIMPLE);
+        wft.setTaskReferenceName("t0");
+        templateWf.getTasks().add(wft);
+        templateWf.setSchemaVersion(2);
+        metadataService.registerWorkflowDef(templateWf);
+
+        Map<String, Object> requestDetails = new HashMap<>();
+        requestDetails.put("key1", "value1");
+        requestDetails.put("key2", 42);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("path1", "file://path1");
+        input.put("path2", "file://path2");
+        input.put("outputPath", "s3://bucket/outputPath");
+        input.put("requestDetails", requestDetails);
+
+        String id = startOrLoadWorkflowExecution(templateWf.getName(), 1, "testTaskDefTemplate", input, null, null);
+        assertNotNull(id);
+        Workflow workflow = workflowExecutionService.getExecutionStatus(id, true);
+        assertNotNull(workflow);
+        assertTrue(workflow.getReasonForIncompletion(), !workflow.getStatus().isTerminal());
+        assertEquals(1, workflow.getTasks().size());
+        Task task = workflow.getTasks().get(0);
+        Map<String, Object> taskInput = task.getInputData();
+        assertNotNull(taskInput);
+        assertTrue(taskInput.containsKey("kafka_request"));
+        assertTrue(taskInput.get("kafka_request") instanceof Map);
+
+        ObjectMapper om = new ObjectMapper();
+
+        //Use the commented sysout to get the string value
+        //System.out.println(om.writeValueAsString(om.writeValueAsString(taskInput)));
+        String expected = "{\"kafka_request\":{\"topic\":\"test_kafka_topic\",\"bootStrapServers\":\"localhost:9092\",\"value\":{\"requestDetails\":{\"key1\":\"value1\",\"key2\":42},\"outputPath\":\"s3://bucket/outputPath\",\"inputPaths\":[\"file://path1\",\"file://path2\"]}}}";
+        assertEquals(expected, om.writeValueAsString(taskInput));
+    }
+
+    @Test
     public void testWorkflowSchemaVersion() {
         WorkflowDef ver2 = new WorkflowDef();
         ver2.setSchemaVersion(2);

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -259,7 +259,6 @@ public abstract class AbstractWorkflowServiceTest {
         }
 
         taskDefs = metadataService.getTaskDefs();
-
         registered = true;
     }
 
@@ -349,11 +348,131 @@ public abstract class AbstractWorkflowServiceTest {
     }
 
     @Test
-    public void testKafkaTaskDefTemplate() throws Exception {
+    public void testKafkaTaskDefTemplateSuccess() throws Exception {
+
+        try {
+            registerKafkaWorkflow();
+        } catch (ApplicationException e) {
+
+        }
+
+        Map<String, Object> input = getKafkaInput();
+        String workflowInstanceId = startOrLoadWorkflowExecution("template_kafka_workflow", 1, "testTaskDefTemplate", input, null, null);
+
+        assertNotNull(workflowInstanceId);
+
+        Workflow workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true);
+
+        assertNotNull(workflow);
+        assertTrue(workflow.getReasonForIncompletion(), !workflow.getStatus().isTerminal());
+        assertEquals(1, workflow.getTasks().size());
+
+        Task task = workflow.getTasks().get(0);
+        Map<String, Object> taskInput = task.getInputData();
+
+        assertNotNull(taskInput);
+        assertTrue(taskInput.containsKey("kafka_request"));
+        assertTrue(taskInput.get("kafka_request") instanceof Map);
+
+        ObjectMapper om = new ObjectMapper();
+        String expected = "{\"kafka_request\":{\"topic\":\"test_kafka_topic\",\"bootStrapServers\":\"localhost:9092\",\"value\":{\"requestDetails\":{\"key1\":\"value1\",\"key2\":42},\"outputPath\":\"s3://bucket/outputPath\",\"inputPaths\":[\"file://path1\",\"file://path2\"]}}}";
+
+        assertEquals(expected, om.writeValueAsString(taskInput));
+
+        TaskResult taskResult = new TaskResult(task);
+
+        taskResult.setStatus(TaskResult.Status.COMPLETED);
+
+
+
+        // Polling for the first task
+        Task task1 = workflowExecutionService.poll("KAFKA_PUBLISH", "test");
+        assertNotNull(task1);
+
+        assertTrue(workflowExecutionService.ackTaskReceived(task1.getTaskId()));
+        assertEquals(workflowInstanceId, task1.getWorkflowInstanceId());
+
+        workflowExecutionService.updateTask(taskResult);
+
+        workflowExecutor.decide(workflowInstanceId);
+
+        workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true);
+        assertNotNull(workflow);
+        assertEquals(WorkflowStatus.COMPLETED, workflow.getStatus());
+    }
+
+    @Test
+    public void testKafkaTaskDefTemplateFailure() throws Exception {
+
+        try {
+            registerKafkaWorkflow();
+        } catch (ApplicationException e) {
+
+        }
+        Map<String, Object> input = getKafkaInput();
+        String workflowInstanceId = startOrLoadWorkflowExecution("template_kafka_workflow", 1, "testTaskDefTemplate", input, null, null);
+
+        assertNotNull(workflowInstanceId);
+
+        Workflow workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true);
+
+        assertNotNull(workflow);
+        assertTrue(workflow.getReasonForIncompletion(), !workflow.getStatus().isTerminal());
+        assertEquals(1, workflow.getTasks().size());
+
+        Task task = workflow.getTasks().get(0);
+        Map<String, Object> taskInput = task.getInputData();
+
+        assertNotNull(taskInput);
+        assertTrue(taskInput.containsKey("kafka_request"));
+        assertTrue(taskInput.get("kafka_request") instanceof Map);
+
+        ObjectMapper om = new ObjectMapper();
+        String expected = "{\"kafka_request\":{\"topic\":\"test_kafka_topic\",\"bootStrapServers\":\"localhost:9092\",\"value\":{\"requestDetails\":{\"key1\":\"value1\",\"key2\":42},\"outputPath\":\"s3://bucket/outputPath\",\"inputPaths\":[\"file://path1\",\"file://path2\"]}}}";
+
+        assertEquals(expected, om.writeValueAsString(taskInput));
+
+        TaskResult taskResult = new TaskResult(task);
+        taskResult.setReasonForIncompletion("NON TRANSIENT ERROR OCCURRED: An integration point required to complete the task is down");
+        taskResult.setStatus(TaskResult.Status.FAILED);
+        taskResult.addOutputData("TERMINAL_ERROR", "Integration endpoint down: FOOBAR");
+        taskResult.addOutputData("ErrorMessage", "There was a terminal error");
+
+
+        // Polling for the first task
+        Task task1 = workflowExecutionService.poll("KAFKA_PUBLISH", "test");
+        assertNotNull(task1);
+
+        assertTrue(workflowExecutionService.ackTaskReceived(task1.getTaskId()));
+        assertEquals(workflowInstanceId, task1.getWorkflowInstanceId());
+
+        workflowExecutionService.updateTask(taskResult);
+
+        workflowExecutor.decide(workflowInstanceId);
+
+        workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true);
+        assertNotNull(workflow);
+        assertEquals(WorkflowStatus.FAILED, workflow.getStatus());
+    }
+
+    private Map<String, Object> getKafkaInput() {
+        Map<String, Object> requestDetails = new HashMap<>();
+        requestDetails.put("key1", "value1");
+        requestDetails.put("key2", 42);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("path1", "file://path1");
+        input.put("path2", "file://path2");
+        input.put("outputPath", "s3://bucket/outputPath");
+        input.put("requestDetails", requestDetails);
+        return input;
+    }
+
+    private void registerKafkaWorkflow() {
         System.setProperty("STACK_KAFKA", "test_kafka_topic");
         TaskDef templatedTask = new TaskDef();
         templatedTask.setName("templated_kafka_task");
-
+        templatedTask.setRetryCount(0);
         Map<String, Object> kafkaRequest = new HashMap<>();
         kafkaRequest.put("topic", "${STACK_KAFKA}");
         kafkaRequest.put("bootStrapServers", "localhost:9092");
@@ -367,43 +486,15 @@ public abstract class AbstractWorkflowServiceTest {
         metadataService.registerTaskDef(Arrays.asList(templatedTask));
 
         WorkflowDef templateWf = new WorkflowDef();
-        templateWf.setName("template_workflow_kafka");
+
+        templateWf.setName("template_kafka_workflow");
         WorkflowTask wft = new WorkflowTask();
         wft.setName(templatedTask.getName());
-        wft.setWorkflowTaskType(TaskType.SIMPLE);
+        wft.setWorkflowTaskType(TaskType.KAFKA_PUBLISH);
         wft.setTaskReferenceName("t0");
         templateWf.getTasks().add(wft);
         templateWf.setSchemaVersion(2);
         metadataService.registerWorkflowDef(templateWf);
-
-        Map<String, Object> requestDetails = new HashMap<>();
-        requestDetails.put("key1", "value1");
-        requestDetails.put("key2", 42);
-
-        Map<String, Object> input = new HashMap<>();
-        input.put("path1", "file://path1");
-        input.put("path2", "file://path2");
-        input.put("outputPath", "s3://bucket/outputPath");
-        input.put("requestDetails", requestDetails);
-
-        String id = startOrLoadWorkflowExecution(templateWf.getName(), 1, "testTaskDefTemplate", input, null, null);
-        assertNotNull(id);
-        Workflow workflow = workflowExecutionService.getExecutionStatus(id, true);
-        assertNotNull(workflow);
-        assertTrue(workflow.getReasonForIncompletion(), !workflow.getStatus().isTerminal());
-        assertEquals(1, workflow.getTasks().size());
-        Task task = workflow.getTasks().get(0);
-        Map<String, Object> taskInput = task.getInputData();
-        assertNotNull(taskInput);
-        assertTrue(taskInput.containsKey("kafka_request"));
-        assertTrue(taskInput.get("kafka_request") instanceof Map);
-
-        ObjectMapper om = new ObjectMapper();
-
-        //Use the commented sysout to get the string value
-        //System.out.println(om.writeValueAsString(om.writeValueAsString(taskInput)));
-        String expected = "{\"kafka_request\":{\"topic\":\"test_kafka_topic\",\"bootStrapServers\":\"localhost:9092\",\"value\":{\"requestDetails\":{\"key1\":\"value1\",\"key2\":42},\"outputPath\":\"s3://bucket/outputPath\",\"inputPaths\":[\"file://path1\",\"file://path2\"]}}}";
-        assertEquals(expected, om.writeValueAsString(taskInput));
     }
 
     @Test

--- a/test-harness/src/test/resources/integration/scenarios/legacy/template_kafka_workflow.json
+++ b/test-harness/src/test/resources/integration/scenarios/legacy/template_kafka_workflow.json
@@ -7,7 +7,7 @@
   "workflowId": "WORKFLOW_INSTANCE_ID",
   "tasks": [
     {
-      "taskType": "templated_kafka_task",
+      "taskType": "KAFKA_PUBLISH",
       "status": "SCHEDULED",
       "inputData": {
         "kafka_request": {
@@ -42,13 +42,13 @@
       "callbackFromWorker": true,
       "responseTimeoutSeconds": 3600,
       "workflowInstanceId": "WORKFLOW_INSTANCE_ID",
-      "workflowType": "template_workflow",
+      "workflowType": "template_kafka_workflow",
       "taskId": "9dea4567-0240-4eab-bde8-99f4535ea3fd",
       "callbackAfterSeconds": 0,
       "workflowTask": {
         "name": "templated_kafka_task",
         "taskReferenceName": "t0",
-        "type": "SIMPLE",
+        "type": "KAFKA_PUBLISH",
         "startDelay": 0,
         "optional": false
       },
@@ -66,7 +66,7 @@
     },
     "outputPath": "s3://bucket/outputPath"
   },
-  "workflowType": "template_workflow",
+  "workflowType": "template_kafka_workflow",
   "version": 1,
   "correlationId": "testTaskDefTemplate",
   "schemaVersion": 2,

--- a/test-harness/src/test/resources/integration/scenarios/legacy/template_workflow_kafka.json
+++ b/test-harness/src/test/resources/integration/scenarios/legacy/template_workflow_kafka.json
@@ -1,0 +1,74 @@
+{
+  "ownerApp": "junit_app",
+  "createTime": 1534983505050,
+  "updateTime": 1534983505131,
+  "status": "RUNNING",
+  "endTime": 0,
+  "workflowId": "WORKFLOW_INSTANCE_ID",
+  "tasks": [
+    {
+      "taskType": "templated_kafka_task",
+      "status": "SCHEDULED",
+      "inputData": {
+        "kafka_request": {
+          "topic": "test_kafka_topic",
+          "bootStrapServers": "localhost:9092",
+          "value": {
+            "requestDetails": {
+              "key1": "value1",
+              "key2": 42
+            },
+            "outputPath": "s3://bucket/outputPath",
+            "inputPaths": [
+              "file://path1",
+              "file://path2"
+            ]
+          }
+        }
+      },
+      "referenceTaskName": "t0",
+      "retryCount": 0,
+      "seq": 1,
+      "correlationId": "testTaskDefTemplate",
+      "pollCount": 0,
+      "taskDefName": "templated_kafka_task",
+      "scheduledTime": 1534983505121,
+      "startTime": 0,
+      "endTime": 0,
+      "updateTime": 1534983505121,
+      "startDelayInSeconds": 0,
+      "retried": false,
+      "executed": false,
+      "callbackFromWorker": true,
+      "responseTimeoutSeconds": 3600,
+      "workflowInstanceId": "WORKFLOW_INSTANCE_ID",
+      "workflowType": "template_workflow",
+      "taskId": "9dea4567-0240-4eab-bde8-99f4535ea3fd",
+      "callbackAfterSeconds": 0,
+      "workflowTask": {
+        "name": "templated_kafka_task",
+        "taskReferenceName": "t0",
+        "type": "SIMPLE",
+        "startDelay": 0,
+        "optional": false
+      },
+      "rateLimitPerSecond": 0,
+      "taskStatus": "SCHEDULED",
+      "queueWaitTime": 0
+    }
+  ],
+  "input": {
+    "path1": "file://path1",
+    "path2": "file://path2",
+    "requestDetails": {
+      "key1": "value1",
+      "key2": 42
+    },
+    "outputPath": "s3://bucket/outputPath"
+  },
+  "workflowType": "template_workflow",
+  "version": 1,
+  "correlationId": "testTaskDefTemplate",
+  "schemaVersion": 2,
+  "startTime": 1534983505050
+}


### PR DESCRIPTION
This PR adds a templatized Kafka task to the conductor. User can specify a Kafka template to publish as follows. 

`"kafka_request": {
            "topic": "test",
             "value": "${workflow.input.value}",
            "bootStrapServers":"localhost:9092",
             "headers" :{
              "Content":"${workflow.input.header}"
             },
             "key":"123",
             "keySerializer":"org.apache.kafka.common.serialization.IntegerSerializer"
          }
`

With this, the conductor can work with microservices listening to Kafka queues. 


@cyzhao @kishorebanala  @apanicker-nflx Please take a look if you think this can be a useful addition to the conductor. 