### PR TITLE
Use protected scope instead of the default scope

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
@@ -161,11 +161,11 @@ public abstract class ClientBase {
         return null;
     }
 
-    <T> T getForEntity(String url, Object[] queryParams, Class<T> responseType, Object... uriVariables) {
+    protected <T> T getForEntity(String url, Object[] queryParams, Class<T> responseType, Object... uriVariables) {
         return getForEntity(url, queryParams, response -> response.getEntity(responseType), uriVariables);
     }
 
-    <T> T getForEntity(String url, Object[] queryParams, GenericType<T> responseType, Object... uriVariables) {
+    protected <T> T getForEntity(String url, Object[] queryParams, GenericType<T> responseType, Object... uriVariables) {
         return getForEntity(url, queryParams, response -> response.getEntity(responseType), uriVariables);
     }
 


### PR DESCRIPTION
We use these APIs within our codebase to get event handler definitions.