### PR TITLE
Support for Basic Authentication and SSL communication (Java cacerts only) for Elasticsearch 6

### DIFF
--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -52,6 +52,21 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_ASYNC_DAO_MAX_POOL_SIZE = "workflow.elasticsearch.async.dao.max.pool.size";
     int DEFAULT_ASYNC_MAX_POOL_SIZE = 12;
 
+    String ELASTIC_SEARCH_SSL_ENABLED = "workflow.elasticsearch.ssl.enabled";
+    boolean DEFAULT_ELASTIC_SEARCH_SSL_ENABLED = false;
+
+    String ELASTIC_SEARCH_BASIC_AUTH_USERNAME = "workflow.elasticsearch.basic.auth.username";
+    String DEFAULT_ELASTIC_SEARCH_BASIC_AUTH_USERNAME = "username";
+
+    String ELASTIC_SEARCH_BASIC_AUTH_PASSWORD = "workflow.elasticsearch.basic.auth.password";
+    String DEFAULT_ELASTIC_SEARCH_BASIC_AUTH_PASSWORD = "password";
+
+    String JAVA_KEYSTORE_PATH = "workflow.java.keystore.path";
+    String DEFAULT_JAVA_KEYSTORE_PATH = "trustStore.jks";
+
+    String JAVA_KEYSTORE_PASSWORD = "workflow.java.keystore.pass";
+    String DEFAULT_JAVA_KEYSTORE_PASSWORD = "changeit";
+
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
     }
@@ -128,5 +143,27 @@ public interface ElasticSearchConfiguration extends Configuration {
 
     default int getAsyncMaxPoolSize() {
         return getIntProperty(ELASTIC_SEARCH_ASYNC_DAO_MAX_POOL_SIZE, DEFAULT_ASYNC_MAX_POOL_SIZE);
+    }
+
+    default boolean getElasticSearchSSLEnabled() {
+        return getBooleanProperty(ELASTIC_SEARCH_SSL_ENABLED, DEFAULT_ELASTIC_SEARCH_SSL_ENABLED);
+    }
+
+    default String getElasticSearchBasicAuthUsername() {
+        return getProperty(ELASTIC_SEARCH_BASIC_AUTH_USERNAME, DEFAULT_ELASTIC_SEARCH_BASIC_AUTH_USERNAME);
+    }
+
+    default String getElasticSearchBasicAuthPassword() {
+        return getProperty(ELASTIC_SEARCH_BASIC_AUTH_PASSWORD, DEFAULT_ELASTIC_SEARCH_BASIC_AUTH_PASSWORD);
+    }
+
+
+    default String getJavaKeystorePath() {
+        return getProperty(JAVA_KEYSTORE_PATH, DEFAULT_JAVA_KEYSTORE_PATH);
+    }
+
+
+    default String getJavaKeystorePassword() {
+        return getProperty(JAVA_KEYSTORE_PASSWORD, DEFAULT_JAVA_KEYSTORE_PASSWORD);
     }
 }

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientBuilderProvider.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientBuilderProvider.java
@@ -1,27 +1,86 @@
 package com.netflix.conductor.elasticsearch;
 
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
+import org.apache.http.client.CredentialsProvider;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.net.ssl.SSLContext;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 
 public class ElasticSearchRestClientBuilderProvider implements Provider<RestClientBuilder> {
     private final ElasticSearchConfiguration configuration;
+
+    private static Logger logger = LoggerFactory.getLogger(ElasticSearchRestClientBuilderProvider.class);
 
     @Inject
     public ElasticSearchRestClientBuilderProvider(ElasticSearchConfiguration configuration) {
         this.configuration = configuration;
     }
 
+    public static String readAsString(String fileName)throws Exception
+    {
+        String data = "";
+        data = new String(Files.readAllBytes(Paths.get(fileName)));
+        return data;
+    }
+
     @Override
     public RestClientBuilder get() {
-        return RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+
+        RestClientBuilder builder = RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+
+        if (configuration.getElasticSearchSSLEnabled()) {
+            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                    new UsernamePasswordCredentials(configuration.getElasticSearchBasicAuthUsername(), configuration.getElasticSearchBasicAuthPassword()));
+
+            String keyStorePass = configuration.getJavaKeystorePassword();
+
+            try {
+                InputStream is = Files.newInputStream(Paths.get(configuration.getJavaKeystorePath()));
+                KeyStore truststore = KeyStore.getInstance("jks");
+                truststore.load(is, keyStorePass.toCharArray());
+                SSLContextBuilder sslBuilder = SSLContexts.custom().loadTrustMaterial(truststore, null);
+
+                SSLContext sslContext = sslBuilder.build();
+
+                return builder.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                                .setSSLContext(sslContext);
+                    }
+                });
+            } catch (Exception e) {
+                logger.error(e.getMessage());
+            }
+        }
+
+        return builder;
     }
+
 
     private HttpHost[] convertToHttpHosts(List<URI> hosts) {
         List<HttpHost> list = hosts.stream()


### PR DESCRIPTION
This PR provides options to have conductor connect to Elasticsearch V6 with basic auth and SSL.
At the moment, it only supports authentication via basic authentication and a Java cacerts keystore file, it can extended to provide mutual TLS as well.

The flags required:

```
workflow.elasticsearch.url=https://<ES-HOSTNAME>:9200
workflow.elasticsearch.ssl.enabled=true

workflow.elasticsearch.basic.auth.username=dummy
workflow.elasticsearch.basic.auth.password=dummy
workflow.java.keystore.path=<path-to-java-cacerts>
workflow.java.keystore.pass=<password-to-access-cacerts>
```

To generate the cacerts file, locate your Elasticsearch's root CA cert and add that to the Java keystore using:

```
$ openssl x509 -outform der -in es-ca.crt -out es-ca.der && /usr/bin/keytool -noprompt -import -alias test -keystore cacerts -file es-ca.der -storepass <password-to-access-cacerts>
```

The path <path-to-java-cacerts> and same password <password-to-access-cacerts> used to access the keystore must be provided in the configuration.