### PR TITLE
Redis cluster ssl

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
@@ -27,9 +27,15 @@ public class RedisClusterJedisProvider implements Provider<JedisCommands> {
     public JedisCommands get() {
         // FIXME This doesn't seem very safe, but is how it was in the code this was moved from.
         Host host = new ArrayList<Host>(hostSupplier.getHosts()).get(0);
+        String password = host.getPassword();
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMinIdle(5);
         poolConfig.setMaxTotal(1000);
-        return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), poolConfig);
+        if (password.length() == 0) {
+            return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), poolConfig);
+        } else {
+            return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), 100000, 100000,
+            3, host.getPassword(), poolConfig);
+        }
     }
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/jedis/RedisClusterJedisProvider.java
@@ -35,7 +35,7 @@ public class RedisClusterJedisProvider implements Provider<JedisCommands> {
             return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), poolConfig);
         } else {
             return new JedisCluster(new HostAndPort(host.getHostName(), host.getPort()), 100000, 100000,
-            3, host.getPassword(), poolConfig);
+            3, password, poolConfig);
         }
     }
 }


### PR DESCRIPTION
Fixes #972 , the password is not propagated to the JedisClusterClient and thus, throws an error stating `NOAUTH` when trying to connect to a Redis instance with Authentication enabled. This PR fixes that. Please review. @kishorebanala @apanicker-nflx , cc: @skyrocknroll