### PR TITLE
Fix tasks removal from elasticsearch

### DIFF
--- a/es6-persistence/src/test/java/com/netflix/conductor/dao/es6/index/TestElasticSearchDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/dao/es6/index/TestElasticSearchDAOV6.java
@@ -195,16 +195,23 @@ public class TestElasticSearchDAOV6 {
     public void shouldRemoveWorkflow() {
         Workflow workflow = TestUtils.loadWorkflowSnapshot("workflow");
         indexDAO.indexWorkflow(workflow);
+        indexDAO.indexTask(workflow.getTasks().get(0));
 
         // wait for workflow to be indexed
         List<String> workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
+
+        List<String> tasks = tryFindResults(() -> searchTasks(workflow), 1);
+        assertEquals(1, tasks.size());
 
         indexDAO.removeWorkflow(workflow.getWorkflowId());
 
         workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 0);
 
         assertTrue("Workflow was not removed.", workflows.isEmpty());
+
+        tasks = tryFindResults(() -> searchTasks(workflow), 0);
+        assertTrue("Task was not removed.", tasks.isEmpty());
     }
 
     @Test

--- a/es6-persistence/src/test/java/com/netflix/conductor/dao/es6/index/TestElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/dao/es6/index/TestElasticSearchRestDAOV6.java
@@ -188,16 +188,23 @@ public class TestElasticSearchRestDAOV6 {
     public void shouldRemoveWorkflow() {
         Workflow workflow = TestUtils.loadWorkflowSnapshot("workflow");
         indexDAO.indexWorkflow(workflow);
+        indexDAO.indexTask(workflow.getTasks().get(0));
 
         // wait for workflow to be indexed
         List<String> workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
+
+        List<String> tasks = tryFindResults(() -> searchTasks(workflow), 1);
+        assertEquals(1, tasks.size());
 
         indexDAO.removeWorkflow(workflow.getWorkflowId());
 
         workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 0);
 
         assertTrue("Workflow was not removed.", workflows.isEmpty());
+
+        tasks = tryFindResults(() -> searchTasks(workflow), 0);
+        assertTrue("Task was not removed.", tasks.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
When deleting workflow via api:
1. DB: entries from `workflows` and `tasks` are deleted.
2. Elasticsearch: only entries from the `workflow` index are deleted, but entries from the `tasks` index remains.