### PR TITLE
Adds max.block.ms config and caching of Kafka producer creation. 

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 	compile "io.swagger:swagger-jaxrs:${revSwagger}"
 
 	compile "org.apache.kafka:kafka-clients:2.2.0"
-	compile "com.google.guava:guava:${revGuava}"
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
 	testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"

--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 	compile "io.swagger:swagger-jaxrs:${revSwagger}"
 
 	compile "org.apache.kafka:kafka-clients:2.2.0"
-
+	compile "com.google.guava:guava:${revGuava}"
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
 	testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
@@ -37,13 +37,17 @@ public class KafkaProducerManager {
 			logger.info("Closed producer for {}",notification.getKey());
 		}
 	};
+	private static final String KAFKA_PUBLISH_MAX_BLOCK_MS = "kafka.publish.max.block.ms";
+	private static final String DEFAULT_MAX_BLOCK_MS = "500";
 
 
 	public final String requestTimeoutConfig;
 	private Cache<Properties, Producer> kafkaProducerCache;
+	private final String maxBlockMsConfig;
 
 	public KafkaProducerManager(Configuration configuration) {
 		this.requestTimeoutConfig = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_TIMEOUT);
+		this.maxBlockMsConfig = configuration.getProperty(KAFKA_PUBLISH_MAX_BLOCK_MS, DEFAULT_MAX_BLOCK_MS);
 		int cacheSize = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_SIZE, DEFAULT_CACHE_SIZE);
 		int cacheTimeInMs = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_TIME_IN_MILLIS, DEFAULT_CACHE_TIME_IN_MILLIS);
 		this.kafkaProducerCache = CacheBuilder.newBuilder().removalListener(LISTENER)
@@ -82,8 +86,15 @@ public class KafkaProducerManager {
 		if (Objects.nonNull(input.getRequestTimeoutMs())) {
 			requestTimeoutMs = String.valueOf(input.getRequestTimeoutMs());
 		}
+		
+		String maxBlockMs = maxBlockMsConfig;
 
+		if (Objects.nonNull(input.getMaxBlockMs())) {
+			maxBlockMs = String.valueOf(input.getMaxBlockMs());
+		}
+		
 		configProperties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+		configProperties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs);
 		configProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, STRING_SERIALIZER);
 		return configProperties;
 	}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
@@ -1,33 +1,72 @@
 package com.netflix.conductor.contribs.kafka;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import com.netflix.conductor.core.config.Configuration;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class KafkaProducerManager {
 
 	public static final String KAFKA_PUBLISH_REQUEST_TIMEOUT_MS = "kafka.publish.request.timeout.ms";
 	public static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
 	public static final String DEFAULT_REQUEST_TIMEOUT = "100";
+	private static final String KAFKA_PRODUCER_CACHE_TIME_IN_MILLIS = "kafka.publish.producer.cache.time.ms" ;
+	private static final int DEFAULT_CACHE_SIZE = 10;
+	private static final String KAFKA_PRODUCER_CACHE_SIZE = "kafka.publish.producer.cache.size";
+	private static final int DEFAULT_CACHE_TIME_IN_MILLIS = 120000;
+
+	private static final Logger logger = LoggerFactory.getLogger(KafkaProducerManager.class);
+
+	public static final RemovalListener<Properties, Producer> LISTENER = new RemovalListener<Properties, Producer>() {
+		@Override
+		public void onRemoval(RemovalNotification<Properties, Producer> notification) {
+			notification.getValue().close();
+			logger.info("Closed producer for {}",notification.getKey());
+		}
+	};
+
 
 	public final String requestTimeoutConfig;
+	private Cache<Properties, Producer> kafkaProducerCache;
 
 	public KafkaProducerManager(Configuration configuration) {
 		this.requestTimeoutConfig = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_TIMEOUT);
+		int cacheSize = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_SIZE, DEFAULT_CACHE_SIZE);
+		int cacheTimeInMs = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_TIME_IN_MILLIS, DEFAULT_CACHE_TIME_IN_MILLIS);
+		this.kafkaProducerCache = CacheBuilder.newBuilder().removalListener(LISTENER)
+				.maximumSize(cacheSize).expireAfterAccess(cacheTimeInMs, TimeUnit.MILLISECONDS)
+				.build();
 	}
 
 
 	public Producer getProducer(KafkaPublishTask.Input input) {
 
 		Properties configProperties = getProducerProperties(input);
-		Producer producer = new KafkaProducer<String, String>(configProperties);
-		return producer;
 
+		return getFromCache(configProperties, () -> new KafkaProducer(configProperties));
+
+	}
+
+	@VisibleForTesting
+	Producer getFromCache(Properties configProperties, Callable<Producer> createProducerCallable) {
+		try {
+			return kafkaProducerCache.get(configProperties, createProducerCallable);
+		} catch (ExecutionException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@VisibleForTesting

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -196,10 +196,12 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 		private Object value;
 
 		private Integer requestTimeoutMs;
+		private Integer maxBlockMs;
 
 		private String topic;
 
 		private String keySerializer = STRING_SERIALIZER;
+
 
 		public Map<String, Object> getHeaders() {
 			return headers;
@@ -257,13 +259,23 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 			this.keySerializer = keySerializer;
 		}
 
+		public Integer getMaxBlockMs() {
+			return maxBlockMs;
+		}
+
+		public void setMaxBlockMs(Integer maxBlockMs) {
+			this.maxBlockMs = maxBlockMs;
+		}
+
 		@Override
 		public String toString() {
 			return "Input{" +
 					"headers=" + headers +
 					", bootStrapServers='" + bootStrapServers + '\'' +
+					", key=" + key +
 					", value=" + value +
 					", requestTimeoutMs=" + requestTimeoutMs +
+					", maxBlockMs=" + maxBlockMs +
 					", topic='" + topic + '\'' +
 					", keySerializer='" + keySerializer + '\'' +
 					'}';

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -145,7 +145,6 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 				null, key, om.writeValueAsString(input.getValue()), headers);
 
 		Future send = producer.send(rec);
-		producer.close();
 
 		long timeTakenToPublish = Instant.now().toEpochMilli() - startPublishingEpochMillis;
 

--- a/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaProducerManager.java
@@ -18,11 +18,7 @@ public class TestKafkaProducerManager {
 	public void testRequestTimeoutSetFromDefault() {
 
 		KafkaProducerManager manager = new KafkaProducerManager(new SystemPropertiesConfiguration());
-		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
-		input.setTopic("testTopic");
-		input.setValue("TestMessage");
-		input.setKeySerializer(LongSerializer.class.getCanonicalName());
-		input.setBootStrapServers("servers");
+		KafkaPublishTask.Input input = getInput();
 		Properties props = manager.getProducerProperties(input);
 		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "100");
 
@@ -32,11 +28,7 @@ public class TestKafkaProducerManager {
 	public void testRequestTimeoutSetFromInput() {
 
 		KafkaProducerManager manager = new KafkaProducerManager(new SystemPropertiesConfiguration());
-		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
-		input.setTopic("testTopic");
-		input.setValue("TestMessage");
-		input.setKeySerializer(LongSerializer.class.getCanonicalName());
-		input.setBootStrapServers("servers");
+		KafkaPublishTask.Input input = getInput();
 		input.setRequestTimeoutMs(200);
 		Properties props = manager.getProducerProperties(input);
 		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "200");
@@ -47,14 +39,9 @@ public class TestKafkaProducerManager {
 	public void testRequestTimeoutSetFromConfig() {
 
 
-		Configuration configuration =  Mockito.mock(Configuration.class);
-		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.request.timeout.ms"),Mockito.eq("100"))).thenReturn("150");
+		Configuration configuration =  getConfiguration();
 		KafkaProducerManager manager = new KafkaProducerManager(configuration);
-		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
-		input.setTopic("testTopic");
-		input.setValue("TestMessage");
-		input.setKeySerializer(LongSerializer.class.getCanonicalName());
-		input.setBootStrapServers("servers");
+		KafkaPublishTask.Input input = getInput();
 		Properties props = manager.getProducerProperties(input);
 		Assert.assertEquals(props.getProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), "150");
 
@@ -63,14 +50,9 @@ public class TestKafkaProducerManager {
 	@Test(expected = RuntimeException.class)
 	public void testExecutionException() {
 
-		Configuration configuration =  Mockito.mock(Configuration.class);
-		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.request.timeout.ms"),Mockito.eq("100"))).thenReturn("150");
+		Configuration configuration =  getConfiguration();
 		KafkaProducerManager manager = new KafkaProducerManager(configuration);
-		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
-		input.setTopic("testTopic");
-		input.setValue("TestMessage");
-		input.setKeySerializer(LongSerializer.class.getCanonicalName());
-		input.setBootStrapServers("servers");
+		KafkaPublishTask.Input input = getInput();
 		Producer producer = manager.getProducer(input);
 		Assert.assertNotNull(producer);
 
@@ -78,19 +60,56 @@ public class TestKafkaProducerManager {
 
 	@Test
 	public void testCacheInvalidation() {
-		Configuration configuration =  Mockito.mock(Configuration.class);
-		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.request.timeout.ms"),Mockito.eq("100"))).thenReturn("150");
+		Configuration configuration =  getConfiguration();
 		KafkaProducerManager manager = new KafkaProducerManager(configuration);
-		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
-		input.setTopic("testTopic");
-		input.setValue("TestMessage");
-		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		KafkaPublishTask.Input input = getInput();
 		input.setBootStrapServers("");
 		Properties props = manager.getProducerProperties(input);
 		Producer producerMock = Mockito.mock(Producer.class);
 		Producer producer = manager.getFromCache(props, () -> producerMock);
 		Assert.assertNotNull(producer);
 		Mockito.verify(producerMock, Mockito.times(1)).close();
+	}
+
+	@Test
+	public void testMaxBlockMsFromConfig() {
+
+		Configuration configuration = getConfiguration();
+		KafkaProducerManager manager = new KafkaProducerManager(configuration);
+		KafkaPublishTask.Input input = getInput();
+		Properties props = manager.getProducerProperties(input);
+		Assert.assertEquals(props.getProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG), "500");
+
+	}
+
+
+
+	@Test
+	public void testMaxBlockMsFromInput() {
+
+		Configuration configuration = getConfiguration();
+		KafkaProducerManager manager = new KafkaProducerManager(configuration);
+		KafkaPublishTask.Input input = getInput();
+		input.setMaxBlockMs(600);
+		Properties props = manager.getProducerProperties(input);
+		Assert.assertEquals(props.getProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG), "600");
+
+	}
+
+	private Configuration getConfiguration() {
+		Configuration configuration = Mockito.mock(Configuration.class);
+		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.request.timeout.ms"), Mockito.eq("100"))).thenReturn("150");
+		Mockito.when(configuration.getProperty(Mockito.eq("kafka.publish.max.block.ms"), Mockito.eq("500"))).thenReturn("500");
+		return configuration;
+	}
+
+	private KafkaPublishTask.Input getInput() {
+		KafkaPublishTask.Input input = new KafkaPublishTask.Input();
+		input.setTopic("testTopic");
+		input.setValue("TestMessage");
+		input.setKeySerializer(LongSerializer.class.getCanonicalName());
+		input.setBootStrapServers("servers");
+		return input;
 	}
 
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
@@ -72,6 +72,8 @@ public class KafkaPublishTaskMapper implements TaskMapper  {
 		kafkaPublishTask.setWorkflowPriority(workflowInstance.getPriority());
 		kafkaPublishTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
 		kafkaPublishTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
+		kafkaPublishTask.setDomain(taskDefinition.getExecutionNameSpace());
+		kafkaPublishTask.setIsolationGroupId(taskDefinition.getIsolationGroupId());
 		return Collections.singletonList(kafkaPublishTask);
 	}
 }

--- a/docs/docs/configuration/isolationgroups.md
+++ b/docs/docs/configuration/isolationgroups.md
@@ -71,7 +71,7 @@ Example Workflow task
 
 The property `workflow.isolated.system.task.worker.thread.count`  sets the thread pool size for isolated tasks; default is `1`.
 
-isolationGroupId is currently supported only in HTTP Task. 
+isolationGroupId is currently supported only in HTTP and kafka Task. 
 
 #### Execution Name Space
 

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -524,10 +524,12 @@ The task expects an input parameter named ```kafka_request``` as part of the tas
 |key|Key to be published|
 |keySerializer | Serializer used for serializing the key published to kafka.  One of the following can be set : <br/> 1. org.apache.kafka.common.serialization.IntegerSerializer<br/>2. org.apache.kafka.common.serialization.LongSerializer<br/>3. org.apache.kafka.common.serialization.StringSerializer. <br/>Default is String serializer  |
 |value| Value published to kafka|
-|requestTimeoutMs| Request timeout while publishing to kafka. If this value is not given the value is read from the property `kafka.publish.request.timeout.ms`. If the property is not set the value defaults to 100 |
+|requestTimeoutMs| Request timeout while publishing to kafka. If this value is not given the value is read from the property `kafka.publish.request.timeout.ms`. If the property is not set the value defaults to 100 ms |
+|maxBlockMs| maxBlockMs while publishing to kafka. If this value is not given the value is read from the property `kafka.publish.max.block.ms`. If the property is not set the value defaults to 500 ms |
 |headers|A map of additional kafka headers to be sent along with the request.|
 |topic|Topic to publish|
 
+The producer created in the kafka task is cached. By default the cache size is 10 and expiry time is 120000 ms. To change the defaults following can be modified kafka.publish.producer.cache.size,kafka.publish.producer.cache.time.ms respectively.  
 
 **Kafka Task Output**
 

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -19,6 +19,7 @@ ext {
     revFlywayCore ='4.0.3'
     revGrpc = '1.14.+'
     revGuavaRetrying = '2.0.0'
+    revGuava = '28.0-jre'
     revGuice = '4.1.0'
     revGuiceMultiBindings = '4.1.0'
     revGuiceServlet = '4.1.0'

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -19,7 +19,6 @@ ext {
     revFlywayCore ='4.0.3'
     revGrpc = '1.14.+'
     revGuavaRetrying = '2.0.0'
-    revGuava = '28.0-jre'
     revGuice = '4.1.0'
     revGuiceMultiBindings = '4.1.0'
     revGuiceServlet = '4.1.0'


### PR DESCRIPTION
max.block.ms  - If the Kafka is not reachable producer blocks for a minute. This is not ideal as it blocks the execution for a long time. I have added the config to enable users to specify the block time, by default the task blocks for 500ms. 

caching of Kafka producer - Bulk of the task execution time is consumed by producer creation and connection establishment. This PR enables users to cache the producer once created and increase the throughput. By default 10 producers are cached. 



@kishorebanala  @apanicker-nflx  Please consider the PR if you think this is a useful addition to the conductor. 