### PR TITLE
Add reasonForIncompletion to ConductorWorker.py

### DIFF
--- a/client/python/conductor/ConductorWorker.py
+++ b/client/python/conductor/ConductorWorker.py
@@ -74,6 +74,8 @@ class ConductorWorker:
             task['status'] = resp['status']
             task['outputData'] = resp['output']
             task['logs'] = resp['logs']
+            if 'reasonForIncompletion' in resp:
+                task['reasonForIncompletion'] = resp['reasonForIncompletion']
             self.taskClient.updateTask(task)
         except Exception as err:
             print('Error executing task: ' + str(err))


### PR DESCRIPTION
Introduces the 'reasonForIncompletion' key into the task result returned by the python client. This key is used to display the failure reason for a task in the conductor UI. It is implemented as an optional key so that successful tasks need not designate a reason, and to maintain backwards compatibility.