### PR TITLE
Fix typo in Cassandra replication factor property name

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/CassandraConfiguration.java
@@ -35,7 +35,7 @@ public interface CassandraConfiguration extends Configuration {
     String CASSANDRA_REPLICATION_FACTOR_KEY_PROPERTY_NAME = "workflow.cassandra.replication.factor.key";
     String CASSANDRA_REPLICATION_FACTOR_KEY_DEFAULT_VALUE = "replication_factor";
 
-    String CASSANDRA_REPLICATION_FACTOR_VALUE_PROPERTY_NAME = "workflow.cassandra.replicaton.factor.value";
+    String CASSANDRA_REPLICATION_FACTOR_VALUE_PROPERTY_NAME = "workflow.cassandra.replication.factor.value";
     int CASSANDRA_REPLICATION_FACTOR_VALUE_DEFAULT_VALUE = 3;
 
     String CASSANDRA_SHARD_SIZE_PROPERTY_KEY = "workflow.cassandra.shard.size";


### PR DESCRIPTION
This PR fixes an apparent typo in one of three property names related to Cassandra replication that could lead to confusion during configuration/implementation.

<pre>
workflow.cassandra.replication.strategy
workflow.cassandra.replication.factor.key
workflow.cassandra.<strong>replicaton</strong>.factor.value
</pre>