### PR TITLE
Fix/update readme: Remove pip install command from python readme

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -6,8 +6,11 @@ Python client for Conductor provides two sets of functions:
 
 ## Install
 
-```shell
-pip install conductor
+```Using virtualenv
+   virtualenv conductorclient
+   source conductorclient/bin/activate
+   cd ../conductor/client/python
+   python setup.py install
 ```
 
 ## Using Workflow Management API


### PR DESCRIPTION
Description:
Remove pip package name python readme as it is not valid.