### PR TITLE
Batch indexing in ES.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -116,7 +116,7 @@ public class Monitors {
 		});
 	}
 
-	public static AtomicLong getGauge(String className, String name, String... additionalTags) {
+	private static AtomicLong getGauge(String className, String name, String... additionalTags) {
 		Map<String, String> tags = toMap(className, additionalTags);
 
 		return gauges.computeIfAbsent(name, s -> new ConcurrentHashMap<>()).computeIfAbsent(tags, t -> {
@@ -270,5 +270,13 @@ public class Monitors {
 
 	public static void recordESIndexTime(String docType, long val) {
 		getTimer(Monitors.classQualifier, docType, docType).record(val, TimeUnit.MILLISECONDS);
+	}
+
+	public static void recordWorkerQueueSize(int val) {
+		getGauge(Monitors.classQualifier, "indexing_worker_queue").set(val);
+	}
+
+	public static void recordDiscardedIndexingCount() {
+		getCounter(Monitors.classQualifier, "discarded_index_count").increment();
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -267,4 +267,8 @@ public class Monitors {
 	public static void recordAckTaskError(String taskType) {
 		counter(classQualifier, "task_ack_error", "taskType", taskType);
 	}
+
+	public static void recordESIndexTime(String docType, long val) {
+		getTimer(Monitors.classQualifier, docType, docType).record(val, TimeUnit.MILLISECONDS);
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -116,7 +116,7 @@ public class Monitors {
 		});
 	}
 
-	private static AtomicLong getGauge(String className, String name, String... additionalTags) {
+	public static AtomicLong getGauge(String className, String name, String... additionalTags) {
 		Map<String, String> tags = toMap(className, additionalTags);
 
 		return gauges.computeIfAbsent(name, s -> new ConcurrentHashMap<>()).computeIfAbsent(tags, t -> {

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -300,9 +300,9 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             req.retryOnConflict(5);
 
             indexObject(req, WORKFLOW_DOC_TYPE);
-
-            logger.debug("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
-            Monitors.recordESIndexTime("index_workflow", Instant.now().toEpochMilli() - startTime);
+            long endTime = Instant.now().toEpochMilli();
+            logger.debug("Time taken {} for  request {}, index {}", endTime - startTime, req, req);
+            Monitors.recordESIndexTime("index_workflow", endTime - startTime);
             Monitors.recordWorkerQueueSize(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             logger.error("Failed to index workflow: {}", workflow.getWorkflowId(), e);
@@ -326,8 +326,9 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             req.doc(doc, XContentType.JSON);
             req.upsert(doc, XContentType.JSON);
             indexObject(req, TASK_DOC_TYPE);
-            logger.debug("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
-            Monitors.recordESIndexTime("index_task", Instant.now().toEpochMilli() - startTime);
+            long endTime = Instant.now().toEpochMilli();
+            logger.debug("Time taken {} for  request {}, index {}", endTime - startTime, req, req);
+            Monitors.recordESIndexTime("index_task", endTime - startTime);
             Monitors.recordWorkerQueueSize(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             logger.error("Failed to index task: {}", task.getTaskId(), e);

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -296,6 +296,8 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             indexObject(req, WORKFLOW_DOC_TYPE);
 
             logger.info("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
+            Monitors.getTimer(Monitors.classQualifier, "index_workflow", "index_time").record(Instant.now().toEpochMilli(), TimeUnit.MILLISECONDS);
+            Monitors.getGauge(Monitors.classQualifier, "worker_queue", "worker_queue").set(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             logger.error("Failed to index workflow: {}", workflow.getWorkflowId(), e);
         }
@@ -319,6 +321,7 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             req.upsert(doc, XContentType.JSON);
             indexObject(req, TASK_DOC_TYPE);
             logger.info("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
+            Monitors.getTimer(Monitors.classQualifier, "index_task", "index_time").record(Instant.now().toEpochMilli(), TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             logger.error("Failed to index task: {}", task.getTaskId(), e);
         }

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -68,7 +68,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -295,7 +294,7 @@ public class ElasticSearchDAOV5 implements IndexDAO {
 
             indexObject(req, WORKFLOW_DOC_TYPE);
 
-            logger.info("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
+            logger.debug("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
             Monitors.recordESIndexTime("index_workflow", Instant.now().toEpochMilli() - startTime);
             Monitors.getGauge(Monitors.classQualifier, "worker_queue", "worker_queue").set(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
@@ -320,7 +319,7 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             req.doc(doc, XContentType.JSON);
             req.upsert(doc, XContentType.JSON);
             indexObject(req, TASK_DOC_TYPE);
-            logger.info("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
+            logger.debug("Time taken {} for  request {}, index {}", Instant.now().toEpochMilli() - startTime, req, req);
             Monitors.recordESIndexTime("index_task", Instant.now().toEpochMilli() - startTime);
             Monitors.getGauge(Monitors.classQualifier, "worker_queue", "worker_queue").set(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -687,6 +687,8 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
             request.clear();
             logger.info("Time taken {} ", Instant.now().toEpochMilli() - startTime);
             logger.info("Current executor state queue {} ,executor {}", ((ThreadPoolExecutor) executorService).getQueue().size(), executorService);
+            Monitors.getTimer(Monitors.classQualifier, "index_time", "index_time").record(Instant.now().toEpochMilli(), TimeUnit.MILLISECONDS);
+            Monitors.getGauge(Monitors.classQualifier, "worker_queue", "worker_queue").set(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             Monitors.error(className, "index");
             logger.error("Failed to index {} for request type: {}", request.toString(), e);

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -660,7 +660,7 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
         }
 
         bulkRequests.get(docType).add(request);
-        if (bulkRequests.get(docType).size() == this.indexBatchSize) {
+        if (bulkRequests.get(docType).size() >= this.indexBatchSize) {
             indexWithRetry(bulkRequests.get(docType), "Indexing " + docType + ": " + docId);
             bulkRequests.put(docType, new ArrayList<>());
         }
@@ -687,7 +687,7 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
             request.clear();
             logger.info("Time taken {} ", Instant.now().toEpochMilli() - startTime);
             logger.info("Current executor state queue {} ,executor {}", ((ThreadPoolExecutor) executorService).getQueue().size(), executorService);
-            Monitors.getTimer(Monitors.classQualifier, "index_time", "index_time").record(Instant.now().toEpochMilli(), TimeUnit.MILLISECONDS);
+            Monitors.recordESIndexTime("index_time", Instant.now().toEpochMilli() - startTime);
             Monitors.getGauge(Monitors.classQualifier, "worker_queue", "worker_queue").set(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             Monitors.error(className, "index");

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -688,9 +688,10 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
                     throw new RuntimeException(e);
                 }
             }, null, null, RETRY_COUNT, operationDescription, "indexWithRetry");
-            logger.info("Time taken {} ", Instant.now().toEpochMilli() - startTime);
+            long endTime = Instant.now().toEpochMilli();
+            logger.info("Time taken {} ", endTime - startTime);
             logger.info("Current executor state queue {} ,executor {}", ((ThreadPoolExecutor) executorService).getQueue().size(), executorService);
-            Monitors.recordESIndexTime("index_time", Instant.now().toEpochMilli() - startTime);
+            Monitors.recordESIndexTime("index_time", endTime - startTime);
             Monitors.recordWorkerQueueSize(((ThreadPoolExecutor) executorService).getQueue().size());
         } catch (Exception e) {
             Monitors.error(className, "index");

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -29,7 +29,6 @@ import org.apache.http.nio.entity.NByteArrayEntity;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -656,13 +655,13 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
         request.source(docBytes, XContentType.JSON);
 
         if(bulkRequests.get(docType) == null) {
-            bulkRequests.put(docType, new ArrayList<>());
+            bulkRequests.put(docType, new ArrayList<>(this.indexBatchSize));
         }
 
         bulkRequests.get(docType).add(request);
         if (bulkRequests.get(docType).size() >= this.indexBatchSize) {
             indexWithRetry(bulkRequests.get(docType), "Indexing " + docType + ": " + docId);
-            bulkRequests.put(docType, new ArrayList<>());
+            bulkRequests.put(docType, new ArrayList<>(this.indexBatchSize));
         }
     }
 

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -46,6 +46,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.archive.search.batchSize";
     int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
 
+    String ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.index.batchSize";
+    int ELASTIC_SEARCH_INDEX_BATCH_SIZE_DEFAULT_VALUE = 10;
+
     String ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE = "workflow.elasticsearch.async.dao.worker.queue.size";
     int DEFAULT_ASYNC_WORKER_QUEUE_SIZE = 100;
 
@@ -120,6 +123,11 @@ public interface ElasticSearchConfiguration extends Configuration {
     default int getArchiveSearchBatchSize() {
         return getIntProperty(ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_PROPERTY_NAME,
             ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE);
+    }
+
+    default int getIndexBatchSize() {
+        return getIntProperty(ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME,
+                ELASTIC_SEARCH_INDEX_BATCH_SIZE_DEFAULT_VALUE);
     }
 
     default int getAsyncWorkerQueueSize() {

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -47,7 +47,7 @@ public interface ElasticSearchConfiguration extends Configuration {
     int ELASTIC_SEARCH_ARCHIVE_SEARCH_BATCH_SIZE_DEFAULT_VALUE = 5000;
 
     String ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME = "workflow.elasticsearch.index.batchSize";
-    int ELASTIC_SEARCH_INDEX_BATCH_SIZE_DEFAULT_VALUE = 10;
+    int ELASTIC_SEARCH_INDEX_BATCH_SIZE_DEFAULT_VALUE = 1;
 
     String ELASTIC_SEARCH_ASYNC_DAO_WORKER_QUEUE_SIZE = "workflow.elasticsearch.async.dao.worker.queue.size";
     int DEFAULT_ASYNC_WORKER_QUEUE_SIZE = 100;

--- a/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchDAOV5.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchDAOV5.java
@@ -374,6 +374,65 @@ public class TestElasticSearchDAOV5 {
 	}
 
 	@Test
+	public void indexTaskWithBatchSizeTwo() throws Exception {
+		embeddedElasticSearch.stop();
+		startElasticSearchWithBatchSize(2);
+		String correlationId = "some-correlation-id";
+
+		Task task = new Task();
+		task.setTaskId("some-task-id");
+		task.setWorkflowInstanceId("some-workflow-instance-id");
+		task.setTaskType("some-task-type");
+		task.setStatus(Status.FAILED);
+		task.setInputData(new HashMap<String, Object>() {{ put("input_key", "input_value"); }});
+		task.setCorrelationId(correlationId);
+		task.setTaskDefName("some-task-def-name");
+		task.setReasonForIncompletion("some-failure-reason");
+
+		indexDAO.indexTask(task);
+		indexDAO.indexTask(task);
+
+		await()
+				.atMost(5, TimeUnit.SECONDS)
+				.untilAsserted(() -> {
+					SearchResult<String> result = indexDAO
+							.searchTasks("correlationId='" + correlationId + "'", "*", 0, 10000, null);
+
+					assertTrue("should return 1 or more search results", result.getResults().size() > 0);
+					assertEquals("taskId should match the indexed task", "some-task-id", result.getResults().get(0));
+				});
+
+		embeddedElasticSearch.stop();
+		startElasticSearchWithBatchSize(1);
+	}
+
+	private void startElasticSearchWithBatchSize(int i) throws Exception {
+		System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, String.valueOf(i));
+
+		configuration = new SystemPropertiesElasticSearchConfiguration();
+		String host = configuration.getEmbeddedHost();
+		int port = configuration.getEmbeddedPort();
+		String clusterName = configuration.getEmbeddedClusterName();
+
+		embeddedElasticSearch = new EmbeddedElasticSearchV5(clusterName, host, port);
+		embeddedElasticSearch.start();
+
+		ElasticSearchTransportClientProvider transportClientProvider =
+				new ElasticSearchTransportClientProvider(configuration);
+		elasticSearchClient = transportClientProvider.get();
+
+		elasticSearchClient.admin()
+				.cluster()
+				.prepareHealth()
+				.setWaitForGreenStatus()
+				.execute()
+				.get();
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		indexDAO = new ElasticSearchDAOV5(elasticSearchClient, configuration, objectMapper);
+	}
+
+	@Test
 	public void addMessage() {
 		String messageId = "some-message-id";
 

--- a/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchDAOV5.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchDAOV5.java
@@ -80,6 +80,7 @@ public class TestElasticSearchDAOV5 {
 	public static void startServer() throws Exception {
 		System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9203");
 		System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "localhost:9303");
+		System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
 		configuration = new SystemPropertiesElasticSearchConfiguration();
 		String host = configuration.getEmbeddedHost();

--- a/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchRestDAOV5.java
@@ -96,6 +96,7 @@ public class TestElasticSearchRestDAOV5 {
     public static void startServer() throws Exception {
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9204");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "http://localhost:9204");
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
         configuration = new SystemPropertiesElasticSearchConfiguration();
 

--- a/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/dao/es5/index/TestElasticSearchRestDAOV5.java
@@ -369,6 +369,67 @@ public class TestElasticSearchRestDAOV5 {
     }
 
     @Test
+    public void indexTaskWithBatchSizeTwo() throws Exception {
+        embeddedElasticSearch.stop();
+        startElasticSearchWithBatchSize(2);
+        String correlationId = "some-correlation-id";
+
+        Task task = new Task();
+        task.setTaskId("some-task-id");
+        task.setWorkflowInstanceId("some-workflow-instance-id");
+        task.setTaskType("some-task-type");
+        task.setStatus(Status.FAILED);
+        task.setInputData(new HashMap<String, Object>() {{ put("input_key", "input_value"); }});
+        task.setCorrelationId(correlationId);
+        task.setTaskDefName("some-task-def-name");
+        task.setReasonForIncompletion("some-failure-reason");
+
+        indexDAO.indexTask(task);
+        indexDAO.indexTask(task);
+
+        await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    SearchResult<String> result = indexDAO
+                            .searchTasks("correlationId='" + correlationId + "'", "*", 0, 10000, null);
+
+                    assertTrue("should return 1 or more search results", result.getResults().size() > 0);
+                    assertEquals("taskId should match the indexed task", "some-task-id", result.getResults().get(0));
+                });
+
+        embeddedElasticSearch.stop();
+        startElasticSearchWithBatchSize(1);
+
+    }
+
+    private void startElasticSearchWithBatchSize(int i) throws Exception {
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, String.valueOf(i));
+
+        configuration = new SystemPropertiesElasticSearchConfiguration();
+
+        String host = configuration.getEmbeddedHost();
+        int port = configuration.getEmbeddedPort();
+        String clusterName = configuration.getEmbeddedClusterName();
+
+        embeddedElasticSearch = new EmbeddedElasticSearchV5(clusterName, host, port);
+        embeddedElasticSearch.start();
+
+        ElasticSearchRestClientProvider restClientProvider =
+                new ElasticSearchRestClientProvider(configuration);
+        restClient = restClientProvider.get();
+        elasticSearchClient = new RestHighLevelClient(restClient);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("wait_for_status", "yellow");
+        params.put("timeout", "30s");
+
+        restClient.performRequest("GET", "/_cluster/health", params);
+
+        objectMapper = new ObjectMapper();
+        indexDAO = new ElasticSearchRestDAOV5(restClient, configuration, objectMapper);
+    }
+
+    @Test
     public void addMessage() {
         String messageId = "some-message-id";
 

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/ESRestClientHttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/ESRestClientHttpEndToEndTest.java
@@ -51,6 +51,7 @@ public class ESRestClientHttpEndToEndTest extends AbstractHttpEndToEndTest {
         TestEnvironment.setup();
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9203");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "http://localhost:9203");
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
         Injector bootInjector = Guice.createInjector(new BootstrapModule());
         Injector serverInjector = Guice.createInjector(bootInjector.getInstance(ModulesProvider.class).get());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/ExclusiveJoinEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/ExclusiveJoinEndToEndTest.java
@@ -69,6 +69,7 @@ public class ExclusiveJoinEndToEndTest {
 		TestEnvironment.setup();
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9205");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "localhost:9305");
+		System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
 		Injector bootInjector = Guice.createInjector(new BootstrapModule());
 		Injector serverInjector = Guice.createInjector(bootInjector.getInstance(ModulesProvider.class).get());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/GrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/GrpcEndToEndTest.java
@@ -50,6 +50,7 @@ public class GrpcEndToEndTest extends AbstractGrpcEndToEndTest {
         System.setProperty(GRPCServerConfiguration.PORT_PROPERTY_NAME, "8092");
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9202");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "localhost:9302");
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
         Injector bootInjector = Guice.createInjector(new BootstrapModule());
         Injector serverInjector = Guice.createInjector(bootInjector.getInstance(ModulesProvider.class).get());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/HttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/HttpEndToEndTest.java
@@ -38,6 +38,7 @@ public class HttpEndToEndTest extends AbstractHttpEndToEndTest {
         TestEnvironment.setup();
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9201");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "localhost:9301");
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
         Injector bootInjector = Guice.createInjector(new BootstrapModule());
         Injector serverInjector = Guice.createInjector(bootInjector.getInstance(ModulesProvider.class).get());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/MySQLGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/MySQLGrpcEndToEndTest.java
@@ -54,6 +54,7 @@ public class MySQLGrpcEndToEndTest extends AbstractGrpcEndToEndTest {
         System.setProperty(GRPCServerConfiguration.PORT_PROPERTY_NAME, "8094");
         System.setProperty(ElasticSearchConfiguration.EMBEDDED_PORT_PROPERTY_NAME, "9204");
         System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_URL_PROPERTY_NAME, "localhost:9304");
+        System.setProperty(ElasticSearchConfiguration.ELASTIC_SEARCH_INDEX_BATCH_SIZE_PROPERTY_NAME, "1");
 
         Injector bootInjector = Guice.createInjector(new BootstrapModule());
         Injector serverInjector = Guice.createInjector(bootInjector.getInstance(ModulesProvider.class).get());


### PR DESCRIPTION
This PR contains changes to index as batch in Elastic Search V5.
1) Batch size can be determined by property workflow.elasticsearch.index.batchSize.
2) Added prometheus metrics to determine queue size and indexing time.
3) Unit test

@kishorebanala @apanicker-nflx @naveenchlsn  Please look at it.