### PR TITLE
Update timeout description

### DIFF
--- a/docs/docs/configuration/taskdef.md
+++ b/docs/docs/configuration/taskdef.md
@@ -35,7 +35,7 @@ Conductor maintains a registry of worker tasks.  A task MUST be registered befor
 |retryLogic|Mechanism for the retries|see possible values below|
 |retryDelaySeconds|Time to wait before retries|defaults to 60 seconds|
 |timeoutPolicy|Task's timeout policy|see possible values below|
-|timeoutSeconds|Time in milliseconds, after which the task is marked as `TIMED_OUT` if not completed after transitioning to `IN_PROGRESS` status for the first time|No timeouts if set to 0|
+|timeoutSeconds|Time in seconds, after which the task is marked as `TIMED_OUT` if not completed after transitioning to `IN_PROGRESS` status for the first time|No timeouts if set to 0|
 |responseTimeoutSeconds|Must be greater than 0 and less than timeoutSeconds. The task is rescheduled if not updated with a status after this time (heartbeat mechanism). Useful when the worker polls for the task but fails to complete due to errors/network failure.|defaults to 3600|
 |inputKeys|Array of keys of task's expected input.  Used for documenting task's input. See [Using inputKeys and outputKeys](#using-inputkeys-and-outputkeys). |optional|
 |outputKeys|Array of keys of task's expected output.  Used for documenting task's output|optional|


### PR DESCRIPTION
it says the `timeoutSeconds` field takes its input in terms of milliseconds, when in reality, it takes it in terms of seconds. :)