### PR TITLE
Fix a typo in systask.md

### DIFF
--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -78,7 +78,7 @@ Event task provides ability to publish an event (message) to either Conductor or
 
 ``` json
 {
-	"sink": "sqs:example_sqs_queue_name"
+	"sink": "sqs:example_sqs_queue_name",
 	"asyncComplete": false
 }
 ```


### PR DESCRIPTION
Fixed a typo line 81. The JSON was missing a comma between the two parameters in the example:
``` json
{
	"sink": "sqs:example_sqs_queue_name"
	"asyncComplete": false
}
```