### PR TITLE
close connections, log the error before propagting it up

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
@@ -24,10 +24,18 @@ public class MySQLDataSourceProvider implements Provider<DataSource> {
 
     @Override
     public DataSource get() {
-        HikariDataSource dataSource = new HikariDataSource(createConfiguration());
-        flywayMigrate(dataSource);
-
-        return dataSource;
+        HikariDataSource dataSource = null;
+        try {
+            dataSource = new HikariDataSource(createConfiguration());
+            flywayMigrate(dataSource);
+            return dataSource;
+        } catch (final Throwable t) {
+            if(null != dataSource && !dataSource.isClosed()){
+                dataSource.close();
+            }
+            logger.error("error migration DB", t);
+            throw t;
+        }
     }
 
     private HikariConfig createConfiguration(){


### PR DESCRIPTION
Side issue discover from https://github.com/Netflix/conductor/issues/1264
To reproduce the issue, simply do something to make flyway blowup.
for example either:
- go to database, schema_version/flyway_schema_history table - which ever you choosed to be history table, update one success to fail. 
- or update a migration script to cause checksum mismatch or bad syntax

The result is while seeing no Error/Exception, new Connection pools keep being created until MySQL runs out of connection. At this point the application will terminate, with Too many Exception error.

This change:
- Log what is specifically is the problem
- Close the connection pool before bubbling up 

