### PR TITLE
deadlock is inavoidable, add retry on MySQL Deadlock

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -220,7 +220,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
         if (taskIds.isEmpty()) {
             return Lists.newArrayList();
         }
-        return getWithTransaction(c -> getTasks(c, taskIds));
+        return getWithRetriedTransactions(c -> getTasks(c, taskIds));
     }
 
     @Override
@@ -238,7 +238,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
     @Override
     public List<Task> getTasksForWorkflow(String workflowId) {
         String GET_TASKS_FOR_WORKFLOW = "SELECT task_id FROM workflow_to_task WHERE workflow_id = ?";
-        return getWithTransaction(tx -> query(tx, GET_TASKS_FOR_WORKFLOW, q -> {
+        return getWithRetriedTransactions(tx -> query(tx, GET_TASKS_FOR_WORKFLOW, q -> {
             List<String> taskIds = q.addParameter(workflowId).executeScalarList(String.class);
             return getTasks(tx, taskIds);
         }));
@@ -287,7 +287,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
 
     @Override
     public Workflow getWorkflow(String workflowId, boolean includeTasks) {
-        Workflow workflow = getWithTransaction(tx -> readWorkflow(tx, workflowId));
+        Workflow workflow = getWithRetriedTransactions(tx -> readWorkflow(tx, workflowId));
 
         if (workflow != null) {
             if (includeTasks) {
@@ -392,7 +392,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
     @Override
     public boolean addEventExecution(EventExecution eventExecution) {
         try {
-            return getWithTransaction(tx -> insertEventExecution(tx, eventExecution));
+            return getWithRetriedTransactions(tx -> insertEventExecution(tx, eventExecution));
         } catch (Exception e) {
             throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR,
                     "Unable to add event execution " + eventExecution.getId(), e);
@@ -456,7 +456,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
     public PollData getPollData(String taskDefName, String domain) {
         Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
         String effectiveDomain = (domain == null) ? "DEFAULT" : domain;
-        return getWithTransaction(tx -> readPollData(tx, taskDefName, effectiveDomain));
+        return getWithRetriedTransactions(tx -> readPollData(tx, taskDefName, effectiveDomain));
     }
 
     @Override

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAO.java
@@ -71,7 +71,7 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
     @Override
     public List<TaskDef> getAllTaskDefs() {
-        return getWithTransaction(this::findAllTaskDefs);
+        return getWithRetriedTransactions(this::findAllTaskDefs);
     }
 
     @Override
@@ -431,7 +431,7 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO {
 
         final String INSERT_TASKDEF_QUERY = "INSERT INTO meta_task_def (name, json_data) VALUES (?, ?)";
 
-        return getWithTransaction(tx -> {
+        return getWithRetriedTransactions(tx -> {
             execute(tx, UPDATE_TASKDEF_QUERY, update -> {
                 int result = update.addJsonParameter(taskDef).addParameter(taskDef.getName()).executeUpdate();
                 if (result == 0) {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -57,7 +57,7 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
     @Override
     public boolean pushIfNotExists(String queueName, String messageId, int priority, long offsetTimeInSecond) {
-        return getWithTransaction(tx -> {
+        return getWithRetriedTransactions(tx -> {
             if (!existsMessage(tx, queueName, messageId)) {
                 pushMessage(tx, queueName, messageId, null, priority, offsetTimeInSecond);
                 return true;
@@ -93,7 +93,7 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
     @Override
     public boolean ack(String queueName, String messageId) {
-        return getWithTransaction(tx -> removeMessage(tx, queueName, messageId));
+        return getWithRetriedTransactions(tx -> removeMessage(tx, queueName, messageId));
     }
 
     @Override
@@ -181,7 +181,7 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
     @Override
     public boolean exists(String queueName, String messageId) {
-        return getWithTransaction(tx -> existsMessage(tx, queueName, messageId));
+        return getWithRetriedTransactions(tx -> existsMessage(tx, queueName, messageId));
     }
 
     private boolean existsMessage(Connection connection, String queueName, String messageId) {


### PR DESCRIPTION
See https://github.com/Netflix/conductor/issues/1263

make getWithTransaction() private, use getWithRetriedTransactions() where it was.
getWithTransactionWithOutErrorPropagation() is used by sweeper, no need to apply retry since it will naturally do so next round.