### PR TITLE
Azure Blob External Storage

### DIFF
--- a/azureblob-storage/.gitignore
+++ b/azureblob-storage/.gitignore
@@ -1,0 +1,2 @@
+out/
+build/

--- a/azureblob-storage/README.md
+++ b/azureblob-storage/README.md
@@ -1,0 +1,111 @@
+# Azure Blob External Storage Module 
+
+This module use azure blob to store and retrieve workflows/tasks input/output payload that
+went over the thresholds defined in properties named `conductor.[workflow|task].[input|output].payload.threshold.kb`.
+
+**Warning** Azure Java SDK use libs already present inside `conductor` like `jackson` and `netty`.
+You may encounter deprecated issues, or conflicts and need to adapt the code if the module is not maintained along with `conductor`.
+It has only been tested with **v12.2.0**.
+
+## Build
+
+### Gradle Configuration
+
+Modify the following files
+
+[versionsOfDependencies.gradle](https://github.com/Netflix/conductor/blob/master/versionsOfDependencies.gradle)
+
+```diff
+@@ -5,6 +5,7 @@ ext {
+     revApacheCommons='2.6'
+     revAwaitility = '3.1.2'
+     revAwsSdk = '1.11.86'
++    revAzureStorageBlobSdk = '12.2.0'
+     revArchaius = '0.7.5'
+     revCassandra = '3.6.0'
+     revCassandraUnit = '3.5.0.1'
+
+
+```
+
+[settings.gradle](https://github.com/Netflix/conductor/blob/master/settings.gradle)
+
+```diff
+@@ -3,6 +3,7 @@ rootProject.name='conductor'
+ include 'client','common','contribs','core', 'es5-persistence','jersey', 'postgres-persistence', 'zookeeper-lock', 'redis-lock'
+ include 'cassandra-persistence', 'mysql-persistence', 'redis-persistence','server','test-harness','ui'
+ include 'grpc', 'grpc-server', 'grpc-client'
++include 'azureblob-storage'
+
+ rootProject.children.each {it.name="conductor-${it.name}"}
+
+```
+
+[server/build.gradle](https://github.com/Netflix/conductor/blob/master/server/build.gradle)
+
+```diff
+@@ -23,6 +23,7 @@ dependencies {
+
+     //Conductor
+     compile project(':conductor-core')
++    compile project(':conductor-azureblob-storage')
+     compile project(':conductor-jersey')
+     compile project(':conductor-redis-persistence')
+     compile project(':conductor-mysql-persistence')
+
+```
+ 
+Delete all dependencies.lock files of all modules and then run at the root folder of the project: 
+
+```
+./gradlew generateLock saveLock -PdependencyLock.includeTransitives=true
+```
+
+Run Build along with the tests
+
+```
+./gradlew conductor:azureblob-storage build
+```
+
+## Configuration
+
+In the `.properties` file of conductor `server` you must add the following configurations.
+
+* Add the AzureBlob module. If you have several modules, separate them with a comma.
+```
+conductor.additional.modules=com.netflix.conductor.azureblob.AzureBlobModule
+```
+
+### Usage
+
+Cf. Documentation [External Payload Storage](https://netflix.github.io/conductor/externalpayloadstorage/#azure-blob-storage)
+
+### Example
+
+```properties
+conductor.additional.modules=com.netflix.conductor.azureblob.AzureBlobModule
+es.set.netty.runtime.available.processors=false
+
+workflow.external.payload.storage=AZURE_BLOB
+workflow.external.payload.storage.azure_blob.connection_string=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;EndpointSuffix=localhost
+workflow.external.payload.storage.azure_blob.signedurlexpirationseconds=360
+```
+
+## Testing
+
+You can use [Azurite](https://github.com/Azure/Azurite) to simulate an Azure Storage.
+
+### Troubleshoots
+
+* When using **es5 persistance** you will receive an `java.lang.IllegalStateException` because the Netty lib will call `setAvailableProcessors` two times. To resolve this issue you need to set the following system property
+
+```
+es.set.netty.runtime.available.processors=false
+```
+
+If you want to change the default HTTP client of azure sdk, you can use `okhttp` instead of `netty`.
+For that you need to add the following [dependency](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/storage/azure-storage-blob#default-http-client).
+
+```
+com.azure:azure-core-http-okhttp:${compatible version}
+```

--- a/azureblob-storage/build.gradle
+++ b/azureblob-storage/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compile project(':conductor-common')
+    compile project(':conductor-core')
+    compile "com.google.inject:guice:${revGuice}"
+
+    compile "com.azure:azure-storage-blob:${revAzureStorageBlobSdk}"
+}

--- a/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/AzureBlobConfiguration.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/AzureBlobConfiguration.java
@@ -1,0 +1,69 @@
+package com.netflix.conductor.azureblob;
+
+import com.netflix.conductor.core.config.Configuration;
+
+public interface AzureBlobConfiguration extends Configuration {
+
+    String CONNECTION_STRING_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.connection_string";
+    String CONNECTION_STRING_DEFAULT_VALUE = null;
+
+    String CONTAINER_NAME_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.container_name";
+    String CONTAINER_NAME_DEFAULT_VALUE = "conductor-payloads";
+
+    String ENDPOINT_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.endpoint";
+    String ENDPOINT_DEFAULT_VALUE = null;
+
+    String SAS_TOKEN_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.sas_token";
+    String SAS_TOKEN_DEFAULT_VALUE = null;
+
+    String SIGNED_URL_EXPIRATION_SECONDS_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.signedurlexpirationseconds";
+    int SIGNED_URL_EXPIRATION_SECONDS_DEFAULT_VALUE = 5;
+
+    String WORKFLOW_INPUT_PATH_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.workflow_input_path";
+    String WORKFLOW_INPUT_PATH_DEFAULT_VALUE = "workflow/input/";
+
+    String WORKFLOW_OUTPUT_PATH_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.workflow_output_path";
+    String WORKFLOW_OUTPUT_PATH_DEFAULT_VALUE = "workflow/output/";
+
+    String TASK_INPUT_PATH_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.task_input_path";
+    String TASK_INPUT_PATH_DEFAULT_VALUE = "task/input/";
+
+    String TASK_OUTPUT_PATH_PROPERTY_NAME = "workflow.external.payload.storage.azure_blob.task_output_path";
+    String TASK_OUTPUT_PATH_DEFAULT_VALUE = "task/output/";
+
+    default String getConnectionString() {
+        return getProperty(CONNECTION_STRING_PROPERTY_NAME, CONNECTION_STRING_DEFAULT_VALUE);
+    }
+
+    default String getContainerName() {
+        return getProperty(CONTAINER_NAME_PROPERTY_NAME, CONTAINER_NAME_DEFAULT_VALUE);
+    }
+
+    default String getEndpoint() {
+        return getProperty(ENDPOINT_PROPERTY_NAME, ENDPOINT_DEFAULT_VALUE);
+    }
+
+    default String getSasToken() {
+        return getProperty(SAS_TOKEN_PROPERTY_NAME, SAS_TOKEN_DEFAULT_VALUE);
+    }
+
+    default int getSignedUrlExpirationSeconds() {
+        return getIntProperty(SIGNED_URL_EXPIRATION_SECONDS_PROPERTY_NAME, SIGNED_URL_EXPIRATION_SECONDS_DEFAULT_VALUE);
+    }
+
+    default String getWorkflowInputPath() {
+        return getProperty(WORKFLOW_INPUT_PATH_PROPERTY_NAME, WORKFLOW_INPUT_PATH_DEFAULT_VALUE);
+    }
+
+    default String getWorkflowOutputPath() {
+        return getProperty(WORKFLOW_OUTPUT_PATH_PROPERTY_NAME, WORKFLOW_OUTPUT_PATH_DEFAULT_VALUE);
+    }
+
+    default String getTaskInputPath() {
+        return getProperty(TASK_INPUT_PATH_PROPERTY_NAME, TASK_INPUT_PATH_DEFAULT_VALUE);
+    }
+
+    default String getTaskOutputPath() {
+        return getProperty(TASK_OUTPUT_PATH_PROPERTY_NAME, TASK_OUTPUT_PATH_DEFAULT_VALUE);
+    }
+}

--- a/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/AzureBlobModule.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/AzureBlobModule.java
@@ -1,0 +1,16 @@
+package com.netflix.conductor.azureblob;
+
+import com.google.inject.AbstractModule;
+
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.storage.AzureBlobPayloadStorage;
+
+public class AzureBlobModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(AzureBlobConfiguration.class).to(SystemPropertiesAzureBlobConfiguration.class);
+        bind(ExternalPayloadStorage.class).to(AzureBlobPayloadStorage.class);
+    }
+
+}

--- a/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/SystemPropertiesAzureBlobConfiguration.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/SystemPropertiesAzureBlobConfiguration.java
@@ -1,0 +1,6 @@
+package com.netflix.conductor.azureblob;
+
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+
+public class SystemPropertiesAzureBlobConfiguration extends SystemPropertiesConfiguration implements AzureBlobConfiguration {
+}

--- a/azureblob-storage/src/main/java/com/netflix/conductor/storage/AzureBlobPayloadStorage.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/storage/AzureBlobPayloadStorage.java
@@ -1,0 +1,208 @@
+package com.netflix.conductor.storage;
+
+import com.azure.core.exception.UnexpectedLengthException;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.blob.specialized.BlockBlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.common.Utility;
+import com.azure.storage.common.implementation.credentials.SasTokenCredential;
+import com.netflix.conductor.azureblob.AzureBlobConfiguration;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.execution.ApplicationException;
+import com.netflix.conductor.core.utils.IDGenerator;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * An implementation of {@link ExternalPayloadStorage} using Azure Blob for storing large JSON payload data.
+ *
+ * @see <a href="https://github.com/Azure/azure-sdk-for-java">Azure Java SDK</a>
+ */
+@Singleton
+public class AzureBlobPayloadStorage implements ExternalPayloadStorage {
+    private static final Logger logger = LoggerFactory.getLogger(AzureBlobPayloadStorage.class);
+    private static final String CONTENT_TYPE = "application/json";
+
+    private final String workflowInputPath;
+    private final String workflowOutputPath;
+    private final String taskInputPath;
+    private final String taskOutputPath;
+
+    private final BlobContainerClient blobContainerClient;
+    private final int expirationSec;
+    private final SasTokenCredential sasTokenCredential;
+
+    @Inject
+    public AzureBlobPayloadStorage(AzureBlobConfiguration config) {
+        workflowInputPath = config.getWorkflowInputPath();
+        workflowOutputPath = config.getWorkflowOutputPath();
+        taskInputPath = config.getTaskInputPath();
+        taskOutputPath = config.getTaskOutputPath();
+        expirationSec = config.getSignedUrlExpirationSeconds();
+        String connectionString = config.getConnectionString();
+        String containerName = config.getContainerName();
+        String endpoint = config.getEndpoint();
+        String sasToken = config.getSasToken();
+
+        BlobContainerClientBuilder blobContainerClientBuilder = new BlobContainerClientBuilder();
+        if (connectionString != null) {
+            blobContainerClientBuilder.connectionString(connectionString);
+            sasTokenCredential = null;
+        } else if (endpoint != null) {
+            blobContainerClientBuilder.endpoint(endpoint);
+            if (sasToken != null) {
+                sasTokenCredential = SasTokenCredential.fromSasTokenString(sasToken);
+                blobContainerClientBuilder.sasToken(sasTokenCredential.getSasToken());
+            } else {
+                sasTokenCredential = null;
+            }
+        } else {
+            String msg = "Missing property "
+                    + config.CONNECTION_STRING_PROPERTY_NAME
+                    + " OR "
+                    + config.ENDPOINT_PROPERTY_NAME;
+            logger.error(msg);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg);
+        }
+        blobContainerClient = blobContainerClientBuilder
+                .containerName(containerName)
+                .buildClient();
+    }
+
+    /**
+     * @param operation   the type of {@link Operation} to be performed
+     * @param payloadType the {@link PayloadType} that is being accessed
+     * @return a {@link ExternalStorageLocation} object which contains the pre-signed URL and the azure blob name
+     *  for the json payload
+     */
+    @Override
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path) {
+        try {
+            ExternalStorageLocation externalStorageLocation = new ExternalStorageLocation();
+
+            String objectKey;
+            if (StringUtils.isNotBlank(path)) {
+                objectKey = path;
+            } else {
+                objectKey = getObjectKey(payloadType);
+            }
+            externalStorageLocation.setPath(objectKey);
+
+            BlockBlobClient blockBlobClient = blobContainerClient.getBlobClient(objectKey).getBlockBlobClient();
+            String blobUrl = Utility.urlDecode(blockBlobClient.getBlobUrl());
+
+            if (sasTokenCredential != null) {
+                blobUrl = blobUrl + "?" + sasTokenCredential.getSasToken();
+            } else {
+                BlobSasPermission blobSASPermission = new BlobSasPermission();
+                if (operation.equals(Operation.READ)) {
+                    blobSASPermission.setReadPermission(true);
+                } else if (operation.equals(Operation.WRITE)) {
+                    blobSASPermission.setWritePermission(true);
+                    blobSASPermission.setCreatePermission(true);
+                }
+                BlobServiceSasSignatureValues blobServiceSasSignatureValues = new BlobServiceSasSignatureValues(
+                        OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(expirationSec),
+                        blobSASPermission
+                );
+                blobUrl = blobUrl + "?" + blockBlobClient.generateSas(blobServiceSasSignatureValues);
+            }
+
+            externalStorageLocation.setUri(blobUrl);
+            return externalStorageLocation;
+        } catch (BlobStorageException e) {
+            String msg = "Error communicating with Azure";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+
+    /**
+     * Uploads the payload to the given azure blob name.
+     * It is expected that the caller retrieves the blob name
+     * using {@link #getLocation(Operation, PayloadType, String)} before making this call.
+     *
+     * @param path        the name of the blob to be uploaded
+     * @param payload     an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     */
+    @Override
+    public void upload(String path, InputStream payload, long payloadSize) {
+        try {
+            BlockBlobClient blockBlobClient = blobContainerClient.getBlobClient(path).getBlockBlobClient();
+            BlobHttpHeaders blobHttpHeaders = new BlobHttpHeaders()
+                    .setContentType(CONTENT_TYPE);
+            blockBlobClient.uploadWithResponse(payload, payloadSize, blobHttpHeaders,
+                    null, null, null, null, null, Context.NONE);
+        } catch (BlobStorageException | UncheckedIOException | UnexpectedLengthException e) {
+            String msg = "Error communicating with Azure";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+
+    /**
+     * Downloads the payload stored in an azure blob.
+     *
+     * @param path the path of the blob
+     * @return an input stream containing the contents of the object
+     * Caller is expected to close the input stream.
+     */
+    @Override
+    public InputStream download(String path) {
+        try {
+            BlockBlobClient blockBlobClient = blobContainerClient.getBlobClient(path).getBlockBlobClient();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            // Avoid another call to the api to get the blob size
+            // ByteArrayOutputStream outputStream = new ByteArrayOutputStream(blockBlobClient.getProperties().value().blobSize());
+            blockBlobClient.download(outputStream);
+            return new ByteArrayInputStream(outputStream.toByteArray());
+        } catch (BlobStorageException | UncheckedIOException | NullPointerException e) {
+            String msg = "Error communicating with Azure";
+            logger.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+
+    /**
+     * Build path on external storage. Copied from S3PayloadStorage.
+     *
+     * @param payloadType the {@link PayloadType} which will determine the base path of the object
+     * @return External Storage path
+     */
+    private String getObjectKey(PayloadType payloadType) {
+        StringBuilder stringBuilder = new StringBuilder();
+        switch (payloadType) {
+            case WORKFLOW_INPUT:
+                stringBuilder.append(workflowInputPath);
+                break;
+            case WORKFLOW_OUTPUT:
+                stringBuilder.append(workflowOutputPath);
+                break;
+            case TASK_INPUT:
+                stringBuilder.append(taskInputPath);
+                break;
+            case TASK_OUTPUT:
+                stringBuilder.append(taskOutputPath);
+                break;
+        }
+        stringBuilder.append(IDGenerator.generate()).append(".json");
+        return stringBuilder.toString();
+    }
+}

--- a/azureblob-storage/src/test/java/com/netflix/conductor/config/InvalidTestConfiguration.java
+++ b/azureblob-storage/src/test/java/com/netflix/conductor/config/InvalidTestConfiguration.java
@@ -1,0 +1,129 @@
+package com.netflix.conductor.config;
+
+import com.netflix.conductor.azureblob.AzureBlobConfiguration;
+
+import java.util.Map;
+
+public class InvalidTestConfiguration implements AzureBlobConfiguration {
+
+    @Override
+    public String getConnectionString() {
+        return null;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return null;
+    }
+
+    @Override
+    public int getSweepFrequency() {
+        return 1;
+    }
+
+    @Override
+    public boolean disableSweep() {
+        return false;
+    }
+
+    @Override
+    public boolean disableAsyncWorkers() {
+        return false;
+    }
+
+    @Override
+    public String getServerId() {
+        return "server_id";
+    }
+
+    @Override
+    public String getEnvironment() {
+        return "test";
+    }
+
+    @Override
+    public String getStack() {
+        return "junit";
+    }
+
+    @Override
+    public String getAppId() {
+        return "workflow";
+    }
+
+    @Override
+    public String getProperty(String string, String def) {
+        return "dummy";
+    }
+
+    @Override
+    public boolean getBooleanProperty(String name, boolean defaultValue) {
+        return false;
+    }
+
+    @Override
+    public String getAvailabilityZone() {
+        return "us-east-1a";
+    }
+
+    @Override
+    public int getIntProperty(String string, int def) {
+        return 100;
+    }
+
+    @Override
+    public String getRegion() {
+        return "us-east-1";
+    }
+
+    @Override
+    public Long getWorkflowInputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getWorkflowOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskInputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxTaskInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Map<String, Object> getAll() {
+        return null;
+    }
+
+    @Override
+    public long getLongProperty(String name, long defaultValue) {
+        return 1000000L;
+    }
+
+}

--- a/azureblob-storage/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/azureblob-storage/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -1,0 +1,152 @@
+package com.netflix.conductor.config;
+
+import com.netflix.conductor.azureblob.AzureBlobConfiguration;
+
+import java.util.Map;
+
+public class TestConfiguration implements AzureBlobConfiguration {
+
+    private String connectionString = null;
+    private String endpoint = null;
+    private String sasToken = null;
+
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public void setSasToken(String sasToken) {
+        this.sasToken = sasToken;
+    }
+
+    @Override
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public String getSasToken() {
+        return sasToken;
+    }
+
+    // Copied from com.netflix.conductor.core.execution.TestConfiguration
+    @Override
+    public int getSweepFrequency() {
+        return 1;
+    }
+
+    @Override
+    public boolean disableSweep() {
+        return false;
+    }
+
+    @Override
+    public boolean disableAsyncWorkers() {
+        return false;
+    }
+
+    @Override
+    public String getServerId() {
+        return "server_id";
+    }
+
+    @Override
+    public String getEnvironment() {
+        return "test";
+    }
+
+    @Override
+    public String getStack() {
+        return "junit";
+    }
+
+    @Override
+    public String getAppId() {
+        return "workflow";
+    }
+
+
+    @Override
+    public String getProperty(String string, String def) {
+        return def;
+    }
+
+    @Override
+    public boolean getBooleanProperty(String name, boolean defaultValue) {
+        return false;
+    }
+
+    @Override
+    public String getAvailabilityZone() {
+        return "us-east-1a";
+    }
+
+    @Override
+    public int getIntProperty(String string, int def) {
+        return 100;
+    }
+
+    @Override
+    public String getRegion() {
+        return "us-east-1";
+    }
+
+    @Override
+    public Long getWorkflowInputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getWorkflowOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskInputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxTaskInputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Long getTaskOutputPayloadSizeThresholdKB() {
+        return 10L;
+    }
+
+    @Override
+    public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+        return 10240L;
+    }
+
+    @Override
+    public Map<String, Object> getAll() {
+        return null;
+    }
+
+    @Override
+    public long getLongProperty(String name, long defaultValue) {
+        return 1000000L;
+    }
+
+}

--- a/azureblob-storage/src/test/java/com/netflix/conductor/storage/AzureBlobPayloadStorageTest.java
+++ b/azureblob-storage/src/test/java/com/netflix/conductor/storage/AzureBlobPayloadStorageTest.java
@@ -1,0 +1,84 @@
+package com.netflix.conductor.storage;
+
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.config.InvalidTestConfiguration;
+import com.netflix.conductor.config.TestConfiguration;
+import com.netflix.conductor.core.execution.ApplicationException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AzureBlobPayloadStorageTest {
+    private final TestConfiguration testConfiguration = new TestConfiguration();
+    private final String path = "somewhere";
+
+    /**
+     * Dummy credentials
+     * Azure SDK doesn't work with Azurite since it cleans parameters
+     */
+    private final String azuriteConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;EndpointSuffix=localhost";
+    private final String azuriteEndpoint = "http://127.0.0.1:10000/";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testNoStorageAccount() {
+        expectedException.expect(ApplicationException.class);
+        new AzureBlobPayloadStorage(new InvalidTestConfiguration());
+    }
+
+    @Test
+    public void testUseConnectionString() {
+        testConfiguration.setConnectionString(azuriteConnectionString);
+        new AzureBlobPayloadStorage(testConfiguration);
+    }
+
+    @Test
+    public void testUseEndpoint() {
+        testConfiguration.setConnectionString(null);
+        testConfiguration.setEndpoint(azuriteEndpoint);
+        new AzureBlobPayloadStorage(testConfiguration);
+    }
+
+    @Test
+    public void testGetLocationFixedPath() {
+        testConfiguration.setConnectionString(azuriteConnectionString);
+        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(testConfiguration);
+        ExternalStorageLocation externalStorageLocation = azureBlobPayloadStorage.getLocation(ExternalPayloadStorage.Operation.READ, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT, path);
+        assertNotNull(externalStorageLocation);
+        assertEquals(path, externalStorageLocation.getPath());
+        assertNotNull(externalStorageLocation.getUri());
+    }
+
+
+    private void testGetLocation(AzureBlobPayloadStorage azureBlobPayloadStorage, ExternalPayloadStorage.Operation operation, ExternalPayloadStorage.PayloadType payloadType, String expectedPath) {
+        ExternalStorageLocation externalStorageLocation = azureBlobPayloadStorage.getLocation(operation, payloadType, null);
+        assertNotNull(externalStorageLocation);
+        assertNotNull(externalStorageLocation.getPath());
+        assertTrue(externalStorageLocation.getPath().startsWith(expectedPath));
+        assertNotNull(externalStorageLocation.getUri());
+        assertTrue(externalStorageLocation.getUri().contains(expectedPath));
+    }
+
+    @Test
+    public void testGetAllLocations() {
+        testConfiguration.setConnectionString(azuriteConnectionString);
+        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(testConfiguration);
+
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.READ, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT, testConfiguration.getWorkflowInputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.READ, ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT, testConfiguration.getWorkflowOutputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.READ, ExternalPayloadStorage.PayloadType.TASK_INPUT, testConfiguration.getTaskInputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.READ, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, testConfiguration.getTaskOutputPath());
+
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_INPUT, testConfiguration.getWorkflowInputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT, testConfiguration.getWorkflowOutputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_INPUT, testConfiguration.getTaskInputPath());
+        testGetLocation(azureBlobPayloadStorage, ExternalPayloadStorage.Operation.WRITE, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, testConfiguration.getTaskOutputPath());
+    }
+}

--- a/docs/docs/externalpayloadstorage.md
+++ b/docs/docs/externalpayloadstorage.md
@@ -23,6 +23,23 @@ The hard barriers are enforced to safeguard the conductor backend from the press
 In such cases, conductor will reject such payloads and will terminate/fail the workflow execution with the reasonForIncompletion set to an appropriate error message detailing the payload size.
 
 ## Usage
+
+### Barriers setup
+
+Set the following properties to the desired values in the JVM system properties:
+
+| Property | Description | default value |
+| conductor.workflow.input.payload.threshold.kb | Soft barrier for workflow input payload in KB | 5120 |
+| conductor.max.workflow.input.payload.threshold.kb | Hard barrier for workflow input payload in KB | 10240 |
+| conductor.workflow.output.payload.threshold.kb | Soft barrier for workflow output payload in KB | 5120 |
+| conductor.max.workflow.output.payload.threshold.kb | Hard barrier for workflow output payload in KB | 10240 |
+| conductor.task.input.payload.threshold.kb | Soft barrier for task input payload in KB | 3072 |
+| conductor.max.task.input.payload.threshold.kb | Hard barrier for task input payload in KB | 10240 |
+| conductor.task.output.payload.threshold.kb | Soft barrier for task output payload in KB | 3072 |
+| conductor.max.task.output.payload.threshold.kb | Hard barrier for task output payload in KB | 10240 |
+
+### Amazon S3
+
 Conductor provides an implementation of [Amazon S3](https://aws.amazon.com/s3/) used to externalize large payload storage.  
 Set the following property in the JVM system properties:
 ```
@@ -38,14 +55,31 @@ Set the following properties to the desired values in the JVM system properties:
 | --- | --- | --- |
 | workflow.external.payload.storage.s3.bucket | S3 bucket where the payloads will be stored | |
 | workflow.external.payload.storage.s3.signedurlexpirationseconds | The expiration time in seconds of the signed url for the payload | 5 |
-| | | | 
-| conductor.workflow.input.payload.threshold.kb | Soft barrier for workflow input payload in KB | 5120 |
-| conductor.max.workflow.input.payload.threshold.kb | Hard barrier for workflow input payload in KB | 10240 |
-| conductor.workflow.output.payload.threshold.kb | Soft barrier for workflow output payload in KB | 5120 |
-| conductor.max.workflow.output.payload.threshold.kb | Hard barrier for workflow output payload in KB | 10240 |
-| conductor.task.input.payload.threshold.kb | Soft barrier for task input payload in KB | 3072 |
-| conductor.max.task.input.payload.threshold.kb | Hard barrier for task input payload in KB | 10240 |
-| conductor.task.output.payload.threshold.kb | Soft barrier for task output payload in KB | 3072 |
-| conductor.max.task.output.payload.threshold.kb | Hard barrier for task output payload in KB | 10240 |
 
 The payloads will be stored in the bucket configured above in a `UUID.json` file at locations determined by the type of the payload. See [here](https://github.com/Netflix/conductor/blob/master/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java#L149-L167) for information about how the object key is determined.
+
+### Azure Blob Storage
+
+ProductLive provides an implementation of [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) used to externalize large payload storage.  
+
+To build conductor with azure blob feature read the [README.md](https://github.com/Netflix/conductor/blob/master/azureblob-storage/README.md) in `azureblob-storage` module 
+
+!!!note
+    This implementation assumes that you have an [Azure Blob Storage account's connection string or SAS Token](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/storage/azure-storage-blob/README.md).
+    If you want signed url to expired you must specify a Connection String. 
+
+Set the following properties to the desired values in the JVM system properties:
+
+| Property | Description | default value |
+| --- | --- | --- |
+| workflow.external.payload.storage.azure_blob.connection_string | Azure Blob Storage connection string. Required to sign Url. | |
+| workflow.external.payload.storage.azure_blob.endpoint | Azure Blob Storage endpoint. Optional if connection_string is set. | |
+| workflow.external.payload.storage.azure_blob.sas_token | Azure Blob Storage SAS Token. Must have permissions `Read` and `Write` on Resource `Object` on Service `Blob`. Optional if connection_string is set. | |
+| workflow.external.payload.storage.azure_blob.container_name | Azure Blob Storage container where the payloads will be stored | `conductor-payloads` |
+| workflow.external.payload.storage.azure_blob.signedurlexpirationseconds | The expiration time in seconds of the signed url for the payload | 5 |
+| workflow.external.payload.storage.azure_blob.workflow_input_path | Path prefix where workflows input will be stored with an random UUID filename | workflow/input/ |
+| workflow.external.payload.storage.azure_blob.workflow_output_path | Path prefix where workflows output will be stored with an random UUID filename | workflow/output/ |
+| workflow.external.payload.storage.azure_blob.task_input_path | Path prefix where tasks input will be stored with an random UUID filename | task/input/ |
+| workflow.external.payload.storage.azure_blob.task_output_path | Path prefix where tasks output will be stored with an random UUID filename | task/output/ |
+
+The payloads will be stored as done in [Amazon S3](https://github.com/Netflix/conductor/blob/master/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java#L149-L167).


### PR DESCRIPTION
Here is an implementation of the Azure Blob as ExternalStorage based on the new [Azure Java SDK](https://github.com/Azure/azure-sdk-for-java) which is still on preview.
I will re-update the PR once the java SDK is stable.
Documentation has been updated.

Following packages have been updated to resolve the downgrading of the dependency `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` to 2.4.5 which is incompatible with azure blob storage sdk because of missing function [setDefaultUseWrapper](https://github.com/FasterXML/jackson-dataformat-xml/blob/2.9/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlMapper.java#L133)
- `com.fasterxml.jackson.core:jackson-core` from 2.7.5 to 2.9.9
- `com.fasterxml.jackson.core:jackson-databind` from 2.7.5 to 2.9.9
- `com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider` from 2.7.5 to 2.9.9
- `io.swagger:swagger-jersey-jaxrs` from 1.5.9 to 1.5.23
- `io.swagger:swagger-jaxrs` from 1.5.9 to 1.5.23

**Questions**

- Is there a better way to implement an External Storage without modifying the core lib ?
- Is there a better way to force the upgrade of `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` to =>2.7 ? 

**Troubleshoots**

- When using **es5 persistance** with azure blob external storage you will receive an `java.lang.IllegalStateException` because the Netty lib will call [setAvailableProcessors](setAvailableProcessors) two times. To resolve this issue you need to set the following system property `es.set.netty.runtime.available.processors=false`

- When using the java client to upload you need to add the [HTTP Header](https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob#request-headers-all-blob-types) `x-ms-blob-type` to `BlockBlob`. This modification is not part of this PR.