### PR TITLE
add GetWorkflows and GetTasks to gRPC service implementation

### DIFF
--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/service/MetadataServiceImpl.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/service/MetadataServiceImpl.java
@@ -34,6 +34,15 @@ public class MetadataServiceImpl extends MetadataServiceGrpc.MetadataServiceImpl
     }
 
     @Override
+    public void getWorkflows(MetadataServicePb.GetWorkflowsRequest req, StreamObserver<MetadataServicePb.GetWorkflowsResponse > response) {
+        response.onNext(
+            MetadataServicePb.GetWorkflowsResponse.newBuilder().addAllWorkflows(
+                service.getWorkflowDefs().stream().map(PROTO_MAPPER::toProto)::iterator
+            ).build());
+        response.onCompleted();
+    }
+
+    @Override
     public void createWorkflow(MetadataServicePb.CreateWorkflowRequest req, StreamObserver<MetadataServicePb.CreateWorkflowResponse> response) {
         WorkflowDef workflow = PROTO_MAPPER.fromProto(req.getWorkflow());
         service.registerWorkflowDef(workflow);
@@ -68,6 +77,15 @@ public class MetadataServiceImpl extends MetadataServiceGrpc.MetadataServiceImpl
                     .asRuntimeException()
             );
         }
+    }
+
+    @Override
+    public void getTasks(MetadataServicePb.GetTasksRequest req, StreamObserver<MetadataServicePb.GetTasksResponse > response) {
+        response.onNext(
+            MetadataServicePb.GetTasksResponse.newBuilder().addAllDefs(
+                service.getTaskDefs().stream().map(PROTO_MAPPER::toProto)::iterator
+            ).build());
+        response.onCompleted();
     }
 
     @Override

--- a/grpc/src/main/java/com/netflix/conductor/grpc/ProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/ProtoMapper.java
@@ -1,7 +1,9 @@
 package com.netflix.conductor.grpc;
 
 import com.google.protobuf.*;
+import com.netflix.conductor.common.metadata.workflow.SubWorkflowParams;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.proto.SubWorkflowParamsPb;
 import com.netflix.conductor.proto.WorkflowTaskPb;
 
 import java.util.ArrayList;
@@ -143,5 +145,20 @@ public final class ProtoMapper extends AbstractProtoMapper {
     @Override
     public Any fromProto(Any in) {
         return in;
+    }
+
+    @Override
+    public SubWorkflowParamsPb.SubWorkflowParams toProto(SubWorkflowParams from) {
+        SubWorkflowParamsPb.SubWorkflowParams.Builder to = SubWorkflowParamsPb.SubWorkflowParams.newBuilder();
+        if (from.getName() != null) {
+            to.setName( from.getName() );
+        }
+        if (from.getVersion() != null) {
+            to.setVersion( from.getVersion() );
+        }
+        if (from.getTaskToDomain() != null) {
+            to.putAllTaskToDomain( from.getTaskToDomain() );
+        }
+        return to.build();
     }
 }

--- a/grpc/src/main/proto/grpc/metadata_service.proto
+++ b/grpc/src/main/proto/grpc/metadata_service.proto
@@ -9,6 +9,9 @@ option java_outer_classname = "MetadataServicePb";
 option go_package = "github.com/netflix/conductor/client/gogrpc/conductor/grpc/metadata";
 
 service MetadataService {
+    // GET /workflow
+    rpc GetWorkflows(GetWorkflowsRequest) returns (GetWorkflowsResponse);
+
     // POST /workflow
     rpc CreateWorkflow(CreateWorkflowRequest) returns (CreateWorkflowResponse);
 
@@ -17,6 +20,9 @@ service MetadataService {
 
     // GET /workflow/{name}
     rpc GetWorkflow(GetWorkflowRequest) returns (GetWorkflowResponse);
+
+    // GET /taskdefs
+    rpc GetTasks(GetTasksRequest) returns (GetTasksResponse);
 
     // POST /taskdefs
     rpc CreateTasks(CreateTasksRequest) returns (CreateTasksResponse);
@@ -29,6 +35,12 @@ service MetadataService {
 
     // DELETE /taskdefs/{tasktype}
     rpc DeleteTask(DeleteTaskRequest) returns (DeleteTaskResponse);
+}
+
+message GetWorkflowsRequest {}
+
+message GetWorkflowsResponse {
+    repeated conductor.proto.WorkflowDef workflows = 1;
 }
 
 message CreateWorkflowRequest {
@@ -50,6 +62,12 @@ message GetWorkflowRequest {
 
 message GetWorkflowResponse {
     conductor.proto.WorkflowDef workflow = 1;
+}
+
+message GetTasksRequest {}
+
+message GetTasksResponse {
+    repeated conductor.proto.TaskDef defs = 1;
 }
 
 message CreateTasksRequest {


### PR DESCRIPTION
This is a small patch to add two gRPC metadata service methods, `GetWorkflows` and `GetTasks`. They are functionally equivalent to the REST API methods.

A small note: the new override in `ProtoMapper` is required because the auto-generator for `AbstractProtoMapper` does not properly implement null checking for map types. Without it you'll get a `NullPointerException` at runtime.