### PR TITLE
MySQL deadlocks: Searching for a SQLException in all nested exceptions

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLBaseDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLBaseDAO.java
@@ -237,10 +237,19 @@ public abstract class MySQLBaseDAO {
     }
 
     private boolean isDeadLockError(Throwable throwable){
-        if (!(throwable.getCause() instanceof SQLException)){
+        SQLException sqlException = findCauseSQLException(throwable);
+        if (sqlException == null){
             return false;
         }
-        return ER_LOCK_DEADLOCK == ((SQLException)throwable.getCause()).getErrorCode();
+        return ER_LOCK_DEADLOCK == sqlException.getErrorCode();
+    }
+
+    private SQLException findCauseSQLException(Throwable throwable) {
+        Throwable causeException = throwable;
+        while (null != causeException && !(causeException instanceof SQLException)) {
+            causeException = causeException.getCause();
+        }
+        return (SQLException)causeException;
     }
 
     private static int getMaxRetriesOnDeadLock() {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/Query.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/Query.java
@@ -273,7 +273,7 @@ public class Query implements AutoCloseable {
 
             return val;
         } catch (SQLException ex) {
-            throw new ApplicationException(Code.BACKEND_ERROR, ex.getMessage());
+            throw new ApplicationException(Code.BACKEND_ERROR, ex.getMessage(), ex);
         }
     }
 


### PR DESCRIPTION
I've tried the recent retries feature for the MySQL deadlocks (https://github.com/Netflix/conductor/pull/1299) and found that there are no retries in most of the cases.

I've got to debug it and found the reason - there can be more than one nested exceptions of `ApplicationException`. Simple `throwable.getCause()` won't return a `SQLException` in this case.

In addition, I've check all places in the MySQL persistence module which throw `ApplicationException` and found one without passing the cause exception (fixed it here as well).