### PR TITLE
MySQL queues: reduce the impact of racing by popping the queue 1 by 1

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -242,19 +242,16 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
             return messages;
         }
 
-        final String POP_MESSAGES = "UPDATE queue_message SET popped = true WHERE queue_name = ? AND message_id IN (%s) AND popped = false";
+        List<Message> poppedMessages = new ArrayList<>();
+        for (Message message: messages) {
+            final String POP_MESSAGE = "UPDATE queue_message SET popped = true WHERE queue_name = ? AND message_id = ? AND popped = false";
+            int result = query(connection, POP_MESSAGE, q -> q.addParameter(queueName).addParameter(message.getId()).executeUpdate());
 
-        final List<String> Ids = messages.stream().map(Message::getId).collect(Collectors.toList());
-        final String query = String.format(POP_MESSAGES, Query.generateInBindings(messages.size()));
-
-        int result = query(connection, query, q -> q.addParameter(queueName).addParameters(Ids).executeUpdate());
-
-        if (result != messages.size()) {
-            String message = String.format("Could not pop all messages for given ids: %s (%d messages were popped)",
-                    Ids, result);
-            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, message);
+            if (result == 1) {
+                poppedMessages.add(message);
+            }
         }
-        return messages;
+        return poppedMessages;
     }
 
 


### PR DESCRIPTION
As I understand, the current implementation is done in this way (everything or nothing) just because there is no way to get the updated row IDs from a MySQL response. And therefore the only consistent behavior is to completely cancel the partial update as it conflicts with another worker.

But it hurts a lot if there is a huge queue of tasks and a lot of workers trying to poll - they get stuck in a deadlock trying to do `set popped = true` for a bunch of messages.

In this change the messages are marker as popped one by one for each row and the popped ones are returned.

**EDIT**
Closes #577 