### PR TITLE
Added optional async decide to decide the workflows through WorkflowSweeper

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -24,6 +24,9 @@ public interface Configuration {
     String DB_PROPERTY_NAME = "db";
     String DB_DEFAULT_VALUE = "memory";
 
+    String ASYNC_WORKFLOW_DECIDE_PROPERTY_NAME = "workflow.decide.async";
+    boolean ASYNC_WORKFLOW_DECIDE_DEFAULT_VALUE = false;
+
     String SWEEP_FREQUENCY_PROPERTY_NAME = "decider.sweep.frequency.seconds";
     int SWEEP_FREQUENCY_DEFAULT_VALUE = 30;
 
@@ -119,6 +122,10 @@ public interface Configuration {
      * @return Availability zone / rack.  for AWS deployments, the value is something like us-east-1a, etc.
      */
     String getAvailabilityZone();
+
+    default boolean asyncDecideEnabled() {
+        return getBooleanProperty(ASYNC_WORKFLOW_DECIDE_PROPERTY_NAME, ASYNC_WORKFLOW_DECIDE_DEFAULT_VALUE);
+    }
 
     /**
      * @return when set to true, the indexing operation to elasticsearch will be performed asynchronously

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -636,4 +636,23 @@ public class DeciderService {
         }
 
     }
+
+    /**
+     * Decide types with increasing order of priority.
+     */
+    public enum DecideType {
+        SWEEP(0),
+        UPDATE_TASK(50),    // In the range of Priority 0-99, keeping at median to avoid starvation by user provided priorities.
+        PARENT_WORKFLOW_EVAL(50);
+
+        private final int priority;
+
+        DecideType(final int priority) {
+            this.priority = priority;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowSweeper.java
@@ -51,6 +51,8 @@ public class WorkflowSweeper {
 
 	private int executorThreadPoolSize;
 
+	private int numberOfMessagesToPop;
+
 	private static final String className = WorkflowSweeper.class.getSimpleName();
 
 	@Inject
@@ -58,6 +60,7 @@ public class WorkflowSweeper {
 		this.config = config;
 		this.queueDAO = queueDAO;
 		this.executorThreadPoolSize = config.getIntProperty("workflow.sweeper.thread.count", 5);
+		this.numberOfMessagesToPop = config.getIntProperty("workflow.sweeper.messages.popCount", 10);
 		if(this.executorThreadPoolSize > 0) {
 			this.executorService = Executors.newFixedThreadPool(executorThreadPoolSize);
 			init(workflowExecutor);
@@ -65,7 +68,6 @@ public class WorkflowSweeper {
 		} else {
 			logger.warn("Workflow sweeper is DISABLED");
 		}
-
 	}
 
 	public void init(WorkflowExecutor workflowExecutor) {
@@ -77,7 +79,7 @@ public class WorkflowSweeper {
 					logger.info("Workflow sweep is disabled.");
 					return;
 				}
-				List<String> workflowIds = queueDAO.pop(WorkflowExecutor.DECIDER_QUEUE, 2 * executorThreadPoolSize, 2000);
+				List<String> workflowIds = queueDAO.pop(WorkflowExecutor.DECIDER_QUEUE, numberOfMessagesToPop, 2000);
 				int currentQueueSize = queueDAO.getSize(WorkflowExecutor.DECIDER_QUEUE);
 				logger.debug("Sweeper's current deciderqueue size: {}.", currentQueueSize);
 				int retrievedWorkflows = (workflowIds != null) ? workflowIds.size() : 0;

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -15,10 +15,10 @@
 #
 
 #Dynomite Cluster details.
-#format is host:port:rack separated by semicolon  
+#format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=host1:port:rack;host2:port:rack:host3:port:rack
 
-#namespace for the keys stored in Dynomite/Redis 
+#namespace for the keys stored in Dynomite/Redis
 workflow.namespace.prefix=
 
 #namespace prefix for the dyno queues
@@ -27,7 +27,7 @@ workflow.namespace.queue.prefix=
 #no. of threads allocated to dyno-queues
 queues.dynomite.threads=10
 
-#non-quorum port used to connect to local redis.  Used by dyno-queues 
+#non-quorum port used to connect to local redis.  Used by dyno-queues
 queues.dynomite.nonQuorum.port=22122
 
 #Transport address to elasticsearch
@@ -44,3 +44,6 @@ EC2_AVAILABILITY_ZONE=us-east-1c
 
 # disable archival service
 workflow.archive=false
+
+# Enable async workflow decide
+workflow.decide.async=true


### PR DESCRIPTION
- The default behavior when set to `false` remains same.
- On calling `decide` through updateTask, or decide on parent workflow through complete or terminate workflow, the workflowId will be added to decider queue with a generic priority (which can be customized per QueueDAO implementation) and offset time of 0 seconds.
- Other calls to decide like start workflow, retry, rerun, resume etc. are kept synchronous, so that users would immediately know whether their request is successful.