### PR TITLE
Goto Task implementation

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -198,6 +198,9 @@ public class Task {
     @ProtoField(id = 40)
     private int iteration;
 
+    @ProtoField(id = 41)
+    private int iterationCount;
+	
     public Task() {
     }
 
@@ -725,6 +728,20 @@ public class Task {
     public void setWorkflowPriority(int workflowPriority) {
         this.workflowPriority = workflowPriority;
     }
+	
+	/**
+     * @return the iterationCount
+     */
+    public int getIterationCount() {
+        return iterationCount;
+    }
+
+    /**
+     * @param iterationCount the iterationCount to set
+     */
+    public void setIterationCount(int iterationCount) {
+        this.iterationCount = iterationCount;
+    }
 
     public Task copy() {
         Task copy = new Task();
@@ -756,6 +773,7 @@ public class Task {
         copy.setIteration(iteration);
         copy.setExecutionNameSpace(executionNameSpace);
         copy.setIsolationGroupId(isolationGroupId);
+		copy.setIterationCount(iterationCount);
 
         return copy;
     }
@@ -769,6 +787,7 @@ public class Task {
                 ", inputData=" + inputData +
                 ", referenceTaskName='" + referenceTaskName + '\'' +
                 ", retryCount=" + retryCount +
+                ", iterationCount=" + iterationCount +
                 ", seq=" + seq +
                 ", correlationId='" + correlationId + '\'' +
                 ", pollCount=" + pollCount +
@@ -810,6 +829,7 @@ public class Task {
         if (o == null || getClass() != o.getClass()) return false;
         Task task = (Task) o;
         return getRetryCount() == task.getRetryCount() &&
+                getIterationCount() == task.getIterationCount() &&
                 getSeq() == task.getSeq() &&
                 getPollCount() == task.getPollCount() &&
                 getScheduledTime() == task.getScheduledTime() &&
@@ -851,6 +871,6 @@ public class Task {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTaskType(), getStatus(), getInputData(), getReferenceTaskName(), getWorkflowPriority(), getRetryCount(), getSeq(), getCorrelationId(), getPollCount(), getTaskDefName(), getScheduledTime(), getStartTime(), getEndTime(), getUpdateTime(), getStartDelayInSeconds(), getRetriedTaskId(), isRetried(), isExecuted(), isCallbackFromWorker(), getResponseTimeoutSeconds(), getWorkflowInstanceId(), getWorkflowType(), getTaskId(), getReasonForIncompletion(), getCallbackAfterSeconds(), getWorkerId(), getOutputData(), getWorkflowTask(), getDomain(), getInputMessage(), getOutputMessage(), getRateLimitPerFrequency(), getRateLimitFrequencyInSeconds(), getExternalInputPayloadStoragePath(), getExternalOutputPayloadStoragePath(), getIsolationGroupId(), getExecutionNameSpace());
+        return Objects.hash(getTaskType(), getStatus(), getInputData(), getReferenceTaskName(), getWorkflowPriority(), getRetryCount(), getSeq(), getCorrelationId(), getPollCount(), getTaskDefName(), getScheduledTime(), getStartTime(), getEndTime(), getUpdateTime(), getStartDelayInSeconds(), getRetriedTaskId(), isRetried(), isExecuted(), isCallbackFromWorker(), getResponseTimeoutSeconds(), getWorkflowInstanceId(), getWorkflowType(), getTaskId(), getReasonForIncompletion(), getCallbackAfterSeconds(), getWorkerId(), getOutputData(), getWorkflowTask(), getDomain(), getInputMessage(), getOutputMessage(), getRateLimitPerFrequency(), getRateLimitFrequencyInSeconds(), getExternalInputPayloadStoragePath(), getExternalOutputPayloadStoragePath(), getIsolationGroupId(), getExecutionNameSpace(), getIterationCount());
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
@@ -20,7 +20,8 @@ public enum TaskType {
     LAMBDA(true),
     EXCLUSIVE_JOIN(true),
     TERMINATE(true),
-    KAFKA_PUBLISH(true);
+    KAFKA_PUBLISH(true),
+	GOTO(true);
 
     /**
      * TaskType constants representing each of the possible enumeration values.
@@ -43,6 +44,7 @@ public enum TaskType {
     public static final String TASK_TYPE_EXCLUSIVE_JOIN = "EXCLUSIVE_JOIN";
     public static final String TASK_TYPE_TERMINATE = "TERMINATE";
     public static final String TASK_TYPE_KAFKA_PUBLISH = "KAFKA_PUBLISH";
+	public static final String TASK_TYPE_GOTO = "GOTO";
     
     private boolean isSystemTask;
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -165,6 +165,9 @@ public class WorkflowTask {
 
 	@ProtoField(id = 25)
 	private List<WorkflowTask> loopOver = new LinkedList<>();
+	
+	@ProtoField(id = 26)
+	private String gotoTask;
 
 	/**
 	 * @return the name
@@ -513,6 +516,24 @@ public class WorkflowTask {
 	public void setDefaultExclusiveJoinTask(List<String> defaultExclusiveJoinTask) {
 		this.defaultExclusiveJoinTask = defaultExclusiveJoinTask;
 	}
+	
+	
+
+	/**
+	 * @return reference name of target Goto task
+	 */
+	public String getGotoTask() {
+		return gotoTask;
+	}
+	
+	/**
+	 * @param gotoTask target Goto Task's reference name
+	 */
+	public void setGotoTask(String gotoTask) {
+		this.gotoTask = gotoTask;
+	}
+
+
 
 	private Collection<List<WorkflowTask>> children() {
 		Collection<List<WorkflowTask>> workflowTaskLists = new LinkedList<>();
@@ -690,7 +711,8 @@ public class WorkflowTask {
                 Objects.equals(getJoinOn(), that.getJoinOn()) &&
                 Objects.equals(getSink(), that.getSink()) &&
 				Objects.equals(isAsyncComplete(), that.isAsyncComplete()) &&
-                Objects.equals(getDefaultExclusiveJoinTask(), that.getDefaultExclusiveJoinTask());
+                Objects.equals(getDefaultExclusiveJoinTask(), that.getDefaultExclusiveJoinTask()) &&
+				Objects.equals(getGotoTask(), that.getGotoTask());
     }
 
     @Override
@@ -717,7 +739,8 @@ public class WorkflowTask {
                 getSink(),
                 isAsyncComplete(),
                 isOptional(),
-                getDefaultExclusiveJoinTask()
+                getDefaultExclusiveJoinTask(),
+				getGotoTask()
         );
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -42,6 +42,7 @@ import com.netflix.conductor.core.execution.mapper.KafkaPublishTaskMapper;
 import com.netflix.conductor.core.execution.mapper.LambdaTaskMapper;
 import com.netflix.conductor.core.execution.mapper.SimpleTaskMapper;
 import com.netflix.conductor.core.execution.mapper.SubWorkflowTaskMapper;
+import com.netflix.conductor.core.execution.mapper.GotoTaskMapper;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
 import com.netflix.conductor.core.execution.mapper.TerminateTaskMapper;
 import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
@@ -50,6 +51,7 @@ import com.netflix.conductor.core.execution.mapper.DoWhileTaskMapper;
 import com.netflix.conductor.core.execution.tasks.Event;
 import com.netflix.conductor.core.execution.tasks.IsolatedTaskQueueProducer;
 import com.netflix.conductor.core.execution.tasks.Lambda;
+import com.netflix.conductor.core.execution.tasks.Goto;
 import com.netflix.conductor.core.execution.tasks.SubWorkflow;
 import com.netflix.conductor.core.execution.tasks.SystemTaskWorkerCoordinator;
 import com.netflix.conductor.core.execution.tasks.Terminate;
@@ -74,6 +76,8 @@ import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_USER_DEFINED;
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_WAIT;
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_DO_WHILE;
+import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_GOTO;
+
 import static com.netflix.conductor.core.events.EventQueues.EVENT_QUEUE_PROVIDERS_QUALIFIER;
 /**
  * @author Viren
@@ -247,5 +251,14 @@ public class CoreModule extends AbstractModule {
     public TaskMapper getKafkaPublishTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
         return new KafkaPublishTaskMapper(parametersUtils, metadataDAO);
     }
+	
+	@ProvidesIntoMap
+    @StringMapKey(TASK_TYPE_GOTO)
+    @Singleton
+    @Named(TASK_MAPPERS_QUALIFIER)
+    public TaskMapper getGotoTaskMapper() {
+        return new GotoTaskMapper();
+    }
+	  
 
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/SystemTaskType.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/SystemTaskType.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.core.execution.tasks.ExclusiveJoin;
 import com.netflix.conductor.core.execution.tasks.Fork;
 import com.netflix.conductor.core.execution.tasks.Join;
 import com.netflix.conductor.core.execution.tasks.DoWhile;
+import com.netflix.conductor.core.execution.tasks.Goto;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 /**
  * Defines a system task type
@@ -34,7 +35,7 @@ import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
  */
 public enum SystemTaskType {
 
-	DECISION(new Decision()), FORK(new Fork()), JOIN(new Join()), EXCLUSIVE_JOIN(new ExclusiveJoin()), DO_WHILE(new DoWhile());
+	DECISION(new Decision()), FORK(new Fork()), JOIN(new Join()), EXCLUSIVE_JOIN(new ExclusiveJoin()), DO_WHILE(new DoWhile()), GOTO(new Goto());
 	
 	private static Set<String> builtInTasks = new HashSet<>();
 	static {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1000,11 +1000,11 @@ public class WorkflowExecutor {
     @VisibleForTesting
     List<Task> dedupAndAddTasks(Workflow workflow, List<Task> tasks) {
         List<String> tasksInWorkflow = workflow.getTasks().stream()
-                .map(task -> task.getReferenceTaskName() + "_" + task.getRetryCount())
+                .map(task -> task.getReferenceTaskName() + "_" + task.getRetryCount() + "_" + task.getIterationCount())
                 .collect(Collectors.toList());
 
         List<Task> dedupedTasks = tasks.stream()
-                .filter(task -> !tasksInWorkflow.contains(task.getReferenceTaskName() + "_" + task.getRetryCount()))
+                .filter(task -> !tasksInWorkflow.contains(task.getReferenceTaskName() + "_" + task.getRetryCount() + "_" + task.getIterationCount()))
                 .collect(Collectors.toList());
 
         workflow.getTasks().addAll(dedupedTasks);
@@ -1476,7 +1476,7 @@ public class WorkflowExecutor {
 
     public void scheduleNextIteration(Task loopTask, Workflow workflow) {
         //Schedule only first loop over task. Rest will be taken care in Decider Service when this task will get completed.
-        List<Task> scheduledLoopOverTasks = deciderService.getTasksToBeScheduled(workflow, loopTask.getWorkflowTask().getLoopOver().get(0), loopTask.getRetryCount(), null);
+        List<Task> scheduledLoopOverTasks = deciderService.getTasksToBeScheduled(workflow, loopTask.getWorkflowTask().getLoopOver().get(0), loopTask.getRetryCount(), null, 0);
         scheduledLoopOverTasks.stream().forEach(t -> {
             t.setReferenceTaskName(TaskUtils.appendIteration(t.getReferenceTaskName(), loopTask.getIteration()));
             t.setIteration(loopTask.getIteration());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -99,7 +99,7 @@ public class DoWhileTaskMapper implements TaskMapper {
         tasksToBeScheduled.add(loopTask);
         List<WorkflowTask> loopOverTasks = taskToSchedule.getLoopOver();
         List<Task> tasks2 = taskMapperContext.getDeciderService()
-                .getTasksToBeScheduled(workflowInstance, loopOverTasks.get(0), retryCount);
+                .getTasksToBeScheduled(workflowInstance, loopOverTasks.get(0), retryCount, 0);
         tasks2.stream().forEach(t -> {
             t.setReferenceTaskName(TaskUtils.appendIteration(t.getReferenceTaskName(), loopTask.getIteration()));
             t.setIteration(loopTask.getIteration());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapper.java
@@ -63,6 +63,7 @@ public class DynamicTaskMapper implements TaskMapper {
         Map<String, Object> taskInput = taskMapperContext.getTaskInput();
         Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
         int retryCount = taskMapperContext.getRetryCount();
+        int iterationCount = taskMapperContext.getIterationCount();
         String retriedTaskId = taskMapperContext.getRetryTaskId();
 
         String taskNameParam = taskToSchedule.getDynamicTaskNameParam();
@@ -86,6 +87,7 @@ public class DynamicTaskMapper implements TaskMapper {
         dynamicTask.setCorrelationId(workflowInstance.getCorrelationId());
         dynamicTask.setScheduledTime(System.currentTimeMillis());
         dynamicTask.setRetryCount(retryCount);
+        dynamicTask.setIterationCount(iterationCount);
         dynamicTask.setCallbackAfterSeconds(taskToSchedule.getStartDelay());
         dynamicTask.setResponseTimeoutSeconds(taskDefinition.getResponseTimeoutSeconds());
         dynamicTask.setWorkflowTask(taskToSchedule);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -114,6 +114,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
         String taskId = taskMapperContext.getTaskId();
         int retryCount = taskMapperContext.getRetryCount();
+        int iterationCount = taskMapperContext.getIterationCount();
 
         List<Task> mappedTasks = new LinkedList<>();
         //Get the list of dynamic tasks and the input for the tasks
@@ -134,7 +135,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         //Add each dynamic task to the mapped tasks and also get the last dynamic task in the list,
         // which indicates that the following task after that needs to be a join task
         for (WorkflowTask wft : dynForkTasks) {//TODO this is a cyclic dependency, break it out using function composition
-            List<Task> forkedTasks = taskMapperContext.getDeciderService().getTasksToBeScheduled(workflowInstance, wft, retryCount);
+            List<Task> forkedTasks = taskMapperContext.getDeciderService().getTasksToBeScheduled(workflowInstance, wft, retryCount, iterationCount);
             for (Task forkedTask : forkedTasks) {
                 Map<String, Object> forkedTaskInput = tasksInput.get(forkedTask.getReferenceTaskName());
                 forkedTask.getInputData().putAll(forkedTaskInput);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
@@ -62,7 +62,7 @@ public class ForkJoinTaskMapper implements TaskMapper {
         Map<String, Object> taskInput = taskMapperContext.getTaskInput();
         Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
         int retryCount = taskMapperContext.getRetryCount();
-
+        int iterationCount = taskMapperContext.getIterationCount();
         String taskId = taskMapperContext.getTaskId();
 
         List<Task> tasksToBeScheduled = new LinkedList<>();
@@ -80,13 +80,15 @@ public class ForkJoinTaskMapper implements TaskMapper {
         forkTask.setStatus(Task.Status.COMPLETED);
         forkTask.setWorkflowPriority(workflowInstance.getPriority());
         forkTask.setWorkflowTask(taskToSchedule);
+        forkTask.setRetryCount(retryCount);
+        forkTask.setIterationCount(iterationCount);
 
         tasksToBeScheduled.add(forkTask);
         List<List<WorkflowTask>> forkTasks = taskToSchedule.getForkTasks();
         for (List<WorkflowTask> wfts : forkTasks) {
             WorkflowTask wft = wfts.get(0);
             List<Task> tasks2 = taskMapperContext.getDeciderService()
-                    .getTasksToBeScheduled(workflowInstance, wft, retryCount);
+                    .getTasksToBeScheduled(workflowInstance, wft, retryCount, iterationCount);
             tasksToBeScheduled.addAll(tasks2);
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/GotoTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/GotoTaskMapper.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.conductor.core.execution.mapper;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.events.ScriptEvaluator;
+import com.netflix.conductor.core.execution.SystemTaskType;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.script.ScriptException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link TaskType#GOTO}
+ * to a List {@link Task} starting with Task of type {@link SystemTaskType#GOTO} which is marked as IN_PROGRESS,
+ * followed by the list of {@link Task} based on the case expression evaluation in the Decision task.
+ */
+public class GotoTaskMapper implements TaskMapper {
+
+    Logger logger = LoggerFactory.getLogger(GotoTaskMapper.class);
+
+    /**
+     * This method gets the list of tasks that need to scheduled when the the task to scheduled is of type {@link TaskType#DECISION}.
+     *
+     * @param taskMapperContext: A wrapper class containing the {@link WorkflowTask}, {@link WorkflowDef}, {@link Workflow} and a string representation of the TaskId
+     * @return List of tasks in the following order:
+     * <ul>
+     * <li>
+     * {@link SystemTaskType#GOTO} with {@link Task.Status#IN_PROGRESS}
+     * </li>
+     * <li>
+     * List of task based on the evaluation of {@link WorkflowTask#getGotoTask()} are scheduled.
+     * </li>
+     * </ul>
+     */
+    @Override
+    public List<Task> getMappedTasks(TaskMapperContext taskMapperContext) {
+    	
+        logger.debug("TaskMapperContext {} in GotoTaskMapper", taskMapperContext);
+        List<Task> tasksToBeScheduled = new LinkedList<>();
+        WorkflowTask taskToSchedule = taskMapperContext.getTaskToSchedule();
+        Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
+        Map<String, Object> taskInput = taskMapperContext.getTaskInput();
+        int retryCount = taskMapperContext.getRetryCount();
+        int iterationCount = taskMapperContext.getIterationCount();
+        String taskId = taskMapperContext.getTaskId();
+
+        Task gotoTask = new Task();
+        gotoTask.setTaskType(SystemTaskType.GOTO.name());
+        gotoTask.setTaskDefName(SystemTaskType.GOTO.name());
+        gotoTask.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
+        gotoTask.setWorkflowInstanceId(workflowInstance.getWorkflowId());
+        gotoTask.setWorkflowType(workflowInstance.getWorkflowName());
+        gotoTask.setCorrelationId(workflowInstance.getCorrelationId());
+        gotoTask.setScheduledTime(System.currentTimeMillis());
+        gotoTask.setInputData(taskInput);
+        gotoTask.setTaskId(taskId);
+        gotoTask.setRetryCount(retryCount);
+        gotoTask.setStatus(Task.Status.IN_PROGRESS);
+        gotoTask.setWorkflowTask(taskToSchedule);
+        gotoTask.setIterationCount(iterationCount);
+        tasksToBeScheduled.add(gotoTask);
+        
+        
+        // get the next task to be executed from goto task
+    	    WorkflowTask nextWorkflowTask = workflowInstance.getWorkflowDefinition().getTaskByRefName(taskToSchedule.getGotoTask());
+    	    
+    	    //get the current iterationCount of next task to be executed if it is already executed.
+    	    Task nextTask = workflowInstance.getTaskByRefName(nextWorkflowTask.getTaskReferenceName());
+    	    int nextTaskIterationCount = 0;
+    	    
+    	    if(nextTask != null)
+    	    {
+    	    		nextTaskIterationCount = nextTask.getIterationCount() + 1;
+    	    }
+    	    
+    	    
+        List<Task> nextTasks = taskMapperContext.getDeciderService().getTasksToBeScheduled(workflowInstance, nextWorkflowTask, retryCount, taskMapperContext.getRetryTaskId(), nextTaskIterationCount); //get next task to be scheduled with iterationCount incremented by one
+    		
+        if(!nextTasks.isEmpty()) { 
+        	
+    			Map<String, Object> gotoTaskInputMap = gotoTask.getInputData();
+    			if(gotoTaskInputMap != null) {
+    				replaceNextTasksInputWithGotoTaskInput(gotoTaskInputMap, nextTasks); // update next task's input with GOTO task's input if they have same input key
+    			}
+    			
+    			tasksToBeScheduled.addAll(nextTasks);
+        }
+            
+        return tasksToBeScheduled;
+    }
+    
+    
+	private void replaceNextTasksInputWithGotoTaskInput(Map<String, Object> gotoTaskInputMap, List<Task> nextTasks) {
+		if (gotoTaskInputMap.size() == 0) {
+			return;
+		}
+
+		for (Map.Entry<String, Object> entry : gotoTaskInputMap.entrySet()) {
+			String keyToSearch = entry.getKey();
+			Object valueToReplace = entry.getValue();
+
+			for (Task t : nextTasks) {
+				Map<String, Object> taskInputMap = t.getInputData();
+				if (taskInputMap.containsKey(keyToSearch)) {
+					taskInputMap.replace(keyToSearch, valueToReplace);
+				}
+			}
+
+		}
+
+	}
+
+  
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
@@ -67,6 +67,7 @@
          Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
          String taskId = taskMapperContext.getTaskId();
          int retryCount = taskMapperContext.getRetryCount();
+         int iterationCount = taskMapperContext.getIterationCount();
 
          TaskDef taskDefinition = Optional.ofNullable(taskMapperContext.getTaskDefinition())
                  .orElseGet(() -> Optional.ofNullable(metadataDAO.getTaskDef(taskToSchedule.getName()))
@@ -88,6 +89,7 @@
          httpTask.getInputData().put("asyncComplete", asynComplete);
          httpTask.setStatus(Task.Status.SCHEDULED);
          httpTask.setRetryCount(retryCount);
+         httpTask.setIterationCount(iterationCount);
          httpTask.setCallbackAfterSeconds(taskToSchedule.getStartDelay());
          httpTask.setWorkflowTask(taskToSchedule);
          httpTask.setWorkflowPriority(workflowInstance.getPriority());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -64,6 +64,7 @@ public class SimpleTaskMapper implements TaskMapper {
         WorkflowTask taskToSchedule = taskMapperContext.getTaskToSchedule();
         Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
         int retryCount = taskMapperContext.getRetryCount();
+        int iterationCount = taskMapperContext.getIterationCount();
         String retriedTaskId = taskMapperContext.getRetryTaskId();
 
         TaskDef taskDefinition = Optional.ofNullable(taskToSchedule.getTaskDefinition())
@@ -86,6 +87,7 @@ public class SimpleTaskMapper implements TaskMapper {
         simpleTask.setCorrelationId(workflowInstance.getCorrelationId());
         simpleTask.setScheduledTime(System.currentTimeMillis());
         simpleTask.setRetryCount(retryCount);
+        simpleTask.setIterationCount(iterationCount);
         simpleTask.setCallbackAfterSeconds(taskToSchedule.getStartDelay());
         simpleTask.setResponseTimeoutSeconds(taskDefinition.getResponseTimeoutSeconds());
         simpleTask.setWorkflowTask(taskToSchedule);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapperContext.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapperContext.java
@@ -34,6 +34,7 @@ public class TaskMapperContext {
     private WorkflowTask taskToSchedule;
     private Map<String, Object> taskInput;
     private int retryCount;
+    private int iterationCount;
     private String retryTaskId;
     private String taskId;
     private DeciderService deciderService;
@@ -44,6 +45,7 @@ public class TaskMapperContext {
         taskToSchedule = builder.taskToSchedule;
         taskInput = builder.taskInput;
         retryCount = builder.retryCount;
+        iterationCount = builder.iterationCount;
         retryTaskId = builder.retryTaskId;
         taskId = builder.taskId;
         deciderService = builder.deciderService;
@@ -61,6 +63,7 @@ public class TaskMapperContext {
         builder.taskToSchedule = copy.getTaskToSchedule();
         builder.taskInput = copy.getTaskInput();
         builder.retryCount = copy.getRetryCount();
+        builder.iterationCount = copy.getIterationCount();
         builder.retryTaskId = copy.getRetryTaskId();
         builder.taskId = copy.getTaskId();
         builder.deciderService = copy.getDeciderService();
@@ -85,6 +88,10 @@ public class TaskMapperContext {
 
     public int getRetryCount() {
         return retryCount;
+    }
+    
+    public int getIterationCount() {
+        return iterationCount;
     }
 
     public String getRetryTaskId() {
@@ -112,6 +119,7 @@ public class TaskMapperContext {
                 ", taskToSchedule=" + taskToSchedule +
                 ", taskInput=" + taskInput +
                 ", retryCount=" + retryCount +
+                ", iterationCount=" + iterationCount +
                 ", retryTaskId='" + retryTaskId + '\'' +
                 ", taskId='" + taskId + '\'' +
                 '}';
@@ -125,6 +133,7 @@ public class TaskMapperContext {
         TaskMapperContext that = (TaskMapperContext) o;
 
         if (getRetryCount() != that.getRetryCount()) return false;
+        if (getIterationCount() != that.getIterationCount()) return false;
         if (!getWorkflowDefinition().equals(that.getWorkflowDefinition())) return false;
         if (!getWorkflowInstance().equals(that.getWorkflowInstance())) return false;
         if (!getTaskToSchedule().equals(that.getTaskToSchedule())) return false;
@@ -141,6 +150,7 @@ public class TaskMapperContext {
         result = 31 * result + getTaskToSchedule().hashCode();
         result = 31 * result + getTaskInput().hashCode();
         result = 31 * result + getRetryCount();
+        result = 31 * result + getIterationCount();
         result = 31 * result + (getRetryTaskId() != null ? getRetryTaskId().hashCode() : 0);
         result = 31 * result + getTaskId().hashCode();
         return result;
@@ -157,6 +167,7 @@ public class TaskMapperContext {
         private WorkflowTask taskToSchedule;
         private Map<String, Object> taskInput;
         private int retryCount;
+        private int iterationCount;
         private String retryTaskId;
         private String taskId;
         private DeciderService deciderService;
@@ -229,7 +240,17 @@ public class TaskMapperContext {
             retryCount = val;
             return this;
         }
-
+        
+        /**
+         * Sets the {@code iterationCount} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param val the {@code iterationCount} to set
+         * @return a reference to this Builder
+         */
+        public Builder withIterationCount(int val) {
+            iterationCount = val;
+            return this;
+        }
         /**
          * Sets the {@code retryTaskId} and returns a reference to this Builder so that the methods can be chained together.
          *

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Goto.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Goto.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.execution.tasks;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+
+/**
+ * @author Shivam
+ *
+ */
+public class Goto extends WorkflowSystemTask {
+	
+	public Goto() {
+		super("GOTO");
+	}
+	
+	@Override
+	public boolean execute(Workflow workflow, Task task, WorkflowExecutor provider) {
+		task.setStatus(Status.COMPLETED);
+		return true;
+	}
+}

--- a/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
+++ b/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
@@ -79,6 +79,9 @@ public @interface WorkflowTaskTypeConstraint {
                 case TaskType.TASK_TYPE_DO_WHILE:
                     valid = isDoWhileTaskValid(workflowTask, context);
                     break;
+				case TaskType.TASK_TYPE_GOTO:
+                    valid = isGotoTaskValid(workflowTask, context);
+                    break; 
             }
 
             return valid;
@@ -253,6 +256,18 @@ public @interface WorkflowTaskTypeConstraint {
                 valid = false;
             }
 
+            return valid;
+        }
+		
+		 private boolean isGotoTaskValid(WorkflowTask workflowTask, ConstraintValidatorContext context) {
+            boolean valid = true;
+
+	        if (workflowTask.getGotoTask() == null || workflowTask.getGotoTask().trim().isEmpty()) {
+                String message = String.format("gotoTask should have a task reference name for taskType: %s taskName: %s", TaskType.GOTO, workflowTask.getName());
+                context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+                valid = false;
+	        }
+            	 
             return valid;
         }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -755,7 +755,7 @@ public class TestDeciderService {
         workflowTask1.setType(TaskType.SIMPLE.name());
         workflowTask1.setTaskDefinition(new TaskDef("s1"));
 
-        List<Task> tasksToBeScheduled = deciderService.getTasksToBeScheduled(workflow, workflowTask1, 0, null);
+        List<Task> tasksToBeScheduled = deciderService.getTasksToBeScheduled(workflow, workflowTask1, 0, null, 0);
         assertNotNull(tasksToBeScheduled);
         assertEquals(1, tasksToBeScheduled.size());
         assertEquals("s1", tasksToBeScheduled.get(0).getReferenceTaskName());
@@ -765,7 +765,7 @@ public class TestDeciderService {
         workflowTask2.setTaskReferenceName("s2");
         workflowTask2.setType(TaskType.SIMPLE.name());
         workflowTask2.setTaskDefinition(new TaskDef("s2"));
-        tasksToBeScheduled = deciderService.getTasksToBeScheduled(workflow, workflowTask2, 0, null);
+        tasksToBeScheduled = deciderService.getTasksToBeScheduled(workflow, workflowTask2, 0, null, 0);
         assertNotNull(tasksToBeScheduled);
         assertEquals(1, tasksToBeScheduled.size());
         assertEquals("s2", tasksToBeScheduled.get(0).getReferenceTaskName());

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
@@ -114,7 +114,7 @@ public class DecisionTaskMapperTest {
         theTask.setReferenceTaskName("Foo");
         theTask.setTaskId(IDGenerator.generate());
 
-        when(deciderService.getTasksToBeScheduled(workflowInstance, task2, 0, null))
+        when(deciderService.getTasksToBeScheduled(workflowInstance, task2, 0, null, 0))
                 .thenReturn(Arrays.asList(theTask));
 
         TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
@@ -75,7 +75,7 @@ public class DoWhileTaskMapperTest {
     @Test
     public void getMappedTasks() {
 
-        Mockito.doReturn(Arrays.asList(task1)).when(deciderService).getTasksToBeScheduled(workflow, workflowTask1, 0);
+        Mockito.doReturn(Arrays.asList(task1)).when(deciderService).getTasksToBeScheduled(workflow, workflowTask1, 0, 0);
 
         List<Task> mappedTasks = new DoWhileTaskMapper(metadataDAO).getMappedTasks(taskMapperContext);
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
@@ -118,8 +118,8 @@ public class ForkJoinDynamicTaskMapperTest {
         Task simpleTask2 = new Task();
         simpleTask2.setReferenceTaskName("xdt2");
 
-        when(deciderService.getTasksToBeScheduled(workflowInstance, wt2, 0 )).thenReturn(Arrays.asList(simpleTask1));
-        when(deciderService.getTasksToBeScheduled(workflowInstance, wt3, 0 )).thenReturn(Arrays.asList(simpleTask2));
+        when(deciderService.getTasksToBeScheduled(workflowInstance, wt2, 0, 0 )).thenReturn(Arrays.asList(simpleTask1));
+        when(deciderService.getTasksToBeScheduled(workflowInstance, wt3, 0, 0 )).thenReturn(Arrays.asList(simpleTask2));
 
         String taskId = IDGenerator.generate();
 
@@ -197,8 +197,8 @@ public class ForkJoinDynamicTaskMapperTest {
         Task simpleTask2 = new Task();
         simpleTask2.setReferenceTaskName("xdt2");
 
-        when(deciderService.getTasksToBeScheduled(workflowInstance, wt2, 0 )).thenReturn(Arrays.asList(simpleTask1));
-        when(deciderService.getTasksToBeScheduled(workflowInstance, wt3, 0 )).thenReturn(Arrays.asList(simpleTask2));
+        when(deciderService.getTasksToBeScheduled(workflowInstance, wt2, 0, 0)).thenReturn(Arrays.asList(simpleTask1));
+        when(deciderService.getTasksToBeScheduled(workflowInstance, wt3, 0, 0)).thenReturn(Arrays.asList(simpleTask2));
 
         String taskId = IDGenerator.generate();
         TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapperTest.java
@@ -97,8 +97,8 @@ public class ForkJoinTaskMapperTest {
         Task task3 = new Task();
         task3.setReferenceTaskName(wft3.getTaskReferenceName());
 
-        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1,0)).thenReturn(Arrays.asList(task1));
-        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2,0)).thenReturn(Arrays.asList(task3));
+        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1, 0, 0)).thenReturn(Arrays.asList(task1));
+        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2, 0, 0)).thenReturn(Arrays.asList(task3));
 
         String taskId = IDGenerator.generate();
         TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
@@ -177,8 +177,8 @@ public class ForkJoinTaskMapperTest {
         Task task3 = new Task();
         task3.setReferenceTaskName(wft3.getTaskReferenceName());
 
-        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1,0)).thenReturn(Arrays.asList(task1));
-        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2,0)).thenReturn(Arrays.asList(task3));
+        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1, 0, 0)).thenReturn(Arrays.asList(task1));
+        Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2, 0, 0)).thenReturn(Arrays.asList(task3));
 
         String taskId = IDGenerator.generate();
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/GotoTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/GotoTaskMapperTest.java
@@ -1,0 +1,109 @@
+package com.netflix.conductor.core.execution.mapper;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.DeciderService;
+import com.netflix.conductor.core.execution.SystemTaskType;
+import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import com.netflix.conductor.core.utils.IDGenerator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class GotoTaskMapperTest {
+
+	private DeciderService deciderService;
+
+	private GotoTaskMapper gotoTaskMapper;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Before
+	public void setUp() throws Exception {
+		deciderService = Mockito.mock(DeciderService.class);
+		gotoTaskMapper = new GotoTaskMapper();
+	}
+
+	@Test
+	public void getMappedTasks() throws Exception {
+
+		WorkflowDef def = new WorkflowDef();
+		def.setName("GOTO_WF");
+		def.setDescription(def.getName());
+		def.setVersion(1);
+		def.setInputParameters(Arrays.asList("param1", "param2"));
+
+		WorkflowTask wft1 = new WorkflowTask();
+		wft1.setName("junit_task_1");
+		Map<String, Object> ip1 = new HashMap<>();
+		ip1.put("p1", "workflow.input.param1");
+		ip1.put("p2", "workflow.input.param2");
+		wft1.setInputParameters(ip1);
+		wft1.setTaskReferenceName("t1");
+
+		WorkflowTask wft2 = new WorkflowTask();
+		wft2.setName("junit_task_2");
+		wft2.setInputParameters(ip1);
+		wft2.setTaskReferenceName("t2");
+		wft2.setInputParameters(ip1);
+
+		WorkflowTask wGotoTask = new WorkflowTask();
+		Map<String, Object> ip2 = new HashMap<>();
+		ip2.put("p1", "workflow.input.param1_newvalue");
+		wGotoTask.setInputParameters(ip2);
+		wGotoTask.setType(TaskType.GOTO.name());
+		wGotoTask.setName("gototask");
+		wGotoTask.setTaskReferenceName("junit_gototask");
+		wGotoTask.setGotoTask("t1");
+
+		List<WorkflowTask> wTaskList = Arrays.asList(wft1, wft2, wGotoTask);
+		def.getTasks().addAll(wTaskList);
+
+		Workflow workflow = new Workflow();
+		workflow.setWorkflowDefinition(def);
+
+		Task task1 = new Task();
+		task1.setReferenceTaskName(wft1.getTaskReferenceName());
+		task1.setInputData(wft1.getInputParameters());
+
+		Task task2 = new Task();
+		task2.setReferenceTaskName(wft2.getTaskReferenceName());
+		task2.setInputData(wft2.getInputParameters());
+
+		Task gotoTask = new Task();
+		gotoTask.setReferenceTaskName(wGotoTask.getTaskReferenceName());
+		gotoTask.setInputData(wGotoTask.getInputParameters());
+
+		Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1, 0, 0)).thenReturn(Arrays.asList(task1));
+		Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2, 0, 0)).thenReturn(Arrays.asList(task2));
+		Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1, 0, null, 0)).thenReturn(Arrays.asList(task1));
+		Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft1, 0, null, 1)).thenReturn(Arrays.asList(task1));
+        
+
+		String taskId = IDGenerator.generate();
+		TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder().withWorkflowDefinition(def)
+				.withWorkflowInstance(workflow).withTaskToSchedule(wGotoTask).withRetryCount(0).withTaskInput(ip2)
+				.withIterationCount(0).withTaskId(taskId).withDeciderService(deciderService).build();
+
+		List<Task> mappedTasks = gotoTaskMapper.getMappedTasks(taskMapperContext);
+        
+		assertEquals(2, mappedTasks.size());
+		assertEquals(wft1.getTaskReferenceName(), mappedTasks.get(1).getReferenceTaskName());
+		assertEquals(mappedTasks.get(1).getInputData().get("p1"), "workflow.input.param1_newvalue");
+
+	}
+
+}

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -645,6 +645,54 @@ public class WorkflowTaskTypeConstraintTest {
         assertEquals(0, result.size());
     }
 
+    @Test
+    public void testWorkflowTaskTypeGoto() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("GOTO");
+        workflowTask.setGotoTask("testTask");
+
+        ConstraintMapping mapping = config.createConstraintMapping();
+
+        mapping.type(WorkflowTask.class)
+                .constraint(new WorkflowTaskTypeConstraintDef());
+
+        Validator validator = config.addMapping(mapping)
+                .buildValidatorFactory()
+                .getValidator();
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(0, result.size());
+    }
+    
+    @Test
+    public void testWorkflowTaskTypeGotoWithGotoTaskMissing() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("GOTO");
+        
+
+        ConstraintMapping mapping = config.createConstraintMapping();
+
+        mapping.type(WorkflowTask.class)
+                .constraint(new WorkflowTaskTypeConstraintDef());
+
+        Validator validator = config.addMapping(mapping)
+                .buildValidatorFactory()
+                .getValidator();
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(1, result.size());
+
+        List<String> validationErrors = new ArrayList<>();
+
+        result.forEach(e -> validationErrors.add(e.getMessage()));
+
+        assertTrue(validationErrors.contains("gotoTask should have a task reference name for taskType: GOTO taskName: encode"));
+    }
+	
     private List<String> getErrorMessages(WorkflowTask workflowTask) {
         Set<ConstraintViolation<WorkflowTask>> result = buildValidator().validate(workflowTask);
         List<String> validationErrors = new ArrayList<>();
@@ -661,6 +709,8 @@ public class WorkflowTaskTypeConstraintTest {
                 .buildValidatorFactory()
                 .getValidator();
     }
+
+
 
     private WorkflowTask createSampleWorkflowTask() {
         WorkflowTask workflowTask = new WorkflowTask();

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -619,3 +619,33 @@ Do while task does NOT support domain or isolation group execution.
 ```
 If any of loopover task will be failed then do while task will be failed. In such case retry will start iteration from 1. TaskType SUB_WORKFLOW is not supported as a part of loopover task. Since loopover tasks will be executed in loop inside scope of parent do while task, crossing branching outside of DO_WHILE task will not be respected. Branching inside loopover task will be supported.
 In case of exception while evaluating loopCondition, do while task will be failed with FAILED_WITH_TERMINAL_ERROR.
+
+
+# Goto Task
+
+Goto task is used to take the workflow execution to a previously executed task with a new iteration count of such task. Goto task is similar to programming language construct of Goto. It can be used in different BPMN (Business Process Model and Notation) workflows where based on a task's output, workflow could decide whether it should run a new task or run a previously executed task.
+
+### Parameters:
+|name|description|
+|---|---|
+| gotoTask | Task reference name of the previously executed task. It should be it should be in same branch of execution. 
+
+### Example
+
+``` json
+{
+   "name": "t2,
+   "taskReferenceName": "t2",
+   "inputParameters": {
+     "param1": "newValue"
+   },
+   "type": "GOTO",
+   "gotoTask": "t1"
+ } 
+```
+When executed, it will take the execution to t1. If task t1 has input field ``param1``, it's value will be replaced by ``newValue``.
+
+!!!warning
+ Use it only for task executed in the same branch(thread) of execution.
+
+

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -557,6 +557,7 @@ public abstract class AbstractProtoMapper {
             to.setIsolationGroupId( from.getIsolationGroupId() );
         }
         to.setIteration( from.getIteration() );
+        to.setIterationCount( from.getIterationCount() );
         return to.build();
     }
 
@@ -614,6 +615,7 @@ public abstract class AbstractProtoMapper {
         to.setExecutionNameSpace( from.getExecutionNameSpace() );
         to.setIsolationGroupId( from.getIsolationGroupId() );
         to.setIteration( from.getIteration() );
+        to.setIterationCount( from.getIterationCount() );
         return to;
     }
 
@@ -1210,6 +1212,9 @@ public abstract class AbstractProtoMapper {
         for (WorkflowTask elem : from.getLoopOver()) {
             to.addLoopOver( toProto(elem) );
         }
+        if (from.getGotoTask() != null) {
+            to.setGotoTask( from.getGotoTask() );
+        }
         return to.build();
     }
 
@@ -1252,6 +1257,7 @@ public abstract class AbstractProtoMapper {
         to.setAsyncComplete( from.getAsyncComplete() );
         to.setLoopCondition( from.getLoopCondition() );
         to.setLoopOver( from.getLoopOverList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
+        to.setGotoTask( from.getGotoTask() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/task.proto
+++ b/grpc/src/main/proto/model/task.proto
@@ -59,4 +59,5 @@ message Task {
     string execution_name_space = 37;
     string isolation_group_id = 38;
     int32 iteration = 40;
+    int32 iteration_count = 41;
 }

--- a/grpc/src/main/proto/model/workflowtask.proto
+++ b/grpc/src/main/proto/model/workflowtask.proto
@@ -38,4 +38,5 @@ message WorkflowTask {
     bool async_complete = 23;
     string loop_condition = 24;
     repeated WorkflowTask loop_over = 25;
+    string goto_task = 26;
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -97,7 +97,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO {
     }
 
     private static String taskKey(Task task) {
-        return task.getReferenceTaskName() + "_" + task.getRetryCount();
+        return task.getReferenceTaskName()  + "_" + task.getRetryCount() + "_" + task.getIterationCount();
     }
 
     @Override

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -127,7 +127,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 
 			recordRedisDaoRequests("createTask", task.getTaskType(), task.getWorkflowType());
 
-			String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
+			String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount() + "" + task.getIterationCount();
 			Long added = dynoClient.hset(nsKey(SCHEDULED_TASKS, task.getWorkflowInstanceId()), taskKey, task.getTaskId());
 			if (added < 1) {
 				logger.debug("Task already scheduled, skipping the run " + task.getTaskId() + ", ref=" + task.getReferenceTaskName() + ", key=" + taskKey);
@@ -294,7 +294,7 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 			logger.warn("No such task found by id {}", taskId);
 			return false;
 		}
-		String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
+		String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount() + "" + task.getIterationCount();
 
 		dynoClient.hdel(nsKey(SCHEDULED_TASKS, task.getWorkflowInstanceId()), taskKey);
 		dynoClient.srem(nsKey(IN_PROGRESS_TASKS, task.getTaskDefName()), task.getTaskId());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractEndToEndTest.java
@@ -117,6 +117,7 @@ public abstract class AbstractEndToEndTest {
         workflowTask.setDynamicForkTasksParam(DEFAULT_NULL_VALUE);
         workflowTask.setDynamicForkTasksInputParamName(DEFAULT_NULL_VALUE);
         workflowTask.setSink(DEFAULT_NULL_VALUE);
+        workflowTask.setGotoTask(DEFAULT_NULL_VALUE);
         return workflowTask;
     }
 


### PR DESCRIPTION
Hi @apanicker-nflx , 
                              Here is the pull request for GOTO task.  The major change is in the way "task_key" was treated earlier in database. Earlier it used to be a combination of "task_ref" and "retry_count", and now it is a combination of "task_ref", "retry_count" and "iteration_count" as a task can now run multiple times  with a different iteration_count. We can understand it better with the help of an example. 



Ex: Sample "GOTO" task:
 ```  
   {
    "name": "gotoLereview",
    "taskReferenceName": "gotoLereview",
    "inputParameters": {
      "fileName": "${MrReview.output.reviewFileName}"
    },
    "type": "GOTO",
    "gotoTask": "t1"
  } 
```
This "GOTO" construct is very similar to what we have in programming languages.  The "GOTO" task would take a task reference t1 where it would take the workflow execution. Task t1 will be created again with new task id. Data-passing from "GOTO" task to the previously executed task t1 will work with superimposed new input i.e. whatever input parameters in t1 matches with input parameters of GOTO, will be replaced with GOTO task's input.

Following is the sample two stage review workflow schema which uses "GOTO" construct:
   
  
```
{
  "name": "TwoStageReviewWithGoto",
  "description": "sample review workflow using GOTO",
  "version": 1,
  "tasks": [
    {
      "name": "review",
      "description": "legal review task",
      "taskReferenceName": "LeReview",
      "inputParameters": {
        "fileName": "${Workflow.input.reviewFileName}"
      },
      "type": "SIMPLE"
    },
    {
      "name": "review",
      "taskReferenceName": "MRreview",
      "description": "marketing review task",
      "inputParameters": {
        "fileName": "${LeReview.output.reviewFileName}"
      },
      "type": "SIMPLE"
    },
    {
      "name": "gotoDecision",
      "taskReferenceName": "gotoDecision",
      "inputParameters": {
        "reviewAccepted": "{MrReview.output.reviewRejected}"
      },
      "type": "DECISION",
      "caseValueParam": "reviewRejected",
      "decisionCases": {
        "1": [
          {
            "name": "gotoLereview",
            "taskReferenceName": "gotoLereview",
            "inputParameters": {
              "fileName": "${MrReview.output.reviewFileName}"
            },
            "type": "GOTO",
            "gotoTask": "LeReview"
          }
        ]
      }
    },
    {
      "name": "search_elasticsearch",
      "taskReferenceName": "get_es_1",
      "type": "HTTP",
      "inputParameters": {
        "http_request": {
          "uri": "http://localhost:9200/conductor/_search?size=10",
          "method": "GET"
        }
      }
    }
  ],
  "outputParameters": {
    "workflowIds": "${get_es_1.output..workflowId}",
    "status": "${get_es_1.output..status}"
  },
  "schemaVersion": 2
}
```

**Explanation:** A review file is taken as workflow input. The first task is a legal review (LeReview) which starts legal review. Then it's output file is shared for marketing review (MrReview). The MRreview task will generate output "reviewRejected" and based on it's value, workflow can either continue or it can go to previously executed task "LeReview". The "GOTO" task has an input parameter "fileName" which matches with "LeReview" task's input parameter "fileName", so it will superimpose value of "fileName" with the earlier one. This approach simplifies passing data to earlier executed task. 