### PR TITLE
Fix and enhance build script

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,4 +36,6 @@ task protogen(dependsOn: jar, type: ProtoGenTask) {
 
     sourceJar = jar.archivePath
     sourcePackage = "com.netflix.conductor.common"
+    outputs.dir protosDir
+    outputs.dir mapperDir
 }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -36,6 +36,7 @@ protobuf {
         }
     }
     generateProtoTasks {
+        processResources.dependsOn extractProto
         all()*.plugins {
             grpc {}
         }


### PR DESCRIPTION
Hello

This commit fixes and enhances build script. Specifically, it first fixes an ordering violation between tasks `processResources` and `extractProto`. If `extractRepo` is applied before `processResouces`, the generated `proto` files are not copied into the build directory.

This is the diff of missing resources inside the build directory.

```
< resources/main/google
< resources/main/google/protobuf
< resources/main/google/protobuf/api.proto
< resources/main/google/protobuf/empty.proto
< resources/main/google/protobuf/type.proto
< resources/main/google/protobuf/compiler
< resources/main/google/protobuf/compiler/plugin.proto
< resources/main/google/protobuf/timestamp.proto
< resources/main/google/protobuf/wrappers.proto
< resources/main/google/protobuf/struct.proto
< resources/main/google/protobuf/source_context.proto
< resources/main/google/protobuf/field_mask.proto
< resources/main/google/protobuf/any.proto
< resources/main/google/protobuf/descriptor.proto
< resources/main/google/protobuf/duration.proto
183,185d167
< resources/main/grpc/health
< resources/main/grpc/health/v1
< resources/main/grpc/health/v1/health.proto
```

This commit also makes the task `protogen` incremental