### PR TITLE
Fix for MySQL unique_event_execution index bug

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
@@ -1,0 +1,14 @@
+# Drop the 'unique_event_execution' index if it exists
+SET @exist := (SELECT COUNT(INDEX_NAME)
+               FROM information_schema.STATISTICS
+               WHERE `TABLE_NAME` = 'event_execution'
+                 AND `INDEX_NAME` = 'unique_event_execution'
+                 AND TABLE_SCHEMA = database());
+SET @sqlstmt := IF(@exist > 0, 'ALTER TABLE `event_execution` DROP INDEX `unique_event_execution`',
+                   'SELECT ''INFO: Index already exists.''');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+# Create the 'unique_event_execution' index with execution_id column instead of 'message_id' so events can be executed multiple times.
+ALTER TABLE `event_execution`
+    ADD CONSTRAINT `unique_event_execution` UNIQUE (event_handler_name, event_name, execution_id);


### PR DESCRIPTION
Fix for #1009 change unique_event_execution index
- Conditionally drop the `unique_event_execution` index if it exists (it should)
- Add a new `unique_event_execution` constraint using `execution_id` instead of `message_id`

The old index used `event_handler_name`, `event_name`, and `message_id` for uniqueness. The `message_id` part of the constraint causes issues with events that require multiple executions. `message_id` was swapped for `execution_id` for this case.
