### PR TITLE
reset workflow upon restarts

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -488,8 +488,9 @@ public class WorkflowExecutor {
             throw new ApplicationException(CONFLICT, String.format("Workflow: %s is non-restartable", workflow));
         }
 
-        // Remove the workflow from the primary datastore (archive in indexer) and re-create it
-        executionDAOFacade.removeWorkflow(workflowId, true);
+        // Reset the workflow in the primary datastore and archive in indexer; then re-create it
+        executionDAOFacade.resetWorkflow(workflowId);
+
         workflow.getTasks().clear();
         workflow.setReasonForIncompletion(null);
         workflow.setStartTime(System.currentTimeMillis());

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -195,7 +195,7 @@ public class Monitors {
 	}
 
 	public static void recordTaskPendingTime(String taskType, String workflowType, long duration) {
-		getTimer(classQualifier, "task_pending_time", "workflowName", workflowType, "taskType", taskType).record(duration, TimeUnit.MILLISECONDS);
+		gauge(classQualifier, "task_pending_time", duration, "workflowName", workflowType, "taskType", taskType);
 	}
 
 	public static void recordWorkflowTermination(String workflowType, WorkflowStatus status, String ownerApp) {


### PR DESCRIPTION
- Added a method `resetWorkflow` to ExecutionDAOFacade to allow asynchronously archiving workflow during restarts.
- Changed `task_pending_time` metric to a gauge.