### PR TITLE
fix issue #1371: inputTemplate value not override by custom value.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
@@ -70,7 +70,11 @@ public class ParametersUtils {
             inputParams = new HashMap<>();
         }
         if (taskDefinition != null && taskDefinition.getInputTemplate() != null) {
-            inputParams.putAll(clone(taskDefinition.getInputTemplate()));
+            taskDefinition.getInputTemplate().forEach((k, v) -> {
+                if (!workflow.getInput().containsKey(k)) {
+                    inputParams.put(k, v);
+                }
+            });
         }
 
         Map<String, Map<String, Object>> inputMap = new HashMap<>();


### PR DESCRIPTION
the inputTemplate's default values can be overridden by values provided in Workflow now.