### PR TITLE
postgres port of fix for #1009, modify unique_event_execution index

### DIFF
--- a/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS unique_event_execution;
+
+CREATE UNIQUE INDEX unique_event_execution ON event_execution (event_handler_name,event_name,execution_id);


### PR DESCRIPTION
This PR adds a postgres migration that modifies the unique_event_execution index to use execution_id instead of message_id for uniqueness. See #1099 and PR #1386 .