### PR TITLE
Support IAM authentication with elasticsearch 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ allprojects {
         maven {
             url "https://dl.bintray.com/netflixoss/oss-candidate"
         }
+        maven {
+            url "https://repository.mulesoft.org/nexus/content/repositories/public/"
+        }
     }
 }
 

--- a/es6-persistence/README.md
+++ b/es6-persistence/README.md
@@ -42,6 +42,8 @@ Default is `MEMORY`.
 * `workflow.elasticsearch.url` - A comma separated list of schema/host/port of the ES nodes to communicate with.
 Schema can be ignored when using `tcp` transport; otherwise, you must specify `http` or `https`.
 If using the `http` or `https`, then conductor will use the REST transport protocol.
+* `workflow.elasticsearch.aws.identity.request.signing.enabled` - Indicates the ES instance is an AWS instance using IAM-based authentication that requires HTTP request signing.
+Defaults to `false`. 
 * `workflow.elasticsearch.index.name` - The name of the workflow and task index.
 Defaults to `conductor`
 * `workflow.elasticsearch.tasklog.index.name` - The name of the task log index.

--- a/es6-persistence/build.gradle
+++ b/es6-persistence/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     //ES6 Dependency
     compile "org.apache.logging.log4j:log4j-api:${revLog4jApi}"
     compile "org.apache.logging.log4j:log4j-core:${revLog4jCore}"
+    compile group: 'com.github.awslabs', name: 'aws-request-signing-apache-interceptor', version: 'b3772780da'
 
     testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"
     testCompile "org.awaitility:awaitility:${revAwaitility}"

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -16,6 +16,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_URL_PROPERTY_NAME = "workflow.elasticsearch.url";
     String ELASTIC_SEARCH_URL_DEFAULT_VALUE = "localhost:9300";
 
+    String AWS_IDENTITY_REQUEST_SIGNING_ENABLED_PROPERTY_NAME = "workflow.elasticsearch.aws.identity.request.signing.enabled";
+    boolean AWS_IDENTITY_REQUEST_SIGNING_ENABLED_DEFAULT_VALUE = false;
+
     String ELASTIC_SEARCH_HEALTH_COLOR_PROPERTY_NAME = "workflow.elasticsearch.cluster.health.color";
     String ELASTIC_SEARCH_HEALTH_COLOR_DEFAULT_VALUE = "green";
 
@@ -60,6 +63,10 @@ public interface ElasticSearchConfiguration extends Configuration {
 
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
+    }
+
+    default boolean isAwsIdentityRequestSigningEnabled() {
+        return getBooleanProperty(AWS_IDENTITY_REQUEST_SIGNING_ENABLED_PROPERTY_NAME, AWS_IDENTITY_REQUEST_SIGNING_ENABLED_DEFAULT_VALUE);
     }
 
     default List<URI> getURIs(){

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientBuilderProvider.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientBuilderProvider.java
@@ -1,5 +1,6 @@
 package com.netflix.conductor.elasticsearch;
 
+import com.netflix.conductor.elasticsearch.aws.AwsRequestSigningHttpClientConfigCallback;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -20,7 +21,12 @@ public class ElasticSearchRestClientBuilderProvider implements Provider<RestClie
 
     @Override
     public RestClientBuilder get() {
-        return RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+        RestClientBuilder builder = RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+        if (configuration.isAwsIdentityRequestSigningEnabled()) {
+            builder.setHttpClientConfigCallback(new AwsRequestSigningHttpClientConfigCallback(configuration));
+        }
+
+        return builder;
     }
 
     private HttpHost[] convertToHttpHosts(List<URI> hosts) {

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
@@ -1,7 +1,9 @@
 package com.netflix.conductor.elasticsearch;
 
+import com.netflix.conductor.elasticsearch.aws.AwsRequestSigningHttpClientConfigCallback;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -20,7 +22,12 @@ public class ElasticSearchRestClientProvider implements Provider<RestClient> {
 
     @Override
     public RestClient get() {
-        return RestClient.builder(convertToHttpHosts(configuration.getURIs())).build();
+        RestClientBuilder clientBuilder = RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+        if (configuration.isAwsIdentityRequestSigningEnabled()) {
+            clientBuilder.setHttpClientConfigCallback(new AwsRequestSigningHttpClientConfigCallback(configuration));
+        }
+
+        return clientBuilder.build();
     }
 
     private HttpHost[] convertToHttpHosts(List<URI> hosts) {

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/aws/AwsRequestSigningHttpClientConfigCallback.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/aws/AwsRequestSigningHttpClientConfigCallback.java
@@ -1,0 +1,38 @@
+package com.netflix.conductor.elasticsearch.aws;
+
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
+import com.netflix.conductor.elasticsearch.ElasticSearchConfiguration;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.client.RestClientBuilder;
+
+public class AwsRequestSigningHttpClientConfigCallback implements RestClientBuilder.HttpClientConfigCallback
+{
+    private static final String SERVICE_NAME = "es";
+
+    private final ElasticSearchConfiguration configuration;
+    private final HttpRequestInterceptor httpRequestInterceptor;
+
+    public AwsRequestSigningHttpClientConfigCallback(ElasticSearchConfiguration configuration)
+    {
+        this.configuration = configuration;
+        this.httpRequestInterceptor = new AWSRequestSigningApacheInterceptor(SERVICE_NAME, buildRequestSigner(), new DefaultAWSCredentialsProviderChain());
+    }
+
+    @Override
+    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder)
+    {
+        return httpClientBuilder.addInterceptorLast(httpRequestInterceptor);
+    }
+
+    private AWS4Signer buildRequestSigner()
+    {
+        AWS4Signer requestSigner = new AWS4Signer();
+        requestSigner.setServiceName(SERVICE_NAME);
+        requestSigner.setRegionName(configuration.getRegion());
+
+        return requestSigner;
+    }
+}


### PR DESCRIPTION
For AWS hosted elasticsearch instances, conductor currently only supports open IAM (e.g. no IAM).

This adds ability to allow for IAM message signing via a configuration value.  It utilizes the AWS labs interceptor to add the token for the requests.