### PR TITLE
Database persistence: connection to a redis host with SSL/TLS encryption can be opted-in

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
@@ -9,6 +9,7 @@ public interface DynomiteConfiguration extends Configuration {
 
     String CLUSTER_NAME_PROPERTY_NAME = "workflow.dynomite.cluster.name";
     String HOSTS_PROPERTY_NAME = "workflow.dynomite.cluster.hosts";
+    String SHOULD_USE_SSL_PROPERTY_NAME = "workflow.dynomite.cluster.hosts.useSSL";
 
     String MAX_CONNECTIONS_PER_HOST_PROPERTY_NAME = "workflow.dynomite.connection.maxConnsPerHost";
     int MAX_CONNECTIONS_PER_HOST_DEFAULT_VALUE = 10;
@@ -32,6 +33,10 @@ public interface DynomiteConfiguration extends Configuration {
 
     default String getHosts() {
         return getProperty(HOSTS_PROPERTY_NAME, null);
+    }
+
+    default Boolean shouldUseSSL() {
+        return Boolean.parseBoolean(getProperty(SHOULD_USE_SSL_PROPERTY_NAME, null));
     }
 
     default String getRootNamespace() {

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -18,6 +18,9 @@
 #format is host:port:rack separated by semicolon
 workflow.dynomite.cluster.hosts=host1:port:rack;host2:port:rack:host3:port:rack
 
+# Connect to host with SSL/TLS encryption? (redis only)
+workflow.dynomite.cluster.hosts.useSSL=false
+
 #namespace for the keys stored in Dynomite/Redis
 workflow.namespace.prefix=
 


### PR DESCRIPTION
Hi,

So following this issue https://github.com/Netflix/conductor/issues/1424 (tldr; I needed conductor to be able to connect to a redis host with TLS encryption enabled), here is a small pull request that enables encrypted communication between conductor and the configured redis host. The encryption can be opted-in by setting `workflow.dynomite.cluster.hosts.useSSL` to `true` in `settings.properties`. 

What I did is setting up an SSL context using platform default security providers and random generator (cf. [Java documentation](https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLContext.html#init(javax.net.ssl.KeyManager[],%20javax.net.ssl.TrustManager[],%20java.security.SecureRandom))). As I said in my issue message, I am not an expert in SSL/TLS encryption, so I would be happy to get feedbacks about that, to know if that is the recommended/safest choice or not.

The `conductor-postgres-persistence:test` tasks fails on my machine but it does not seem to fail on the latest travis build, and I do not think to have touched anything related to it (but I may be mistaken), however the `conductor-redis-persistence:test` runs fine.

Thank you for reviewing this :)