### PR TITLE
Added link to view a subworkflow execution

### DIFF
--- a/ui/src/components/common/Grapher.js
+++ b/ui/src/components/common/Grapher.js
@@ -3,6 +3,7 @@ import dagreD3 from 'dagre-d3'
 import d3 from 'd3'
 import {Tabs, Tab, Table} from 'react-bootstrap';
 import Clipboard from 'clipboard';
+import { Link } from 'react-router';
 
 new Clipboard('.btn');
 
@@ -202,6 +203,15 @@ class Grapher extends Component {
                         <i className="fa fa-close fa-1x close-btn" onClick={hideProps}/>
                         {this.state.selectedTask.taskType} ({this.state.selectedTask.status})
                     </h4>
+                    {this.state.selectedTask.taskType == 'SUB_WORKFLOW' &&
+                        <div>
+                            <p>
+                            <Link onClick={hideProps} to={'/workflow/id/' + this.state.selectedTask.outputData.subWorkflowId}>
+                                <u>View Subworkflow</u>
+                            </Link>
+                            </p>
+                        </div>
+                    }
                     <div style={{
                         color: '#ff0000',
                         display: this.state.selectedTask.status === 'FAILED' ? '' : 'none'

--- a/ui/src/components/common/Grapher.js
+++ b/ui/src/components/common/Grapher.js
@@ -206,7 +206,7 @@ class Grapher extends Component {
                     {this.state.selectedTask.taskType == 'SUB_WORKFLOW' &&
                         <div>
                             <p>
-                            <Link onClick={hideProps} to={'/workflow/id/' + this.state.selectedTask.outputData.subWorkflowId}>
+                            <Link onClick={hideProps} to={'/workflow/id/' + this.state.selectedTask.subWorkflowId}>
                                 <u>View Subworkflow</u>
                             </Link>
                             </p>


### PR DESCRIPTION
This PR will add a "View Subworkflow" link to the pop up menu when viewing a subworkflow task of an execution.

Right now there is an option to view a parent workflow from inside of a subworkflow, but there is no option to view the subworkflow from the parent workflow.

This would help users who are troubleshooting or checking their executed workflows.