### PR TITLE
Use boolean instead of String in TaskService/TaskResource

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -87,7 +87,7 @@ public interface TaskService {
      * @param workerId Id of the worker
      * @return `true|false` if task if received or not
      */
-    String ackTaskReceived(@NotEmpty(message = "TaskId cannot be null or empty.") String taskId, String workerId);
+    boolean ackTaskReceived(@NotEmpty(message = "TaskId cannot be null or empty.") String taskId, String workerId);
 
     /**
      * Ack Task is received.

--- a/core/src/main/java/com/netflix/conductor/service/TaskServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskServiceImpl.java
@@ -147,9 +147,9 @@ public class TaskServiceImpl implements TaskService {
      * @return `true|false` if task if received or not
      */
     @Service
-    public String ackTaskReceived(String taskId, String workerId) {
+    public boolean ackTaskReceived(String taskId, String workerId) {
         LOGGER.debug("Ack received for task: {} from worker: {}", taskId, workerId);
-        return String.valueOf(ackTaskReceived(taskId));
+        return ackTaskReceived(taskId);
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/service/TaskServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/TaskServiceTest.java
@@ -21,6 +21,7 @@ import static com.netflix.conductor.utility.TestUtils.getConstraintViolationMess
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class TaskServiceTest {
 
@@ -139,8 +140,8 @@ public class TaskServiceTest {
     }
     @Test
     public void testAckTaskReceivedMissingWorkerId() {
-        String ack = taskService.ackTaskReceived("abc", null);
-        assertNotNull(ack);
+        boolean ack = taskService.ackTaskReceived("abc", null);
+        assertFalse(ack);
     }
 
     @Test(expected = ConstraintViolationException.class)

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -111,7 +111,7 @@ public class TaskResource {
 	@Path("/{taskId}/ack")
 	@ApiOperation("Ack Task is received")
 	@Consumes({MediaType.WILDCARD})
-	public String ack(@PathParam("taskId") String taskId,
+	public boolean ack(@PathParam("taskId") String taskId,
 					  @QueryParam("workerid") String workerId) {
 		return taskService.ackTaskReceived(taskId, workerId);
 	}

--- a/jersey/src/test/java/com/netflix/conductor/server/resources/TaskResourceTest.java
+++ b/jersey/src/test/java/com/netflix/conductor/server/resources/TaskResourceTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -99,9 +100,9 @@ public class TaskResourceTest {
 
     @Test
     public void testAck() throws Exception {
-        String acked = "true";
+        boolean acked = true;
         when(mockTaskService.ackTaskReceived(anyString(), anyString())).thenReturn(acked);
-        assertEquals("true", taskResource.ack("123", "456"));
+        assertTrue(taskResource.ack("123", "456"));
     }
 
     @Test


### PR DESCRIPTION
This PR replaces using a string representation of a boolean with a boolean in TaskService.ackTaskReceived and TaskResource.ack.