### PR TITLE
update doc

### DIFF
--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -336,7 +336,7 @@ When executed, the dynamic fork task will schedule two parallel task of type "en
 	
 	Workflow definition MUST include a Join task definition followed by FORK_JOIN_DYNAMIC task.  However, given the dynamic nature of the task, no joinOn parameters are required for this Join.  The join will wait for ALL the forked branches to complete before completing.
 	
-	Unlike FORK, which can execute parallel flows with each fork executing a series of tasks in  sequence, FORK_JOIN_DYNAMIC is limited to only one task per fork.  However, forked task can be a Sub Workflow, allowing for more complex execution flows. We can use LAMBDA task to form a JSON based on previous task's output. That LAMBDA task output can be input to subsequent SUB_WORKFLOW tasks.
+	Unlike FORK, which can execute parallel flows with each fork executing a series of tasks in  sequence, FORK_JOIN_DYNAMIC is limited to only one task per fork.  However, forked task can be a Sub Workflow, allowing for more complex execution flows. We can use LAMBDA task to form a JSON, based on previous task's output. That LAMBDA task output can be input to subsequent SUB_WORKFLOW tasks.
 
 
 

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -336,7 +336,7 @@ When executed, the dynamic fork task will schedule two parallel task of type "en
 	
 	Workflow definition MUST include a Join task definition followed by FORK_JOIN_DYNAMIC task.  However, given the dynamic nature of the task, no joinOn parameters are required for this Join.  The join will wait for ALL the forked branches to complete before completing.
 	
-	Unlike FORK, which can execute parallel flows with each fork executing a series of tasks in  sequence, FORK_JOIN_DYNAMIC is limited to only one task per fork.  However, forked task can be a Sub Workflow, allowing for more complex execution flows.
+	Unlike FORK, which can execute parallel flows with each fork executing a series of tasks in  sequence, FORK_JOIN_DYNAMIC is limited to only one task per fork.  However, forked task can be a Sub Workflow, allowing for more complex execution flows. We can use LAMBDA task to form a JSON based on previous task's output. That LAMBDA task output can be input to subsequent SUB_WORKFLOW tasks.
 
 
 


### PR DESCRIPTION
HI @apanicker-nflx , I would like to update documentation of DYNAMIC_FORK_JOIN task.
We recently had a use case where the dynamic_fork_join task was not workflow's first task. We used LAMBDA task to form a json using previous task's otuput. We have passed that to DYNAMIC_FORK_JOIN task. I can share the LAMBDA task definition also required.