### PR TITLE
Fixed deep copy of task model.

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -15,18 +15,19 @@
  */
 package com.netflix.conductor.common.metadata.tasks;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.github.vmg.protogen.annotations.ProtoEnum;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
 import com.google.protobuf.Any;
 import com.netflix.conductor.common.metadata.workflow.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 
 @ProtoMessage
 public class Task {
@@ -765,6 +766,29 @@ public class Task {
 
         return copy;
     }
+
+  /**
+   * @return a deep copy of the task instance
+   * To be used inside copy Workflow method to provide
+   * a valid deep copied object.
+   * Note: This does not copy the following fields:
+   * <ul>
+   * <li>retried</li>
+   * <li>seq</li>
+   * <li>updateTime</li>
+   * <li>retriedTaskId</li>
+   * </ul>
+   */
+  public Task deepCopy() {
+    Task deepCopy = copy();
+    deepCopy.setStartTime(startTime);
+    deepCopy.setScheduledTime(scheduledTime);
+    deepCopy.setEndTime(endTime);
+    deepCopy.setWorkerId(workerId);
+    deepCopy.setReasonForIncompletion(reasonForIncompletion);
+
+    return deepCopy;
+  }
 
 
     @Override

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -485,7 +485,7 @@ public class Workflow extends Auditable{
 		copy.setWorkflowDefinition(workflowDefinition);
 		copy.setPriority(priority);
 		copy.setTasks(tasks.stream()
-				.map(Task::copy)
+				.map(Task::deepCopy)
 				.collect(Collectors.toList()));
 		return copy;
 	}
@@ -549,4 +549,5 @@ public class Workflow extends Auditable{
 				getPriority()
         );
     }
+
 }

--- a/common/src/test/java/com/netflix/conductor/common/tasks/TaskTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/tasks/TaskTest.java
@@ -17,12 +17,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.Any;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -90,5 +92,54 @@ public class TaskTest {
         task.setCallbackAfterSeconds(10);
         queueWaitTime = task.getQueueWaitTime();
         assertTrue(queueWaitTime > 0);
+    }
+
+    @Test
+    public void testDeepCopyTask() {
+        final Task task = new Task();
+        // In order to avoid forgetting putting inside the copy method the newly added fields check the number of declared fields.
+        final int expectedTaskFieldsNumber = 39;
+        final int declaredFieldsNumber = task.getClass().getDeclaredFields().length;
+
+        assertEquals(expectedTaskFieldsNumber, declaredFieldsNumber);
+
+        task.setCallbackAfterSeconds(111L);
+        task.setCallbackFromWorker(false);
+        task.setCorrelationId("correlation_id");
+        task.setInputData(new HashMap<>());
+        task.setOutputData(new HashMap<>());
+        task.setReferenceTaskName("ref_task_name");
+        task.setStartDelayInSeconds(1);
+        task.setTaskDefName("task_def_name");
+        task.setTaskType("dummy_task_type");
+        task.setWorkflowInstanceId("workflowInstanceId");
+        task.setWorkflowType("workflowType");
+        task.setResponseTimeoutSeconds(11L);
+        task.setStatus(Status.COMPLETED);
+        task.setRetryCount(0);
+        task.setPollCount(0);
+        task.setTaskId("taskId");
+        task.setWorkflowTask(new WorkflowTask());
+        task.setDomain("domain");
+        task.setInputMessage(Any.getDefaultInstance());
+        task.setOutputMessage(Any.getDefaultInstance());
+        task.setRateLimitPerFrequency(11);
+        task.setRateLimitFrequencyInSeconds(11);
+        task.setExternalInputPayloadStoragePath("externalInputPayloadStoragePath");
+        task.setExternalOutputPayloadStoragePath("externalOutputPayloadStoragePath");
+        task.setWorkflowPriority(0);
+        task.setIteration(1);
+        task.setExecutionNameSpace("name_space");
+        task.setIsolationGroupId("groupId");
+        task.setStartTime(12L);
+        task.setEndTime(20L);
+        task.setScheduledTime(7L);
+        task.setRetried(false);
+        task.setReasonForIncompletion("");
+        task.setWorkerId("");
+
+        final Task copy = task.deepCopy();
+        assertEquals(task, copy);
+
     }
 }


### PR DESCRIPTION
This PR provides a quick fix for deep copy method of Workflow. Copy method of Workflow is using the copy method from the Task model in a wrong way, since currently, the main purpose of the copy method is to help copy over required fields during retry operation.