### PR TITLE
Update ElasticSearch when a task is CANCELED

### DIFF
--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -38,6 +38,25 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.netflix.conductor.common.metadata.tasks.PollData;
@@ -69,26 +88,10 @@ import com.netflix.conductor.core.metadata.MetadataMapperService;
 import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.service.ExecutionLockService;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.stubbing.Answer;
 
 /**
  * @author Viren
@@ -99,6 +102,7 @@ public class TestWorkflowExecutor {
     private ExecutionDAOFacade executionDAOFacade;
     private MetadataDAO metadataDAO;
     private QueueDAO queueDAO;
+    private IndexDAO indexDAO;
     private WorkflowStatusListener workflowStatusListener;
     private ExecutionLockService executionLockService;
 
@@ -108,6 +112,7 @@ public class TestWorkflowExecutor {
         executionDAOFacade = mock(ExecutionDAOFacade.class);
         metadataDAO = mock(MetadataDAO.class);
         queueDAO = mock(QueueDAO.class);
+        indexDAO = mock(IndexDAO.class);
         workflowStatusListener = mock(WorkflowStatusListener.class);
         ExternalPayloadStorageUtils externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         executionLockService = mock(ExecutionLockService.class);
@@ -129,7 +134,7 @@ public class TestWorkflowExecutor {
 
         DeciderService deciderService = new DeciderService(parametersUtils, metadataDAO, externalPayloadStorageUtils, taskMappers, config);
         MetadataMapperService metadataMapperService = new MetadataMapperService(metadataDAO);
-        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, queueDAO, metadataMapperService, workflowStatusListener, executionDAOFacade, config, executionLockService);
+        workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, queueDAO, indexDAO, metadataMapperService, workflowStatusListener, executionDAOFacade, config, executionLockService);
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
@@ -16,6 +16,15 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.TaskType;
@@ -28,16 +37,10 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.WorkflowStatusListener;
 import com.netflix.conductor.core.metadata.MetadataMapperService;
 import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import com.netflix.conductor.service.ExecutionLockService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * @author Manan
@@ -58,6 +61,7 @@ public class DoWhileTest {
     DeciderService deciderService;
     MetadataDAO metadataDAO;
     QueueDAO queueDAO ;
+    IndexDAO indexDAO;
     MetadataMapperService metadataMapperService;
     WorkflowStatusListener workflowStatusListener ;
     ExecutionDAOFacade executionDAOFacade;
@@ -72,13 +76,14 @@ public class DoWhileTest {
         deciderService = Mockito.mock(DeciderService.class);
         metadataDAO = Mockito.mock(MetadataDAO.class);
         queueDAO = Mockito.mock(QueueDAO.class);
+        indexDAO = Mockito.mock(IndexDAO.class);
         parametersUtils = Mockito.mock(ParametersUtils.class);
         metadataMapperService = Mockito.mock(MetadataMapperService.class);
         workflowStatusListener = Mockito.mock(WorkflowStatusListener.class);
         executionDAOFacade = Mockito.mock(ExecutionDAOFacade.class);
         executionLockService = Mockito.mock(ExecutionLockService.class);
         config = Mockito.mock(Configuration.class);
-        provider = spy(new WorkflowExecutor(deciderService, metadataDAO, queueDAO, metadataMapperService,
+        provider = spy(new WorkflowExecutor(deciderService, metadataDAO, queueDAO, indexDAO, metadataMapperService,
                 workflowStatusListener, executionDAOFacade, config, executionLockService));
         loopWorkflowTask1 = new WorkflowTask();
         loopWorkflowTask1.setTaskReferenceName("task1__1");


### PR DESCRIPTION
When a workflow is TERMINATED, all tasks are added to ElasticSearch in their current state, even if they are in SCHEDULED state because they have not yet been polled. After that, SCHEDULED tasks have their status changed to CANCELED and the database is updated. But ElasticSearch is not updated (indexDAO.indexTask() is never called), so the database is out of sync with ElasticSearch. This change will index the task after the database is updated so that both are in sync.