### PR TITLE
Create Correlation id index on workflow table

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
@@ -1,0 +1,13 @@
+# Drop the 'workflow_corr_id_index' index if it exists
+SET @exist := (SELECT COUNT(INDEX_NAME)
+               FROM information_schema.STATISTICS
+               WHERE `TABLE_NAME` = 'workflow'
+                 AND `INDEX_NAME` = 'workflow_corr_id_index'
+                 AND TABLE_SCHEMA = database());
+SET @sqlstmt := IF(@exist > 0, 'ALTER TABLE `workflow` DROP INDEX `workflow_corr_id_index`',
+                   'SELECT ''INFO: Index already exists.''');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+# Create the 'workflow_corr_id_index' index with correlation_id column because correlation_id queries are slow in large databases.
+CREATE INDEX workflow_corr_id_index ON workflow (correlation_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS workflow_corr_id_index;
+
+CREATE INDEX workflow_corr_id_index ON workflow (correlation_id);


### PR DESCRIPTION
Currently queries on the workflow table by correlation_id are slow in large databases. This PR adds an index to the workflow table to fix this for both Postgres and MySql persistence modules