### PR TITLE
Get rid of IllegalArgumentException at startup when not using S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Conductor is an _orchestration_ engine that runs in the cloud.
 ## Community
 [![Gitter](https://badges.gitter.im/netflix-conductor/community.svg)](https://gitter.im/netflix-conductor/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) Please feel free to join our Gitter for questions and interacting with the community.
 
+[Access here other Conductor related projects made by the community!](/RELATED.md) - Backup tool, Cron like workflow starter, Docker containers...
+
 ## Builds
 Conductor builds are run on Travis CI [here](https://travis-ci.org/Netflix/conductor).
 

--- a/RELATED.md
+++ b/RELATED.md
@@ -1,0 +1,31 @@
+# Community projects related to Conductor
+
+
+## Microservices operations
+
+* https://github.com/flaviostutz/schellar - Schellar is a scheduler tool for instantiating Conductor workflows from time to time, mostly like a cron job, but with transport of input/output variables between calls.
+
+* https://github.com/flaviostutz/backtor - Backtor is a backup scheduler tool that uses Conductor workers to handle backup operations and decide when to expire backups (ex.: keep backup 3 days, 2 weeks, 2 months, 1 semester)
+
+* https://github.com/cquon/conductor-tools - Conductor CLI for launching workflows, polling tasks, listing running tasks etc
+
+
+## Conductor deployment
+
+* https://github.com/flaviostutz/conductor-server - Docker container for running Conductor with  Prometheus metrics plugin installed and some tweaks to ease provisioning of workflows from json files embedded to the container
+
+* https://github.com/flaviostutz/conductor-ui - Docker container for running Conductor UI so that you can easily scale UI independently
+
+* https://github.com/flaviostutz/elasticblast - "Elasticsearch to Bleve" bridge tailored for running Conductor on top of Bleve indexer. The footprint of Elasticsearch may cost too much for small deployments on Cloud environment.
+
+* https://github.com/mohelsaka/conductor-prometheus-metrics - Conductor plugin for exposing Prometheus metrics over path '/metrics'
+
+
+## Conductor Worker utilities
+
+* https://github.com/ggrcha/conductor-go-client - Conductor Golang client for writing Workers in Golang
+
+* https://github.com/courosh12/conductor-dotnet-client - Conductor DOTNET client for writing Workers in DOTNET
+
+* https://github.com/davidwadden/conductor-workers - Various ready made Conductor workers for common operations on some platforms (ex.: Jira, Github, Concourse)
+

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -745,7 +745,7 @@ public class WorkflowExecutor {
                             null,
                             workflowId,
                             null,
-                            null
+                            workflow.getTaskToDomain()
                     );
 
                     workflow.getOutput().put("conductor.failure_workflow", failureWFId);

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -60,7 +60,8 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
     private final Configuration configuration;
 
     enum ExternalPayloadStorageType {
-        S3
+        S3,
+        DUMMY
     }
 
     @Inject
@@ -163,7 +164,7 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         }
 
         ExternalPayloadStorageType externalPayloadStorageType = null;
-        String externalPayloadStorageString = configuration.getProperty("workflow.external.payload.storage", "");
+        String externalPayloadStorageString = configuration.getProperty("workflow.external.payload.storage", "DUMMY");
         try {
             externalPayloadStorageType = ExternalPayloadStorageType.valueOf(externalPayloadStorageString);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When not using S3 as an ExternalPayloadStorageType, Conductor gets an IllegalArgumentException at startup. This bugfix gets rid of that exception. The actual exception is:

java.lang.IllegalArgumentException: No enum constant com.netflix.conductor.bootstrap.ModulesProvider.ExternalPayloadStorageType.