### PR TITLE
get rid of ExternalPayloadStorageType exception on startup

### DIFF
--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -60,7 +60,8 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
     private final Configuration configuration;
 
     enum ExternalPayloadStorageType {
-        S3
+        S3,
+        DUMMY
     }
 
     @Inject
@@ -163,7 +164,7 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         }
 
         ExternalPayloadStorageType externalPayloadStorageType = null;
-        String externalPayloadStorageString = configuration.getProperty("workflow.external.payload.storage", "");
+        String externalPayloadStorageString = configuration.getProperty("workflow.external.payload.storage", "DUMMY");
         try {
             externalPayloadStorageType = ExternalPayloadStorageType.valueOf(externalPayloadStorageString);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When not using S3 as an ExternalPayloadStorageType, Conductor gets an IllegalArgumentException at startup. This bugfix gets rid of that exception. The actual exception is:

java.lang.IllegalArgumentException: No enum constant com.netflix.conductor.bootstrap.ModulesProvider.ExternalPayloadStorageType.