### PR TITLE
Remove /tasks/{taskId}/ack endpoint

### DIFF
--- a/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/TaskResource.java
@@ -108,15 +108,6 @@ public class TaskResource {
 	}
 
 	@POST
-	@Path("/{taskId}/ack")
-	@ApiOperation("Ack Task is received")
-	@Consumes({MediaType.WILDCARD})
-	public String ack(@PathParam("taskId") String taskId,
-					  @QueryParam("workerid") String workerId) {
-		return taskService.ackTaskReceived(taskId, workerId);
-	}
-
-	@POST
 	@Path("/{taskId}/log")
 	@ApiOperation("Log Task Execution Details")
 	public void log(@PathParam("taskId") String taskId, String log) {

--- a/jersey/src/test/java/com/netflix/conductor/server/resources/TaskResourceTest.java
+++ b/jersey/src/test/java/com/netflix/conductor/server/resources/TaskResourceTest.java
@@ -98,13 +98,6 @@ public class TaskResourceTest {
     }
 
     @Test
-    public void testAck() throws Exception {
-        String acked = "true";
-        when(mockTaskService.ackTaskReceived(anyString(), anyString())).thenReturn(acked);
-        assertEquals("true", taskResource.ack("123", "456"));
-    }
-
-    @Test
     public void testLog() {
         taskResource.log("123", "test log");
         verify(mockTaskService, times(1)).log(anyString(), anyString());

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractGrpcEndToEndTest.java
@@ -138,10 +138,6 @@ public abstract class AbstractGrpcEndToEndTest extends AbstractEndToEndTest {
         assertEquals(t0.getName(), polled.get(0).getTaskDefName());
         Task task = polled.get(0);
 
-        Boolean acked = taskClient.ack(task.getTaskId(), "test");
-        assertNotNull(acked);
-        assertTrue(acked);
-
         task.getOutputData().put("key1", "value1");
         task.setStatus(Status.COMPLETED);
         taskClient.updateTask(new TaskResult(task));

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractHttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractHttpEndToEndTest.java
@@ -151,10 +151,6 @@ public abstract class AbstractHttpEndToEndTest extends AbstractEndToEndTest {
         assertEquals(t0.getName(), polled.get(0).getTaskDefName());
         Task task = polled.get(0);
 
-        Boolean acked = taskClient.ack(task.getTaskId(), "test");
-        assertNotNull(acked);
-        assertTrue(acked);
-
         task.getOutputData().put("key1", "value1");
         task.setStatus(Status.COMPLETED);
         taskClient.updateTask(new TaskResult(task));


### PR DESCRIPTION
Discussed with @kishorebanala in #1501 , the `/tasks/{taskId}/ack` endpoint is no longer needed and to be removed.

In this PR, I only removed the endpoint on the API layer, as I didn't want to prematurely remove anything from the core. Please let me know if more removal or deprecation should be included in this PR.