### PR TITLE
Set password for redis server used for distributed lock.

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockConfiguration.java
@@ -24,6 +24,8 @@ public interface RedisLockConfiguration extends Configuration {
     String REDIS_SERVER_TYPE_DEFAULT_VALUE = "single";
     String REDIS_SERVER_STRING_PROP_NAME = "workflow.redis.locking.server.address";
     String REDIS_SERVER_STRING_DEFAULT_VALUE = "redis://127.0.0.1:6379";
+    String REDIS_SERVER_PASSWORD_PROP_NAME = "workflow.redis.locking.server.password";
+    String REDIS_SERVER_PASSWORD_DEFAULT_VALUE = null;
 
     default REDIS_SERVER_TYPE getRedisServerType() {
         return REDIS_SERVER_TYPE.valueOf(getRedisServerStringValue());
@@ -35,6 +37,10 @@ public interface RedisLockConfiguration extends Configuration {
 
     default String getRedisServerAddress() {
         return getProperty(REDIS_SERVER_STRING_PROP_NAME, REDIS_SERVER_STRING_DEFAULT_VALUE);
+    }
+
+    default String getRedisServerPassword() {
+        return getProperty(REDIS_SERVER_PASSWORD_PROP_NAME, REDIS_SERVER_PASSWORD_DEFAULT_VALUE);
     }
 
     enum REDIS_SERVER_TYPE {

--- a/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockModule.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockModule.java
@@ -52,6 +52,7 @@ public class RedisLockModule extends AbstractModule{
             throw new ProvisionException(message, ie);
         }
         String redisServerAddress = clusterConfiguration.getRedisServerAddress();
+        String redisServerPassword = clusterConfiguration.getRedisServerPassword();
 
         Config redisConfig = new Config();
 
@@ -60,18 +61,21 @@ public class RedisLockModule extends AbstractModule{
             case SINGLE:
                 redisConfig.useSingleServer()
                         .setAddress(redisServerAddress)
+                        .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout);
                 break;
             case CLUSTER:
                 redisConfig.useClusterServers()
                         .setScanInterval(2000) // cluster state scan interval in milliseconds
                         .addNodeAddress(redisServerAddress.split(","))
+                        .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout);
                 break;
             case SENTINEL:
                 redisConfig.useSentinelServers()
                         .setScanInterval(2000)
                         .addSentinelAddress(redisServerAddress)
+                        .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout);
                 break;
         }


### PR DESCRIPTION
Hi,

I've added possibility to set password for redis server used for distributed lock. Password is optional (null by default) so that the old behavior is intact.

Resolves issue: https://github.com/Netflix/conductor/issues/1402

Pavel