### PR TITLE
Fixes issue #1553

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestBuilderWrapper.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestBuilderWrapper.java
@@ -1,0 +1,45 @@
+package com.netflix.conductor.dao.es5.index;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Thread-safe wrapper for {@link BulkRequestBuilder}.
+ */
+public class BulkRequestBuilderWrapper {
+	private final BulkRequestBuilder bulkRequestBuilder;
+
+	public BulkRequestBuilderWrapper(@Nonnull BulkRequestBuilder bulkRequestBuilder) {
+		this.bulkRequestBuilder = Objects.requireNonNull(bulkRequestBuilder);
+	}
+
+	public void add(@Nonnull UpdateRequest req) {
+		synchronized (bulkRequestBuilder) {
+			bulkRequestBuilder.add(Objects.requireNonNull(req));
+		}
+	}
+
+	public void add(@Nonnull IndexRequest req) {
+		synchronized (bulkRequestBuilder) {
+			bulkRequestBuilder.add(Objects.requireNonNull(req));
+		}
+	}
+
+	public int numberOfActions() {
+		synchronized (bulkRequestBuilder) {
+			return bulkRequestBuilder.numberOfActions();
+		}
+	}
+
+	public ActionFuture<BulkResponse> execute() {
+		synchronized (bulkRequestBuilder) {
+			return bulkRequestBuilder.execute();
+		}
+	}
+}

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestBuilderWrapper.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestBuilderWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Medallia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.dao.es5.index;
 
 import org.elasticsearch.action.ActionFuture;

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -423,7 +423,7 @@ public class ElasticSearchDAOV5 implements IndexDAO {
 
         try {
             long startTime = Instant.now().toEpochMilli();
-            BulkRequestBuilder bulkRequestBuilder = elasticSearchClient.prepareBulk();
+            BulkRequestBuilderWrapper bulkRequestBuilder = new BulkRequestBuilderWrapper(elasticSearchClient.prepareBulk());
             for (TaskExecLog log : taskExecLogs) {
                 IndexRequest request = new IndexRequest(logIndexName, LOG_DOC_TYPE);
                 request.source(objectMapper.writeValueAsBytes(log), XContentType.JSON);
@@ -563,7 +563,7 @@ public class ElasticSearchDAOV5 implements IndexDAO {
         }
     }
 
-    private void updateWithRetry(BulkRequestBuilder request, String docType) {
+    private void updateWithRetry(BulkRequestBuilderWrapper request, String docType) {
         try {
             long startTime = Instant.now().toEpochMilli();
             new RetryUtil<BulkResponse>().retryOnException(
@@ -856,19 +856,19 @@ public class ElasticSearchDAOV5 implements IndexDAO {
 
     private static class BulkRequests {
         private final long lastFlushTime;
-        private final BulkRequestBuilder bulkRequestBuilder;
+        private final BulkRequestBuilderWrapper bulkRequestBuilder;
 
         public long getLastFlushTime() {
             return lastFlushTime;
         }
 
-        public BulkRequestBuilder getBulkRequestBuilder() {
+        public BulkRequestBuilderWrapper getBulkRequestBuilder() {
             return bulkRequestBuilder;
         }
 
         BulkRequests(long lastFlushTime, BulkRequestBuilder bulkRequestBuilder) {
             this.lastFlushTime = lastFlushTime;
-            this.bulkRequestBuilder = bulkRequestBuilder;
+            this.bulkRequestBuilder = new BulkRequestBuilderWrapper(bulkRequestBuilder);
         }
     }
 }

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestBuilderWrapper.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestBuilderWrapper.java
@@ -1,0 +1,46 @@
+package com.netflix.conductor.dao.es6.index;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Thread-safe wrapper for {@link BulkRequestBuilder}.
+ */
+public class BulkRequestBuilderWrapper {
+	private final BulkRequestBuilder bulkRequestBuilder;
+
+	public BulkRequestBuilderWrapper(@Nonnull BulkRequestBuilder bulkRequestBuilder) {
+		this.bulkRequestBuilder = Objects.requireNonNull(bulkRequestBuilder);
+	}
+
+	public void add(@Nonnull UpdateRequest req) {
+		synchronized (bulkRequestBuilder) {
+			bulkRequestBuilder.add(Objects.requireNonNull(req));
+		}
+	}
+
+	public void add(@Nonnull IndexRequest req) {
+		synchronized (bulkRequestBuilder) {
+			bulkRequestBuilder.add(Objects.requireNonNull(req));
+		}
+	}
+
+	public int numberOfActions() {
+		synchronized (bulkRequestBuilder) {
+			return bulkRequestBuilder.numberOfActions();
+		}
+	}
+
+	public ActionFuture<BulkResponse> execute() {
+		synchronized (bulkRequestBuilder) {
+			return bulkRequestBuilder.execute();
+		}
+	}
+}
+

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestBuilderWrapper.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestBuilderWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Medallia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.dao.es6.index;
 
 import org.elasticsearch.action.ActionFuture;

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
@@ -412,7 +412,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
 
         try {
             long startTime = Instant.now().toEpochMilli();
-            BulkRequestBuilder bulkRequestBuilder = elasticSearchClient.prepareBulk();
+            BulkRequestBuilderWrapper bulkRequestBuilder = new BulkRequestBuilderWrapper(elasticSearchClient.prepareBulk());
             for (TaskExecLog log : taskExecLogs) {
                 IndexRequest request = new IndexRequest(logIndexName, LOG_DOC_TYPE);
                 request.source(objectMapper.writeValueAsBytes(log), XContentType.JSON);
@@ -579,7 +579,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
         return executions;
     }
 
-    private void updateWithRetry(BulkRequestBuilder request, String docType) {
+    private void updateWithRetry(BulkRequestBuilderWrapper request, String docType) {
         try {
             long startTime = Instant.now().toEpochMilli();
             new RetryUtil<BulkResponse>().retryOnException(
@@ -793,7 +793,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
 
     private static class BulkRequests {
         private long lastFlushTime;
-        private BulkRequestBuilder bulkRequestBuilder;
+        private BulkRequestBuilderWrapper bulkRequestBuilder;
 
         public long getLastFlushTime() {
             return lastFlushTime;
@@ -803,17 +803,17 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
             this.lastFlushTime = lastFlushTime;
         }
 
-        public BulkRequestBuilder getBulkRequestBuilder() {
+        public BulkRequestBuilderWrapper getBulkRequestBuilder() {
             return bulkRequestBuilder;
         }
 
         public void setBulkRequestBuilder(BulkRequestBuilder bulkRequestBuilder) {
-            this.bulkRequestBuilder = bulkRequestBuilder;
+            this.bulkRequestBuilder = new BulkRequestBuilderWrapper(bulkRequestBuilder);
         }
 
         BulkRequests(long lastFlushTime, BulkRequestBuilder bulkRequestBuilder) {
             this.lastFlushTime = lastFlushTime;
-            this.bulkRequestBuilder = bulkRequestBuilder;
+            this.bulkRequestBuilder = new BulkRequestBuilderWrapper(bulkRequestBuilder);
         }
     }
 }


### PR DESCRIPTION
Fixes issue #1553. The most obvious thing I could think of is to wrap access to the BulkRequestBuilder object in `synchronized(){}`. In my own testing, this resolves the issue both for ES5 and ES6.