### PR TITLE
Make use of ElasticSearch optional

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -79,6 +79,9 @@ public interface Configuration {
     String TASKEXECLOG_INDEXING_ENABLED_PROPERTY_NAME = "workflow.taskExecLog.indexing.enabled";
     boolean TASKEXECLOG_INDEXING_ENABLED_DEFAULT_VALUE = true;
 
+    String INDEXING_ENABLED_PROPERTY_NAME = "workflow.indexing.enabled";
+    boolean INDEXING_ENABLED_DEFAULT_VALUE = false;
+
     String TASK_DEF_REFRESH_TIME_SECS_PROPERTY_NAME = "conductor.taskdef.cache.refresh.time.seconds";
     int TASK_DEF_REFRESH_TIME_SECS_DEFAULT_VALUE = 60;
 
@@ -119,6 +122,13 @@ public interface Configuration {
      */
     default boolean isTaskExecLogIndexingEnabled() {
         return getBooleanProperty(TASKEXECLOG_INDEXING_ENABLED_PROPERTY_NAME, TASKEXECLOG_INDEXING_ENABLED_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return if true(default), enables indexing persistence
+     */
+    default boolean isIndexingPersistenceEnabled() {
+            return getBooleanProperty(INDEXING_ENABLED_PROPERTY_NAME, INDEXING_ENABLED_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -80,7 +80,7 @@ public interface Configuration {
     boolean TASKEXECLOG_INDEXING_ENABLED_DEFAULT_VALUE = true;
 
     String INDEXING_ENABLED_PROPERTY_NAME = "workflow.indexing.enabled";
-    boolean INDEXING_ENABLED_DEFAULT_VALUE = false;
+    boolean INDEXING_ENABLED_DEFAULT_VALUE = true;
 
     String TASK_DEF_REFRESH_TIME_SECS_PROPERTY_NAME = "conductor.taskdef.cache.refresh.time.seconds";
     int TASK_DEF_REFRESH_TIME_SECS_DEFAULT_VALUE = 60;

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -29,6 +29,7 @@ import com.netflix.conductor.core.utils.NoopLockModule;
 import com.netflix.conductor.core.execution.WorkflowExecutorModule;
 import com.netflix.conductor.core.utils.DummyPayloadStorage;
 import com.netflix.conductor.core.utils.S3PayloadStorage;
+import com.netflix.conductor.noopindex.NoopIndexModule;
 import com.netflix.conductor.dao.RedisWorkflowModule;
 import com.netflix.conductor.elasticsearch.ElasticSearchModule;
 import com.netflix.conductor.locking.redis.config.RedisLockModule;
@@ -127,7 +128,10 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
                 break;
         }
 
-        modules.add(new ElasticSearchModule());
+        if (configuration.isIndexingPersistenceEnabled())
+            modules.add(new ElasticSearchModule());
+        else
+            modules.add(new NoopIndexModule());
 
         modules.add(new WorkflowExecutorModule());
 

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Netflix, Inc.
+/*
+ * Copyright 2020 Medallia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.noopindex;
 
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearch;

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopEmbeddedElasticSearchProvider.java
@@ -1,0 +1,16 @@
+package com.netflix.conductor.noopindex;
+
+import com.netflix.conductor.elasticsearch.EmbeddedElasticSearch;
+import com.netflix.conductor.elasticsearch.EmbeddedElasticSearchProvider;
+
+import java.util.Optional;
+
+/**
+ * Dummy implementation of {@link EmbeddedElasticSearchProvider}.
+ */
+public class NoopEmbeddedElasticSearchProvider implements EmbeddedElasticSearchProvider {
+	@Override
+	public Optional<EmbeddedElasticSearch> get() {
+		return Optional.empty();
+	}
+}

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.noopindex;
 
 import com.netflix.conductor.annotations.Trace;

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
@@ -1,0 +1,136 @@
+package com.netflix.conductor.noopindex;
+
+import com.netflix.conductor.annotations.Trace;
+import com.netflix.conductor.common.metadata.events.EventExecution;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.dao.IndexDAO;
+
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Dummy implementation of {@link IndexDAO} which does nothing. Nothing is ever indexed, and no results are ever
+ * returned.
+ */
+@Trace
+@Singleton
+public class NoopIndexDAO implements IndexDAO {
+	@Override
+	public void setup() {
+	}
+
+	@Override
+	public void indexWorkflow(Workflow workflow) {
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncIndexWorkflow(Workflow workflow) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void indexTask(Task task) {
+
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncIndexTask(Task task) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public SearchResult<String> searchWorkflows(String query, String freeText, int start, int count, List<String> sort) {
+		return new SearchResult<>(0, Collections.emptyList());
+	}
+
+	@Override
+	public SearchResult<String> searchTasks(String query, String freeText, int start, int count, List<String> sort) {
+		return new SearchResult<>(0, Collections.emptyList());
+	}
+
+	@Override
+	public void removeWorkflow(String workflowId) {
+
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void updateWorkflow(String workflowInstanceId, String[] keys, Object[] values) {
+
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncUpdateWorkflow(String workflowInstanceId, String[] keys, Object[] values) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public String get(String workflowInstanceId, String key) {
+		return null;
+	}
+
+	@Override
+	public void addTaskExecutionLogs(List<TaskExecLog> logs) {
+
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncAddTaskExecutionLogs(List<TaskExecLog> logs) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public List<TaskExecLog> getTaskExecutionLogs(String taskId) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void addEventExecution(EventExecution eventExecution) {
+
+	}
+
+	@Override
+	public List<EventExecution> getEventExecutions(String event) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncAddEventExecution(EventExecution eventExecution) {
+		return null;
+	}
+
+	@Override
+	public void addMessage(String queue, Message msg) {
+
+	}
+
+	@Override
+	public CompletableFuture<Void> asyncAddMessage(String queue, Message message) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public List<Message> getMessages(String queue) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<String> searchArchivableWorkflows(String indexName, long archiveTtlDays) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<String> searchRecentRunningWorkflows(int lastModifiedHoursAgoFrom, int lastModifiedHoursAgoTo) {
+		return Collections.emptyList();
+	}
+}

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexDAO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Netflix, Inc.
+/*
+ * Copyright 2020 Medallia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
@@ -1,0 +1,17 @@
+package com.netflix.conductor.noopindex;
+
+import com.google.inject.AbstractModule;
+import com.netflix.conductor.dao.IndexDAO;
+import com.netflix.conductor.elasticsearch.EmbeddedElasticSearchProvider;
+
+/**
+ * Configures no-op implementation of {@link IndexDAO}. Used when you don't want any indexing support (meaning no
+ * ElasticSearch is required.)
+ */
+public class NoopIndexModule extends AbstractModule {
+	@Override
+	protected void configure() {
+		bind(IndexDAO.class).to(NoopIndexDAO.class);
+		bind(EmbeddedElasticSearchProvider.class).to(NoopEmbeddedElasticSearchProvider.class);
+	}
+}

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.noopindex;
 
 import com.google.inject.AbstractModule;

--- a/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
+++ b/server/src/main/java/com/netflix/conductor/noopindex/NoopIndexModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Netflix, Inc.
+/*
+ * Copyright 2020 Medallia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds a configuration parameter which, when set, completely disables use of ElasticSearch. Note that search operations which require ElasticSearch will silently fail by returning empty results.

The new configuration parameter is `workflow.indexing.enabled` with a default value of true. Setting it to false will completely disable use of ElasticSearch.

(Of course, with this configuration, significant parts of the Conductor UI will no longer function correctly. However, not all users of Conductor actually use the Conductor UI, so for such users that will not be an issue.)