### PR TITLE
allow input to FORK_JOIN_DYNAMIC task to be empty

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -252,7 +252,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
             }
         }
         Object dynamicForkTasksInput = input.get(taskToSchedule.getDynamicForkTasksInputParamName());
-        if (dynamicForkTasksInput != null && !(dynamicForkTasksInput instanceof Map)) {
+        if (!(dynamicForkTasksInput instanceof Map)) {
             throw new TerminateWorkflowException("Input to the dynamically forked tasks is not a map -> expecting a map of K,V  but found " + dynamicForkTasksInput);
         }
         return new ImmutablePair<>(dynamicForkWorkflowTasks, (Map<String, Map<String, Object>>) dynamicForkTasksInput);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -15,6 +15,20 @@
  */
 package com.netflix.conductor.core.execution.mapper;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -29,18 +43,6 @@ import com.netflix.conductor.core.execution.SystemTaskType;
 import com.netflix.conductor.core.execution.TerminateWorkflowException;
 import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.dao.MetadataDAO;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link TaskType#FORK_JOIN_DYNAMIC}
@@ -241,13 +243,16 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         Map<String, Object> input = parametersUtils.getTaskInput(taskToSchedule.getInputParameters(), workflowInstance, null, null);
         Object dynamicForkTasksJson = input.get(dynamicForkTaskParam);
         List<WorkflowTask> dynamicForkWorkflowTasks = objectMapper.convertValue(dynamicForkTasksJson, ListOfWorkflowTasks);
+		if(dynamicForkWorkflowTasks == null) {
+			dynamicForkWorkflowTasks = new ArrayList<WorkflowTask>();
+		}
         for (WorkflowTask workflowTask : dynamicForkWorkflowTasks) {
             if ((workflowTask.getTaskDefinition() == null) && StringUtils.isNotBlank(workflowTask.getName())) {
                 workflowTask.setTaskDefinition(metadataDAO.getTaskDef(workflowTask.getName()));
             }
         }
         Object dynamicForkTasksInput = input.get(taskToSchedule.getDynamicForkTasksInputParamName());
-        if (!(dynamicForkTasksInput instanceof Map)) {
+        if (dynamicForkTasksInput != null && !(dynamicForkTasksInput instanceof Map)) {
             throw new TerminateWorkflowException("Input to the dynamically forked tasks is not a map -> expecting a map of K,V  but found " + dynamicForkTasksInput);
         }
         return new ImmutablePair<>(dynamicForkWorkflowTasks, (Map<String, Map<String, Object>>) dynamicForkTasksInput);


### PR DESCRIPTION
If the input to a FORK_JOIN_DYNAMIC task is empty (i.e. empty or non-existent dynamicForkTasksParam), ForkJoinDynamicTaskMapper.java gets a NullPointerException. This Pull Request fixes that by simulating an empty array of tasks.