### PR TITLE
add flyway files used to add priority to the combo_queue_message index

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
@@ -1,0 +1,13 @@
+# Drop the 'combo_queue_message' index if it exists
+SET @exist := (SELECT COUNT(INDEX_NAME)
+               FROM information_schema.STATISTICS
+               WHERE `TABLE_NAME` = 'queue_message'
+                 AND `INDEX_NAME` = 'combo_queue_message'
+                 AND TABLE_SCHEMA = database());
+SET @sqlstmt := IF(@exist > 0, 'ALTER TABLE `queue_message` DROP INDEX `combo_queue_message`',
+                   'SELECT ''INFO: Index already exists.''');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+# Re-create the 'combo_queue_message' index to add priority column because queries that order by priority are slow in large databases.
+CREATE INDEX combo_queue_message ON queue_message (queue_name,priority,popped,deliver_on,created_on);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS combo_queue_message;
+
+CREATE INDEX combo_queue_message ON queue_message (queue_name,priority,popped,deliver_on,created_on);


### PR DESCRIPTION
When there is a large volume of scheduled tasks of a specific type in the queue_message table, the queries slow down significantly during polling because priority is not indexed and the ORDER BY clause uses priority. In our specific case there were 2.3 million tasks of a type and the  poll query for that type was taking 17 seconds. Adding priority to the combo_queue_message index brought that down to 4 seconds.