### PR TITLE
added resiliency during task poll

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraBaseDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraBaseDAO.java
@@ -81,7 +81,7 @@ import org.slf4j.LoggerFactory;
  * CREATE TABLE IF NOT EXISTS conductor.event_handlers( handlers text, event_handler_name text, event_handler text,
  * PRIMARY KEY ((handlers), event_handler_name) );
  */
-public class CassandraBaseDAO {
+public abstract class CassandraBaseDAO {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraBaseDAO.class);
 

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -165,6 +165,10 @@ public class Monitors {
 		getTimer(classQualifier, "task_execution", "taskType", taskType, "includeRetries", "" + includesRetries, "status", status.name()).record(duration, TimeUnit.MILLISECONDS);
 	}
 
+	public static void recordTaskPollError(String taskType, String domain, String exception) {
+		counter(classQualifier, "task_poll_error", "taskType", taskType, "domain", domain, "exception", exception);
+	}
+
 	public static void recordTaskPoll(String taskType) {
 		counter(classQualifier, "task_poll", "taskType", taskType);
 	}


### PR DESCRIPTION
When polling for a task, if a db operation fails on a dequeued task, this task will now be lost and the corresponding workflow will be unable to progress.
This PR addresses this issue by re-enqueueing this task with a delay so that the workflow will be unblocked.
Note that the priority of this task is set to 0 since this task need not wait for other tasks with different priority to be dequeued (as it was already dequeued once).