### PR TITLE
Add config setting to control whether ownerEmail is mandatory or not

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/constraints/OwnerEmailMandatoryConstraint.java
+++ b/common/src/main/java/com/netflix/conductor/common/constraints/OwnerEmailMandatoryConstraint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * Copyright 2020 Medallia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.common.constraints;
+
+import com.google.common.base.Strings;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+
+/**
+ * This constraint class validates that owner email is non-empty, but only if configuration says owner email is
+ * mandatory.
+ */
+@Documented
+@Constraint(validatedBy = OwnerEmailMandatoryConstraint.WorkflowTaskValidValidator.class)
+@Target({TYPE, FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OwnerEmailMandatoryConstraint {
+
+	String message() default "ownerEmail cannot be empty";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	class WorkflowTaskValidValidator implements ConstraintValidator<OwnerEmailMandatoryConstraint, String> {
+
+		@Override
+		public void initialize(OwnerEmailMandatoryConstraint constraintAnnotation) {
+		}
+
+		@Override
+		public boolean isValid(String ownerEmail, ConstraintValidatorContext context) {
+			return !ownerEmailMandatory || !Strings.isNullOrEmpty(ownerEmail);
+		}
+
+		private static boolean ownerEmailMandatory = true;
+
+    public static void setOwnerEmailMandatory(boolean ownerEmailMandatory) {
+        WorkflowTaskValidValidator.ownerEmailMandatory = ownerEmailMandatory;
+    }
+  }
+}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -19,6 +19,7 @@ package com.netflix.conductor.common.metadata.tasks;
 import com.github.vmg.protogen.annotations.ProtoEnum;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
+import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.constraints.TaskTimeoutConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
 import java.util.ArrayList;
@@ -109,7 +110,7 @@ public class TaskDef extends Auditable {
 	private String executionNameSpace;
 
 	@ProtoField(id = 18)
-	@NotEmpty(message = "ownerEmail cannot be empty")
+	@OwnerEmailMandatoryConstraint
 	@Email(message = "ownerEmail should be valid email address")
 	private String ownerEmail;
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -19,6 +19,7 @@ import com.github.vmg.protogen.annotations.ProtoEnum;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
 import com.netflix.conductor.common.constraints.NoSemiColonConstraint;
+import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.constraints.TaskReferenceNameUniqueConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
 import java.util.HashMap;
@@ -84,7 +85,7 @@ public class WorkflowDef extends Auditable {
 	private boolean workflowStatusListenerEnabled = false;
 
 	@ProtoField(id = 11)
-	@NotEmpty(message = "ownerEmail cannot be empty")
+	@OwnerEmailMandatoryConstraint
 	@Email(message = "ownerEmail should be valid email address")
 	private String ownerEmail;
 

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -85,6 +85,9 @@ public interface Configuration {
     String EVENT_HANDLER_REFRESH_TIME_SECS_PROPERTY_NAME = "conductor.eventhandler.cache.refresh.time.seconds";
     int EVENT_HANDLER_REFRESH_TIME_SECS_DEFAULT_VALUE = 60;
 
+    String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
+    boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
+
     //TODO add constants for input/output external payload related properties.
 
     default DB getDB() {
@@ -197,6 +200,13 @@ public interface Configuration {
 
     default boolean getJerseyEnabled() {
         return getBooleanProperty(JERSEY_ENABLED_PROPERTY_NAME, JERSEY_ENABLED_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return true if owner email is mandatory for task definitions and workflow definitions
+     */
+    default boolean isOwnerEmailMandatory() {
+            return getBooleanProperty(OWNER_EMAIL_MANDATORY_NAME, OWNER_EMAIL_MANDATORY_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -19,10 +19,12 @@ package com.netflix.conductor.service;
 import com.netflix.conductor.annotations.Audit;
 import com.netflix.conductor.annotations.Service;
 import com.netflix.conductor.annotations.Trace;
+import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.WorkflowContext;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.events.EventQueues;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.core.execution.ApplicationException.Code;
@@ -44,12 +46,14 @@ public class MetadataServiceImpl implements MetadataService {
     private final EventQueues eventQueues;
 
     @Inject
-    public MetadataServiceImpl(MetadataDAO metadataDAO, EventHandlerDAO eventHandlerDAO, EventQueues eventQueues) {
+    public MetadataServiceImpl(MetadataDAO metadataDAO, EventHandlerDAO eventHandlerDAO, EventQueues eventQueues,
+                               Configuration configuration) {
         this.metadataDAO = metadataDAO;
         this.eventHandlerDAO = eventHandlerDAO;
         this.eventQueues = eventQueues;
 
         ValidationContext.initialize(metadataDAO);
+        OwnerEmailMandatoryConstraint.WorkflowTaskValidValidator.setOwnerEmailMandatory(configuration.isOwnerEmailMandatory());
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -30,6 +30,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.ValidationModule;
 import com.netflix.conductor.core.events.EventQueues;
 import com.netflix.conductor.core.execution.ApplicationException;
@@ -54,12 +55,15 @@ public class MetadataServiceTest{
     private EventHandlerDAO eventHandlerDAO;
 
     private EventQueues eventQueues;
+    private Configuration configuration;
 
     @Before
     public void before() {
         metadataDAO = Mockito.mock(MetadataDAO.class);
         eventHandlerDAO = Mockito.mock(EventHandlerDAO.class);
         eventQueues = Mockito.mock(EventQueues.class);
+        configuration = Mockito.mock(Configuration.class);
+        when(configuration.isOwnerEmailMandatory()).thenReturn(true);
 
         Injector injector =
                 Guice.createInjector(
@@ -70,6 +74,7 @@ public class MetadataServiceTest{
                                 bind(MetadataDAO.class).toInstance(metadataDAO);
                                 bind(EventHandlerDAO.class).toInstance(eventHandlerDAO);
                                 bind(EventQueues.class).toInstance(eventQueues);
+                                bind(Configuration.class).toInstance(configuration);
 
                                 install(new ValidationModule());
                                 bindInterceptor(


### PR DESCRIPTION
Addresses issue #1585 – adds a config setting `workflow.owner.email.mandatory` (with a default value of true) which controls whether ownerEmail attribute is mandatory on task definitions and workflow definitions. With the default value of true, the behaviour is the same as at present. If you change the value to false, then ownerEmail becomes an optional attribute.

Implementation is by replacing the `@NotEmpty(message = "ownerEmail cannot be empty")` annotation on ownerEmail with a new custom annotation `@OwnerEmailMandatoryConstraint`. We push the value of the config setting into the annotation validator; when the setting is true, it ensures the value is neither null nor an empty string; when the setting is false, the validation always succeeds.