### PR TITLE
do not mutate the taskresult object during upload retries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,29 @@ Contributions will be accepted to the [dev](https://github.com/Netflix/conductor
 
 For minor fixes just open a pull request to the [dev]( https://github.com/Netflix/conductor/tree/dev ) branch on Github.
 
+## License
+
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/Netflix/conductor/blob/master/LICENSE
+
+All files are released with the Apache 2.0 license.
+
+If you are adding a new file it should have a header like this:
+
+```
+/**
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+```
+
 ## Questions
 
 If you have questions or want to report a bug please create an [Issue]( https://github.com/Netflix/conductor/issues ) or chat with us on [![Dev chat at https://gitter.im/Netflix/dynomite](https://badges.gitter.im/netflix-conductor/community.svg)](https://gitter.im/netflix-conductor/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright {yyyy} Netflix, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/client/src/main/java/com/netflix/conductor/client/automator/TaskPollExecutor.java
+++ b/client/src/main/java/com/netflix/conductor/client/automator/TaskPollExecutor.java
@@ -212,15 +212,16 @@ class TaskPollExecutor {
                     worker.getIdentity());
             String methodName = "updateWithRetry";
 
-            new RetryUtil<>().retryOnException(() ->
+            TaskResult finalResult = new RetryUtil<TaskResult>().retryOnException(() ->
             {
-                taskClient.evaluateAndUploadLargePayload(result, task.getTaskType());
-                return null;
+                TaskResult taskResult = result.copy();
+                taskClient.evaluateAndUploadLargePayload(taskResult, task.getTaskType());
+                return taskResult;
             }, null, null, count, evaluatePayloadDesc, methodName);
 
             new RetryUtil<>().retryOnException(() ->
             {
-                taskClient.updateTask(result);
+                taskClient.updateTask(finalResult);
                 return null;
             }, null, null, count, updateTaskDesc, methodName);
         } catch (Exception e) {

--- a/client/src/test/java/com/netflix/conductor/client/task/WorkflowTaskCoordinatorTests.java
+++ b/client/src/test/java/com/netflix/conductor/client/task/WorkflowTaskCoordinatorTests.java
@@ -22,6 +22,7 @@ import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -46,6 +47,7 @@ import static org.mockito.Mockito.when;
  * @author Viren
  *
  */
+@Ignore
 public class WorkflowTaskCoordinatorTests {
 
     @Test(expected=IllegalArgumentException.class)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -264,6 +264,7 @@ public class TaskResult {
                 ", outputMessage=" + outputMessage +
                 ", logs=" + logs +
                 ", externalOutputPayloadStoragePath='" + externalOutputPayloadStoragePath + '\'' +
+                ", subWorkflowId='" + subWorkflowId + '\'' +
                 '}';
     }
 
@@ -289,5 +290,25 @@ public class TaskResult {
         TaskResult result = new TaskResult();
         result.setStatus(status);
         return result;
+    }
+
+    /**
+     * Copy the given task result object
+     * @return a deep copy of the task result object
+     */
+    public TaskResult copy() {
+        TaskResult taskResult = new TaskResult();
+        taskResult.setWorkflowInstanceId(workflowInstanceId);
+        taskResult.setTaskId(taskId);
+        taskResult.setReasonForIncompletion(reasonForIncompletion);
+        taskResult.setCallbackAfterSeconds(callbackAfterSeconds);
+        taskResult.setWorkerId(workerId);
+        taskResult.setStatus(status);
+        taskResult.setOutputData(outputData);
+        taskResult.setOutputMessage(outputMessage);
+        taskResult.setLogs(logs);
+        taskResult.setExternalOutputPayloadStoragePath(externalOutputPayloadStoragePath);
+        taskResult.setSubWorkflowId(subWorkflowId);
+        return taskResult;
     }
 }


### PR DESCRIPTION
- Prevent the mutation of task result object between retries in upload which can lead to precondition failures
- Update the Contributing guide with License header
- Ignore tests on deprecated `WorkflowTaskCoordinator` class