### PR TITLE
Add prefix queries to es5,es6 using STARTS_WITH operator

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/query/parser/NameValue.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/query/parser/NameValue.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
  * @author Viren
  * <pre>
  * Represents an expression of the form as below:
- * key OPR value 
+ * key OPR value
  * OPR is the comparison operator which could be on the following:
  * 	&gt;, &lt;, = , !=, IN, BETWEEN
  * </pre>
@@ -115,6 +115,8 @@ public class NameValue extends AbstractNode implements FilterProvider {
             }
         } else if (op.getOperator().equals(Operators.LESS_THAN.value())) {
             return QueryBuilders.rangeQuery(name.getName()).to(value.getValue()).includeLower(false).includeUpper(false);
+        } else if (op.getOperator().equals(Operators.STARTS_WITH.value())) {
+            return QueryBuilders.prefixQuery(name.getName(), value.getUnquotedValue());
         }
 
         throw new IllegalStateException("Incorrect/unsupported operators");

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ConstValue.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ConstValue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -32,22 +32,24 @@ import java.io.InputStream;
  * <li>A value (x)
  * <li>A value is either a string or a number
  * </ol>
- * 
+ *
  */
 public class ConstValue extends AbstractNode {
-	
+
 	public static enum SystemConsts {
 		NULL("null"), NOT_NULL("not null");
 		private String value;
 		SystemConsts(String value){
 			this.value = value;
 		}
-		
+
 		public String value(){
 			return value;
 		}
 	}
-	
+
+	private static String QUOTE = "\"";
+
 	private Object value;
 
 	private SystemConsts sysConsts;
@@ -115,22 +117,30 @@ public class ConstValue extends AbstractNode {
 		if(!valid){
 			throw new ParserException("String constant is not quoted with <" + delim + "> : " + sb.toString());
 		}
-		return "\"" + sb.toString() + "\"";
+		return QUOTE + sb.toString() + QUOTE;
 	}
-	
+
 	public Object getValue(){
 		return value;
 	}
-	
+
 	@Override
 	public String toString(){
 		return ""+value;
 	}
-	
+
+	public String getUnquotedValue() {
+		String result = toString();
+		if (result.length() >= 2 && result.startsWith(QUOTE) && result.endsWith(QUOTE)) {
+			result = result.substring(1, result.length() - 1);
+		}
+		return result;
+	}
+
 	public boolean isSysConstant(){
 		return this.sysConsts != null;
 	}
-	
+
 	public SystemConsts getSysConstant(){
 		return this.sysConsts;
 	}

--- a/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -32,7 +32,7 @@ public class TestComparisonOp extends AbstractParserTest {
 
 	@Test
 	public void test() throws Exception {
-		String[] tests = new String[]{"<",">","=","!=","IN"};
+		String[] tests = new String[]{"<",">","=","!=","IN","STARTS_WITH"};
 		for(String test : tests){
 			ComparisonOp name = new ComparisonOp(getInputStream(test));
 			String nameVal = name.getOperator();
@@ -40,7 +40,7 @@ public class TestComparisonOp extends AbstractParserTest {
 			assertEquals(test, nameVal);
 		}
 	}
-	
+
 	@Test(expected=ParserException.class)
 	public void testInvalidOp() throws Exception {
 		String test =  "AND";

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/query/parser/NameValue.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/query/parser/NameValue.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
  * @author Viren
  * <pre>
  * Represents an expression of the form as below:
- * key OPR value 
+ * key OPR value
  * OPR is the comparison operator which could be on the following:
  * 	&gt;, &lt;, = , !=, IN, BETWEEN
  * </pre>
@@ -115,6 +115,8 @@ public class NameValue extends AbstractNode implements FilterProvider {
             }
         } else if (op.getOperator().equals(Operators.LESS_THAN.value())) {
             return QueryBuilders.rangeQuery(name.getName()).to(value.getValue()).includeLower(false).includeUpper(false);
+        } else if (op.getOperator().equals(Operators.STARTS_WITH.value())) {
+            return QueryBuilders.prefixQuery(name.getName(), value.getUnquotedValue());
         }
 
         throw new IllegalStateException("Incorrect/unsupported operators");

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -24,31 +24,44 @@ import java.io.InputStream;
  * @author Viren
  */
 public class ComparisonOp extends AbstractNode {
-	
+
 	public static enum Operators {
-		BETWEEN("BETWEEN"), EQUALS("="), LESS_THAN("<"), GREATER_THAN(">"), IN("IN"), NOT_EQUALS("!="), IS("IS");
-		
+		BETWEEN("BETWEEN"), EQUALS("="), LESS_THAN("<"), GREATER_THAN(">"), IN("IN"), NOT_EQUALS("!="), IS("IS"),
+		STARTS_WITH("STARTS_WITH");
+
 		private String value;
 		Operators(String value){
 			this.value = value;
 		}
-		
+
 		public String value(){
 			return value;
 		}
 	}
-	
+
+	static {
+		int max = 0;
+		for (Operators op: Operators.values()) {
+			max = Math.max(max, op.value().length());
+		}
+		maxOperatorLength = max;
+	}
+
+	private static final int maxOperatorLength;
+
 	private static final int betwnLen = Operators.BETWEEN.value().length();
-	
+
+	private static final int startsWithLen = Operators.STARTS_WITH.value().length();
+
 	private String value;
-	
+
 	public ComparisonOp(InputStream is) throws ParserException {
 		super(is);
 	}
 
 	@Override
 	protected void _parse() throws Exception {
-		byte[] peeked = peek(betwnLen);
+		byte[] peeked = peek(maxOperatorLength);
 		if(peeked[0] == '=' || peeked[0] == '>' || peeked[0] == '<'){
 			this.value = new String(peeked, 0, 1);
 		}else if(peeked[0] == 'I' && peeked[1] == 'N'){
@@ -59,18 +72,20 @@ public class ComparisonOp extends AbstractNode {
 			this.value = "!=";
 		}else if(peeked.length == betwnLen && new String(peeked).equals(Operators.BETWEEN.value())){
 			this.value = Operators.BETWEEN.value();
+		}else if(peeked.length == startsWithLen && new String(peeked).equals(Operators.STARTS_WITH.value())) {
+			this.value = Operators.STARTS_WITH.value();
 		}else{
-			throw new ParserException("Expecting an operator (=, >, <, !=, BETWEEN, IN), but found none.  Peeked=>" + new String(peeked));
+			throw new ParserException("Expecting an operator (=, >, <, !=, BETWEEN, IN, STARTS_WITH), but found none.  Peeked=>" + new String(peeked));
 		}
-		
+
 		read(this.value.length());
 	}
-	
+
 	@Override
 	public String toString(){
 		return " " + value + " ";
 	}
-	
+
 	public String getOperator(){
 		return value;
 	}

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ConstValue.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ConstValue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -32,22 +32,24 @@ import java.io.InputStream;
  * <li>A value (x)
  * <li>A value is either a string or a number
  * </ol>
- * 
+ *
  */
 public class ConstValue extends AbstractNode {
-	
+
 	public static enum SystemConsts {
 		NULL("null"), NOT_NULL("not null");
 		private String value;
 		SystemConsts(String value){
 			this.value = value;
 		}
-		
+
 		public String value(){
 			return value;
 		}
 	}
-	
+
+	private static String QUOTE = "\"";
+
 	private Object value;
 
 	private SystemConsts sysConsts;
@@ -115,22 +117,30 @@ public class ConstValue extends AbstractNode {
 		if(!valid){
 			throw new ParserException("String constant is not quoted with <" + delim + "> : " + sb.toString());
 		}
-		return "\"" + sb.toString() + "\"";
+		return QUOTE + sb.toString() + QUOTE;
 	}
-	
+
 	public Object getValue(){
 		return value;
 	}
-	
+
 	@Override
 	public String toString(){
 		return ""+value;
 	}
-	
+
+	public String getUnquotedValue() {
+		String result = toString();
+		if (result.length() >= 2 && result.startsWith(QUOTE) && result.endsWith(QUOTE)) {
+			result = result.substring(1, result.length() - 1);
+		}
+		return result;
+	}
+
 	public boolean isSysConstant(){
 		return this.sysConsts != null;
 	}
-	
+
 	public SystemConsts getSysConstant(){
 		return this.sysConsts;
 	}

--- a/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * 
+ *
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -32,7 +32,7 @@ public class TestComparisonOp extends AbstractParserTest {
 
 	@Test
 	public void test() throws Exception {
-		String[] tests = new String[]{"<",">","=","!=","IN"};
+		String[] tests = new String[]{"<",">","=","!=","IN","STARTS_WITH"};
 		for(String test : tests){
 			ComparisonOp name = new ComparisonOp(getInputStream(test));
 			String nameVal = name.getOperator();
@@ -40,7 +40,7 @@ public class TestComparisonOp extends AbstractParserTest {
 			assertEquals(test, nameVal);
 		}
 	}
-	
+
 	@Test(expected=ParserException.class)
 	public void testInvalidOp() throws Exception {
 		String test =  "AND";


### PR DESCRIPTION
Allow passing [Prefix Queries](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-prefix-query.html) e.g. `workflowType STARTS_WITH "add"`.