### PR TITLE
add workflow cleaner to clean expired workflows periodically

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -79,6 +79,15 @@ public interface Configuration {
     String TASKEXECLOG_INDEXING_ENABLED_PROPERTY_NAME = "workflow.taskExecLog.indexing.enabled";
     boolean TASKEXECLOG_INDEXING_ENABLED_DEFAULT_VALUE = true;
 
+    String WORKFLOW_CLEANER_EXPIRE_SECONDS_PROPERTY_NAME = "workflow.cleaner.expire.seconds";
+    long WORKFLOW_CLEANER_EXPIRE_SECONDS_DEFAULT_VALUE = -1;
+
+    String WORKFLOW_CLEANER_PERIOD_SECONDS_PROPERTY_NAME = "workflow.cleaner.period.seconds";
+    long WORKFLOW_CLEANER_PERIOD_SECONDS_DEFAULT_VALUE = 1800;
+
+    String WORKFLOW_CLEANER_BATCH_SIZE_PROPERTY_NAME = "workflow.cleaner.batch.size";
+    long WORKFLOW_CLEANER_BATCH_SIZE_DEFAULT_VALUE = 200;
+
     String TASK_DEF_REFRESH_TIME_SECS_PROPERTY_NAME = "conductor.taskdef.cache.refresh.time.seconds";
     int TASK_DEF_REFRESH_TIME_SECS_DEFAULT_VALUE = 60;
 
@@ -197,6 +206,30 @@ public interface Configuration {
 
     default boolean getJerseyEnabled() {
         return getBooleanProperty(JERSEY_ENABLED_PROPERTY_NAME, JERSEY_ENABLED_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the expire seconds of workflow used by workflow cleaner
+     */
+    default long getWorkflowCleanerExpireSeconds() {
+        return getLongProperty(WORKFLOW_CLEANER_EXPIRE_SECONDS_PROPERTY_NAME,
+                WORKFLOW_CLEANER_EXPIRE_SECONDS_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the period seconds of workflow used by workflow cleaner
+     */
+    default long getWorkflowCleanerPeriodSeconds() {
+        return getLongProperty(WORKFLOW_CLEANER_PERIOD_SECONDS_PROPERTY_NAME,
+                WORKFLOW_CLEANER_PERIOD_SECONDS_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return batch size used by workflow cleaner
+     */
+    default long getWorkflowCleanerBatchSize() {
+        return getLongProperty(WORKFLOW_CLEANER_BATCH_SIZE_PROPERTY_NAME,
+                WORKFLOW_CLEANER_BATCH_SIZE_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -246,6 +246,7 @@ public interface Configuration {
     default long getWorkflowCleanerBatchSize() {
         return getLongProperty(WORKFLOW_CLEANER_BATCH_SIZE_PROPERTY_NAME,
                 WORKFLOW_CLEANER_BATCH_SIZE_DEFAULT_VALUE);
+    }
     
    /**
      * @return true if owner email is mandatory for task definitions and workflow definitions


### PR DESCRIPTION
Hi, I ran into a problem while using redis persistence, which has already been discussed  in some issues like #1315.  Redis memory usage kept growing and random data including some metadata got evicted.
So I add a workflow cleaner in RedisExecutionDAO. It records the timestamp and workflowId in zset (timestamp as score, workflowId as value) when a workflow is created. A background thread will find and clean the expired workflows (indicated by config **workflow.cleaner.expire.seconds**) periodically. The period is indicated by config **workflow.cleaner.period.seconds**. If there are too many expired workflows, cleaner will process them batch by batch. The batch size is indicated by config **workflow.cleaner.batch.size**.
The cleaner is not meant to clean data in IndexDAO or other db implementation, because the disk-based storage may not have this problem. It works well in my environment and I hope this would help someone else. 