### PR TITLE
Update V3__queue_add_priority.sql

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `queue_message` ADD COLUMN IF NOT EXISTS `priority` TINYINT DEFAULT 0 AFTER `message_id`;
+ALTER TABLE `queue_message` ADD COLUMN `priority` TINYINT DEFAULT 0 AFTER `message_id`;


### PR DESCRIPTION
Remove SQL grammar when adding column : 'IF NOT EXISTS' , it's for PostgreSQL.