### PR TITLE
ElasticSearch Rest  BulkIndex NPE fix for Race condition

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestWrapper.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.dao.es5.index;
 
 import org.elasticsearch.action.bulk.BulkRequest;

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestWrapper.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/BulkRequestWrapper.java
@@ -1,0 +1,43 @@
+package com.netflix.conductor.dao.es5.index;
+
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Thread-safe wrapper for {@link BulkRequest}.
+ */
+class BulkRequestWrapper
+{
+    private final BulkRequest bulkRequest;
+
+    BulkRequestWrapper(@Nonnull BulkRequest bulkRequest) {
+        this.bulkRequest = Objects.requireNonNull(bulkRequest);
+    }
+
+    public void add(@Nonnull UpdateRequest req) {
+        synchronized (bulkRequest) {
+            bulkRequest.add(Objects.requireNonNull(req));
+        }
+    }
+
+    public void add(@Nonnull IndexRequest req) {
+        synchronized (bulkRequest) {
+            bulkRequest.add(Objects.requireNonNull(req));
+        }
+    }
+
+    BulkRequest get()
+    {
+        return bulkRequest;
+    }
+
+    int numberOfActions() {
+        synchronized (bulkRequest) {
+            return bulkRequest.numberOfActions();
+        }
+    }
+}

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -47,7 +47,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -57,7 +56,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.annotation.Nonnull;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -951,41 +949,6 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
         BulkRequests(long lastFlushTime, BulkRequest bulkRequestWrapper) {
             this.lastFlushTime = lastFlushTime;
             this.bulkRequestWrapper = new BulkRequestWrapper(bulkRequestWrapper);
-        }
-
-        /**
-         * Thread-safe wrapper for {@link BulkRequest}.
-         */
-        private static class BulkRequestWrapper
-        {
-            private final BulkRequest bulkRequest;
-
-            BulkRequestWrapper(@Nonnull BulkRequest bulkRequest) {
-                this.bulkRequest = Objects.requireNonNull(bulkRequest);
-            }
-
-            public void add(@Nonnull UpdateRequest req) {
-                synchronized (bulkRequest) {
-                    bulkRequest.add(Objects.requireNonNull(req));
-                }
-            }
-
-            public void add(@Nonnull IndexRequest req) {
-                synchronized (bulkRequest) {
-                    bulkRequest.add(Objects.requireNonNull(req));
-                }
-            }
-
-            private BulkRequest get()
-            {
-                return bulkRequest;
-            }
-
-            int numberOfActions() {
-                synchronized (bulkRequest) {
-                    return bulkRequest.numberOfActions();
-                }
-            }
         }
     }
 }

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestWrapper.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.dao.es6.index;
 
 import org.elasticsearch.action.bulk.BulkRequest;

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestWrapper.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/BulkRequestWrapper.java
@@ -1,0 +1,43 @@
+package com.netflix.conductor.dao.es6.index;
+
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Thread-safe wrapper for {@link BulkRequest}.
+ */
+class BulkRequestWrapper
+{
+    private final BulkRequest bulkRequest;
+
+    BulkRequestWrapper(@Nonnull BulkRequest bulkRequest) {
+        this.bulkRequest = Objects.requireNonNull(bulkRequest);
+    }
+
+    public void add(@Nonnull UpdateRequest req) {
+        synchronized (bulkRequest) {
+            bulkRequest.add(Objects.requireNonNull(req));
+        }
+    }
+
+    public void add(@Nonnull IndexRequest req) {
+        synchronized (bulkRequest) {
+            bulkRequest.add(Objects.requireNonNull(req));
+        }
+    }
+
+    BulkRequest get()
+    {
+        return bulkRequest;
+    }
+
+    int numberOfActions() {
+        synchronized (bulkRequest) {
+            return bulkRequest.numberOfActions();
+        }
+    }
+}


### PR DESCRIPTION
As per https://github.com/Netflix/conductor/issues/1553, there is a race condition in `BulkRequestBuilder` class of ElasticSearch which is used in ElasticSearchDAO transport client. In our setup, this NullPointerException happens in case of ElasticSearchRestDAO as well. ElasticSearchRestDAO uses `BulkRequest` object which in turn uses `ArrayList` to maintain the index requests is not synchronized. Hence this problem occurs in Rest implementation as well. So using an approach similar to https://github.com/Netflix/conductor/pull/1554 to use thread-safe wrapper for Rest implementation as well. Verified that in high throughput scenario the NullPointerExceptions are happening no more. Thanks, @skissane for the initial solution.