### PR TITLE
Update V3__queue_add_priority.sql

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
@@ -1,17 +1,1 @@
-SET @dbname = DATABASE();
-SET @tablename = "queue_message";
-SET @columnname = "priority";
-SET @preparedStatement = (SELECT IF(
-  (
-    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE
-      (table_name = @tablename)
-      AND (table_schema = @dbname)
-      AND (column_name = @columnname)
-  ) > 0,
-  "SELECT 1",
-  CONCAT("ALTER TABLE ", @tablename, " ADD ", @columnname, " TINYINT DEFAULT 0 AFTER `message_id`")
-));
-PREPARE addColumnIfNotExist FROM @preparedStatement;
-EXECUTE addColumnIfNotExist;
-DEALLOCATE PREPARE addColumnIfNotExist;
+ALTER TABLE `queue_message` ADD COLUMN `priority` TINYINT DEFAULT 0 AFTER `message_id`;


### PR DESCRIPTION
fix mysql compatibility problem, both the old syntax and the latest merged syntax are just for miradb:
The old syntax(The Mysql DDL can not support 'IF NOT EXISTS' syntax):
**ALTER TABLE `queue_message` ADD COLUMN IF NOT EXISTS `priority` TINYINT DEFAULT 0**

And the latest merged syntax also can't work for Mysql:
**SET @dbname = DATABASE();
SET @tablename = "queue_message";
SET @columnname = "priority";
SET @preparedStatement = (SELECT IF(
  (
    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
    WHERE
      (table_name = @tablename)
      AND (table_schema = @dbname)
      AND (column_name = @columnname)
  ) > 0,
  "SELECT 1",
  CONCAT("ALTER TABLE ", @tablename, " ADD ", @columnname, " TINYINT DEFAULT 0 AFTER `message_id`")
));
PREPARE addColumnIfNotExist FROM @preparedStatement;
EXECUTE addColumnIfNotExist;
DEALLOCATE PREPARE addColumnIfNotExist;**

