### PR TITLE
fix all in one dockerfile

### DIFF
--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -y \
   && chmod +x /app/startup.sh \
 
   # Get node
-  && curl -sL https://deb.nodesource.com/setup_6.x |  bash - \
+  && curl -sL https://deb.nodesource.com/setup_10.x |  bash - \
   && apt-get install -y nodejs build-essential
 
 # Get and install conductor


### PR DESCRIPTION
This fix the issue where
```
docker build ./docker/serverAndUI -f docker/serverAndUI/Dockerfile -t conductor:all-latest
```
can not be built because the container does not have npm. 

Check a few and found node 10.x is build-able - include NPM - and runable:
BUILD:
```
docker build ./docker/serverAndUI -f docker/serverAndUI/Dockerfile -t conductor:all-latest
```
RUN
```
docker run --rm --name conductor --rm -p 9000:8080 -p 5000:5000  -edb=memory -eworkflow.elasticsearch.instanceType=memory conductor:all-latest
```