### PR TITLE
tasklog limit - allow more than 10 entries

### DIFF
--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchDAOV5.java
@@ -469,8 +469,9 @@ public class ElasticSearchDAOV5 implements IndexDAO {
             final SearchRequestBuilder srb = elasticSearchClient.prepareSearch(logIndexPrefix + "*")
                 .setQuery(fq)
                 .setTypes(LOG_DOC_TYPE)
-                .addSort(sortBuilder);
-
+                .addSort(sortBuilder)
+                .setSize(config.getElasticSearchTasklogLimit());
+            
             SearchResponse response = srb.execute().actionGet();
 
             return Arrays.stream(response.getHits().getHits())

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/index/ElasticSearchRestDAOV5.java
@@ -509,6 +509,7 @@ public class ElasticSearchRestDAOV5 implements IndexDAO {
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             searchSourceBuilder.query(fq);
             searchSourceBuilder.sort(new FieldSortBuilder("createdTime").order(SortOrder.ASC));
+            searchSourceBuilder.size(config.getElasticSearchTasklogLimit());
 
             // Generate the actual request to send to ES.
             SearchRequest searchRequest = new SearchRequest(logIndexPrefix + "*");

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -76,6 +76,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_PROPERTY_NAME = "workflow.elasticsearch.index.replicas.count";
     int ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_DEFAULT_VALUE = 1;
 
+    String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "task.elasticsearch.query.size";
+    int ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE = 10;
+
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
     }
@@ -174,5 +177,11 @@ public interface ElasticSearchConfiguration extends Configuration {
     {
         return getIntProperty(ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_PROPERTY_NAME,
                               ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_DEFAULT_VALUE);
+    }
+
+    default int getElasticSearchTasklogLimit()
+    {
+        return getIntProperty(ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT,
+                ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE);
     }
 }

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -76,7 +76,7 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_PROPERTY_NAME = "workflow.elasticsearch.index.replicas.count";
     int ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_DEFAULT_VALUE = 1;
 
-    String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "task.elasticsearch.query.size";
+    String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "tasklog.elasticsearch.query.size";
     int ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE = 10;
 
     default String getURL() {

--- a/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/dao/es6/index/ElasticSearchDAOV6.java
@@ -451,6 +451,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
             final SearchRequestBuilder srb = elasticSearchClient.prepareSearch(logIndexPrefix + "*")
                     .setQuery(query)
                     .setTypes(LOG_DOC_TYPE)
+                    .setSize(config.getElasticSearchTasklogLimit())
                     .addSort(SortBuilders.fieldSort("createdTime").order(SortOrder.ASC));
 
             return mapTaskExecLogsResponse(srb.execute().actionGet());

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -64,6 +64,8 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_PROPERTY_NAME = "workflow.elasticsearch.index.replicas.count";
     int ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_DEFAULT_VALUE = 1;
 
+    String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "tasklog.elasticsearch.query.size";
+    int ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE = 10;
 
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
@@ -162,5 +164,11 @@ public interface ElasticSearchConfiguration extends Configuration {
     {
         return getIntProperty(ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_PROPERTY_NAME,
                 ELASTIC_SEARCH_INDEX_REPLICAS_COUNT_DEFAULT_VALUE);
+    }
+
+    default int getElasticSearchTasklogLimit()
+    {
+        return getIntProperty(ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT,
+                ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE);
     }
 }


### PR DESCRIPTION
When query elasticsearch if size is not specified ES server will serve only 10 first entries by default, this caused lost of task_log on conductor-ui

Assuming we have lots of task logs entries:
```
TASK_ID=$1

for i in {1..20};
do curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' "http://localhost:9000/api/tasks/$1/log" -d "$i";
done
```
Currently we can only see:
<img width="1125" alt="before" src="https://user-images.githubusercontent.com/5586453/78811520-55bf8600-7a0d-11ea-855f-be56982eac8a.png">

After the change, started with `task_elasticsearch_query_size=20`
```
docker run --rm --name conductor -p 9000:8080 -p 5000:5000  -edb=memory -eworkflow.elasticsearch.instanceType=memory -etask_elasticsearch_query_size=20 s50600822/conductor:all-tasklog-limit-4
```
<img width="1408" alt="after-startingwith-limit-at-20" src="https://user-images.githubusercontent.com/5586453/78811531-59eba380-7a0d-11ea-8026-f1ece1505cf1.png">

