### PR TITLE
Update elasticsearch when workflows get paused/resumed

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1058,7 +1058,7 @@ public class WorkflowExecutor {
                 return;        //Already paused!
             }
             workflow.setStatus(status);
-            executionDAOFacade.updateWorkflow(workflow, true);
+            executionDAOFacade.updateWorkflow(workflow);
         } finally {
             executionLockService.releaseLock(workflowId);
         }
@@ -1075,7 +1075,7 @@ public class WorkflowExecutor {
                     "Current status is " + workflow.getStatus().name());
         }
         workflow.setStatus(WorkflowStatus.RUNNING);
-        executionDAOFacade.updateWorkflow(workflow, true);
+        executionDAOFacade.updateWorkflow(workflow);
         decide(workflowId);
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1058,7 +1058,7 @@ public class WorkflowExecutor {
                 return;        //Already paused!
             }
             workflow.setStatus(status);
-            executionDAOFacade.updateWorkflow(workflow);
+            executionDAOFacade.updateWorkflow(workflow, true);
         } finally {
             executionLockService.releaseLock(workflowId);
         }
@@ -1075,7 +1075,7 @@ public class WorkflowExecutor {
                     "Current status is " + workflow.getStatus().name());
         }
         workflow.setStatus(WorkflowStatus.RUNNING);
-        executionDAOFacade.updateWorkflow(workflow);
+        executionDAOFacade.updateWorkflow(workflow, true);
         decide(workflowId);
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -225,7 +225,9 @@ public class ExecutionDAOFacade {
             } else {
                 indexDAO.asyncIndexWorkflow(workflow);
             }
-            workflow.getTasks().forEach(indexDAO::asyncIndexTask);
+			if (workflow.getStatus().isTerminal()) {
+				workflow.getTasks().forEach(indexDAO::asyncIndexTask);
+			}
         } else {
             indexDAO.indexWorkflow(workflow);
         }

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -237,12 +237,10 @@ public class ExecutionDAOFacade {
                     Monitors.recordWorkerQueueSize("delayQueue", scheduledThreadPoolExecutor.getQueue().size());
                 } else {
                 	indexWorkflow = true;
-                    indexDAO.asyncIndexWorkflow(workflow);
                 }
                 workflow.getTasks().forEach(indexDAO::asyncIndexTask);
             } else {
             	indexWorkflow = true;
-                indexDAO.indexWorkflow(workflow);
             }
         }
         


### PR DESCRIPTION
When workflows get paused or resumed, indexDAO.indexWorkflow() is not invoked so the workflow status stays at RUNNING even if it is PAUSED. Therefore you cannot get an accurate list of workflows when using workflow/search with freeText of status:PAUSED. This calls indexWorkflow() when the workflow is paused or resumed.