### PR TITLE
use semaphore instead of inmemory queue for processing system tasks

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraEventHandlerDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraEventHandlerDAO.java
@@ -20,6 +20,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.cassandra.CassandraConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.core.execution.ApplicationException;
@@ -36,9 +37,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
+@Trace
 public class CassandraEventHandlerDAO extends CassandraBaseDAO implements EventHandlerDAO {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraEventHandlerDAO.class);

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
@@ -54,9 +54,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 @Trace
 public class CassandraExecutionDAO extends CassandraBaseDAO implements ExecutionDAO, PollDataDAO {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraExecutionDAO.class);

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraMetadataDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraMetadataDAO.java
@@ -24,6 +24,7 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.cassandra.CassandraConfiguration;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -44,9 +45,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
+@Trace
 public class CassandraMetadataDAO extends CassandraBaseDAO implements MetadataDAO {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraMetadataDAO.class);

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
 package com.netflix.conductor.core.config;
 
 import com.google.inject.AbstractModule;
-
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +33,21 @@ public interface Configuration {
     String DISABLE_ASYNC_WORKERS_PROPERTY_NAME = "conductor.disable.async.workers";
     // FIXME This really should be typed correctly.
     String DISABLE_ASYNC_WORKERS_DEFAULT_VALUE = "false";
+
+    String SYSTEM_TASK_WORKER_THREAD_COUNT_PROPERTY_NAME = "workflow.system.task.worker.thread.count";
+    int SYSTEM_TASK_WORKER_THREAD_COUNT_DEFAULT_VALUE = 10;
+
+    String SYSTEM_TASK_WORKER_CALLBACK_SECONDS_PROPERTY_NAME = "workflow.system.task.worker.callback.seconds";
+    int SYSTEM_TASK_WORKER_CALLBACK_SECONDS_DEFAULT_VALUE = 30;
+
+    String SYSTEM_TASK_WORKER_POLL_INTERVAL_PROPERTY_NAME = "workflow.system.task.worker.poll.interval";
+    int SYSTEM_TASK_WORKER_POLL_INTERVAL_DEFAULT_VALUE = 50;
+
+    String SYSTEM_TASK_WORKER_EXECUTION_NAMESPACE_PROPERTY_NAME = "workflow.system.task.worker.executionNameSpace";
+    String SYSTEM_TASK_WORKER_EXECUTION_NAMESPACE_DEFAULT_VALUE = "";
+
+    String SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME = "workflow.isolated.system.task.worker.thread.count";
+    int SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE = 1;
 
     String ENVIRONMENT_PROPERTY_NAME = "environment";
     String ENVIRONMENT_DEFAULT_VALUE = "test";
@@ -138,6 +152,41 @@ public interface Configuration {
     }
 
     /**
+     * @return the number of threads to be used within the threadpool for system task workers
+     */
+    default int getSystemTaskWorkerThreadCount() {
+        return getIntProperty(SYSTEM_TASK_WORKER_THREAD_COUNT_PROPERTY_NAME, SYSTEM_TASK_WORKER_THREAD_COUNT_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the interval (in seconds) after which a system task will be checked for completion
+     */
+    default int getSystemTaskWorkerCallbackSeconds() {
+        return getIntProperty(SYSTEM_TASK_WORKER_CALLBACK_SECONDS_PROPERTY_NAME, SYSTEM_TASK_WORKER_CALLBACK_SECONDS_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the interval (in seconds) at which system task queues will be polled by the system task workers
+     */
+    default int getSystemTaskWorkerPollInterval() {
+        return getIntProperty(SYSTEM_TASK_WORKER_POLL_INTERVAL_PROPERTY_NAME, SYSTEM_TASK_WORKER_POLL_INTERVAL_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the namespace for the system task workers to provide instance level isolation
+     */
+    default String getSystemTaskWorkerExecutionNamespace() {
+        return getProperty(SYSTEM_TASK_WORKER_EXECUTION_NAMESPACE_PROPERTY_NAME, SYSTEM_TASK_WORKER_EXECUTION_NAMESPACE_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the number of threads to be used within the threadpool for system task workers in each isolation group
+     */
+    default int getSystemTaskWorkerIsolatedThreadCount() {
+        return getIntProperty(SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME, SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE);
+    }
+
+    /**
      * @return time frequency in seconds, at which the workflow sweeper should run to evaluate running workflows.
      */
     int getSweepFrequency();
@@ -238,7 +287,6 @@ public interface Configuration {
     }
 
     /**
-     *
      * @return The time to live in seconds of the event execution persisted. Currently, only RedisExecutionDAO supports it.
      */
     default int getEventExecutionPersistenceTTL() {

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.netflix.conductor.core.execution.ParametersUtils;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.JsonUtils;
 
+import com.netflix.conductor.metrics.Monitors;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -115,6 +116,7 @@ public class SimpleActionProcessor implements ActionProcessor {
             executor.updateTask(new TaskResult(task));
             logger.debug("Updated task: {} in workflow:{} with status: {} for event: {} for message:{}", taskId, workflowId, status, event, messageId);
         } catch (RuntimeException e) {
+            Monitors.recordEventActionError(action.getAction().name(), task.getTaskType(), event);
             logger.error("Error updating task: {} in workflow: {} in action: {} for event: {} for message: {}", taskDetails.getTaskRefName(), taskDetails.getWorkflowId(), action.getAction(), event, messageId, e);
             replaced.put("error", e.getMessage());
             throw e;
@@ -145,6 +147,7 @@ public class SimpleActionProcessor implements ActionProcessor {
             logger.debug("Started workflow: {}/{}/{} for event: {} for message:{}", params.getName(), params.getVersion(), workflowId, event, messageId);
 
         } catch (RuntimeException e) {
+            Monitors.recordEventActionError(action.getAction().name(), params.getName(), event);
             logger.error("Error starting workflow: {}, version: {}, for event: {} for message: {}", params.getName(), params.getVersion(), event, messageId, e);
             output.put("error", e.getMessage());
             throw e;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1146,7 +1146,7 @@ public class WorkflowExecutor {
     }
 
     //Executes the async system task
-    public void executeSystemTask(WorkflowSystemTask systemTask, String taskId, int unackTimeout) {
+    public void executeSystemTask(WorkflowSystemTask systemTask, String taskId, int callbackTime) {
         try {
             Task task = executionDAOFacade.getTaskById(taskId);
             if (task == null) {
@@ -1223,7 +1223,7 @@ public class WorkflowExecutor {
             }
 
             if (!task.getStatus().isTerminal()) {
-                task.setCallbackAfterSeconds(unackTimeout);
+                task.setCallbackAfterSeconds(callbackTime);
             }
 
             updateTask(new TaskResult(task));
@@ -1231,6 +1231,7 @@ public class WorkflowExecutor {
                 task.getOutputData().toString());
 
         } catch (Exception e) {
+            Monitors.error(className, "executeSystemTask");
             LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
@@ -1,5 +1,5 @@
  /*
-  * Copyright 2018 Netflix, Inc.
+  * Copyright 2020 Netflix, Inc.
   * <p>
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@
              httpTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
              httpTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
              httpTask.setIsolationGroupId(taskDefinition.getIsolationGroupId());
-             httpTask.setDomain(taskDefinition.getExecutionNameSpace());
+             httpTask.setExecutionNameSpace(taskDefinition.getExecutionNameSpace());
          }
          return Collections.singletonList(httpTask);
      }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
@@ -1,16 +1,43 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.core.execution.tasks;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.netflix.conductor.core.utils.SemaphoreUtil;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Executors;
 
 class ExecutionConfig {
 
-	ExecutorService service;
-	LinkedBlockingQueue<Runnable> workerQueue;
+    private ExecutorService executorService;
+    private SemaphoreUtil semaphoreUtil;
 
-	public ExecutionConfig(ExecutorService service, LinkedBlockingQueue<Runnable> workerQueue) {
-		this.service = service;
-		this.workerQueue = workerQueue;
-	}
+    public ExecutionConfig(int threadCount, String threadNameFormat) {
 
+        this.executorService = Executors.newFixedThreadPool(threadCount,
+            new ThreadFactoryBuilder().setNameFormat(threadNameFormat).build());
+
+        this.semaphoreUtil = new SemaphoreUtil(threadCount);
+    }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
+
+    public SemaphoreUtil getSemaphoreUtil() {
+        return semaphoreUtil;
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.execution.tasks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.QueueUtils;
+import com.netflix.conductor.core.utils.SemaphoreUtil;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.metrics.Monitors;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the threadpool used by system task workers for execution.
+ */
+class SystemTaskExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTaskExecutor.class);
+
+    private final int callbackTime;
+    private final QueueDAO queueDAO;
+
+    ExecutionConfig defaultExecutionConfig;
+    private final WorkflowExecutor workflowExecutor;
+    private final Configuration config;
+
+    ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
+
+    SystemTaskExecutor(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config) {
+        this.config = config;
+        int threadCount = config.getSystemTaskWorkerThreadCount();
+        this.callbackTime = config.getSystemTaskWorkerCallbackSeconds();
+
+        String threadNameFormat = "system-task-worker-%d";
+        this.defaultExecutionConfig = new ExecutionConfig(threadCount, threadNameFormat);
+        this.workflowExecutor = workflowExecutor;
+        this.queueDAO = queueDAO;
+
+        LOGGER.info("Initialized the SystemTaskExecutor with {} threads and callback time: {} seconds", threadCount,
+            callbackTime);
+    }
+
+    void pollAndExecute(String queueName) {
+        // get the remaining capacity of worker queue to prevent queue full exception
+        ExecutionConfig executionConfig = getExecutionConfig(queueName);
+        SemaphoreUtil semaphoreUtil = executionConfig.getSemaphoreUtil();
+        ExecutorService executorService = executionConfig.getExecutorService();
+        String taskName = QueueUtils.getTaskType(queueName);
+
+        if (!semaphoreUtil.canProcess()) {
+            // no available permits, do not poll
+            Monitors.recordSystemTaskWorkerPollingLimited(queueName);
+            return;
+        }
+        try {
+            List<String> polledTaskIds = queueDAO.pop(queueName, 1, 200);
+            Monitors.recordTaskPoll(queueName);
+            LOGGER.debug("Polling queue:{}, got {} tasks", queueName, polledTaskIds.size());
+            if (polledTaskIds.size() == 1 && StringUtils.isNotBlank(polledTaskIds.get(0))) {
+                String taskId = polledTaskIds.get(0);
+                LOGGER.debug("Task: {} from queue: {} being sent to the workflow executor", taskId, queueName);
+                Monitors.recordTaskPollCount(queueName, "", 1);
+
+                WorkflowSystemTask systemTask = SystemTaskWorkerCoordinator.taskNameWorkflowTaskMapping.get(taskName);
+                CompletableFuture<Void> taskCompletableFuture = CompletableFuture.runAsync(() ->
+                    workflowExecutor.executeSystemTask(systemTask, taskId, callbackTime), executorService);
+
+                // release permit after processing is complete
+                taskCompletableFuture.whenComplete((r, e) -> semaphoreUtil.completeProcessing());
+            } else {
+                // no task polled, release permit
+                semaphoreUtil.completeProcessing();
+            }
+        } catch (Exception e) {
+            // release the permit if exception is thrown during polling, because the thread would not be busy
+            semaphoreUtil.completeProcessing();
+            Monitors.recordTaskPollError(taskName, "", e.getClass().getSimpleName());
+            LOGGER.error("Error polling system task in queue:{}", queueName, e);
+        }
+    }
+
+    @VisibleForTesting
+    ExecutionConfig getExecutionConfig(String taskQueue) {
+        if (!QueueUtils.isIsolatedQueue(taskQueue)) {
+            return this.defaultExecutionConfig;
+        }
+        return queueExecutionConfigMap.computeIfAbsent(taskQueue, __ -> this.createExecutionConfig());
+    }
+
+    private ExecutionConfig createExecutionConfig() {
+        int threadCount = config.getSystemTaskWorkerIsolatedThreadCount();
+        String threadNameFormat = "isolated-system-task-worker-%d";
+        return new ExecutionConfig(threadCount, threadNameFormat);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,31 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- */
 package com.netflix.conductor.core.execution.tasks;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -45,188 +36,93 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Viren
- *
- */
 @Singleton
 public class SystemTaskWorkerCoordinator {
 
-	private static final Logger logger = LoggerFactory.getLogger(SystemTaskWorkerCoordinator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTaskWorkerCoordinator.class);
 
-	private QueueDAO queueDAO;
+    private SystemTaskExecutor systemTaskExecutor;
+    private final Configuration config;
 
-	private WorkflowExecutor workflowExecutor;
+    private final int pollInterval;
+    private final String executionNameSpace;
 
-	private ExecutorService executorService;
+    static BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+    private static Set<String> listeningTaskQueues = new HashSet<>();
+    public static Map<String, WorkflowSystemTask> taskNameWorkflowTaskMapping = new ConcurrentHashMap<>();
 
-	private int workerQueueSize;
+    private static final String CLASS_NAME = SystemTaskWorkerCoordinator.class.getName();
 
-	//Number of items to poll for
-	private int pollCount;
+    @Inject
+    public SystemTaskWorkerCoordinator(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config) {
+        this.config = config;
 
-	//Interval in ms at which the polling is done
-	private int pollInterval;
+        this.executionNameSpace = config.getSystemTaskWorkerExecutionNamespace();
+        this.pollInterval = config.getSystemTaskWorkerPollInterval();
+        int threadCount = config.getSystemTaskWorkerThreadCount();
+        if (threadCount > 0) {
+            this.systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, config);
+            new Thread(this::listen).start();
+            LOGGER.info("System Task Worker Coordinator initialized with poll interval: {}", pollInterval);
+        } else {
+            LOGGER.info("System Task Worker DISABLED");
+        }
+    }
 
-	private LinkedBlockingQueue<Runnable> workerQueue;
+    static synchronized void add(WorkflowSystemTask systemTask) {
+        LOGGER.info("Adding the queue for system task: {}", systemTask.getName());
+        taskNameWorkflowTaskMapping.put(systemTask.getName(), systemTask);
+        queue.add(systemTask.getName());
+    }
 
-	private int unackTimeout;
+    private void listen() {
+        try {
+            for (; ; ) {
+                String workflowSystemTaskQueueName = queue.poll(60, TimeUnit.SECONDS);
+                if (workflowSystemTaskQueueName != null && !listeningTaskQueues.contains(workflowSystemTaskQueueName)
+                    && shouldListen(workflowSystemTaskQueueName)) {
+                    listen(workflowSystemTaskQueueName);
+                    listeningTaskQueues.add(workflowSystemTaskQueueName);
+                }
+            }
+        } catch (InterruptedException ie) {
+            Monitors.error(CLASS_NAME, "listen");
+            LOGGER.warn("Error listening for workflow system tasks", ie);
+        }
+    }
 
-	private Configuration config;
+    private void listen(String queueName) {
+        Executors.newSingleThreadScheduledExecutor()
+            .scheduleWithFixedDelay(() -> pollAndExecute(queueName), 1000, pollInterval, TimeUnit.MILLISECONDS);
+        LOGGER.info("Started listening for queue: {}", queueName);
+    }
 
-	private final String executionNameSpace;
+    private void pollAndExecute(String queueName) {
+        if (config.disableAsyncWorkers()) {
+            LOGGER.warn("System Task Worker is DISABLED.  Not polling for system task in queue : {}", queueName);
+            return;
+        }
+        systemTaskExecutor.pollAndExecute(queueName);
+    }
 
-	static BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+    @VisibleForTesting
+    boolean isFromCoordinatorExecutionNameSpace(String queueName) {
+        String queueExecutionNameSpace = QueueUtils.getExecutionNameSpace(queueName);
+        return StringUtils.equals(queueExecutionNameSpace, executionNameSpace);
+    }
 
-	private static Set<String> listeningTaskQueues = new HashSet<>();
+    private boolean shouldListen(String workflowSystemTaskQueueName) {
+        return isFromCoordinatorExecutionNameSpace(workflowSystemTaskQueueName)
+            && isAsyncSystemTask(workflowSystemTaskQueueName);
+    }
 
-	ExecutionConfig defaultExecutionConfig;
-
-	ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
-
-	public static Map<String, WorkflowSystemTask> taskNameWorkFlowTaskMapping = new ConcurrentHashMap<>();
-
-	private static final String className = SystemTaskWorkerCoordinator.class.getName();
-
-	@Inject
-	public SystemTaskWorkerCoordinator(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config) {
-		this.queueDAO = queueDAO;
-		this.workflowExecutor = workflowExecutor;
-		this.config = config;
-		this.unackTimeout = config.getIntProperty("workflow.system.task.worker.callback.seconds", 30);
-		int threadCount = config.getIntProperty("workflow.system.task.worker.thread.count", 10);
-		this.pollCount = config.getIntProperty("workflow.system.task.worker.poll.count", 10);
-		this.pollInterval = config.getIntProperty("workflow.system.task.worker.poll.interval", 50);
-		this.workerQueueSize = config.getIntProperty("workflow.system.task.worker.queue.size", 100);
-		this.workerQueue = new LinkedBlockingQueue<>(workerQueueSize);
-		this.executionNameSpace =config.getProperty("workflow.system.task.worker.executionNameSpace","");
-
-		if(threadCount > 0) {
-			ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("system-task-worker-%d").build();
-			this.executorService = new ThreadPoolExecutor(threadCount, threadCount,
-	                0L, TimeUnit.MILLISECONDS,
-	                workerQueue,
-	                threadFactory);
-			this.defaultExecutionConfig = new ExecutionConfig(this.executorService, this.workerQueue);
-			new Thread(this::listen).start();
-			logger.info("System Task Worker initialized with {} threads and a callback time of {} seconds and queue size: {} with pollCount: {} and poll interval: {}", threadCount, unackTimeout, workerQueueSize, pollCount, pollInterval);
-		} else {
-			logger.info("System Task Worker DISABLED");
-		}
-	}
-
-	static synchronized void add(WorkflowSystemTask systemTask) {
-		logger.info("Adding the queue for system task: {}", systemTask.getName());
-		taskNameWorkFlowTaskMapping.put(systemTask.getName(),systemTask);
-		queue.add(systemTask.getName());
-	}
-
-	private void listen() {
-		try {
-			//noinspection InfiniteLoopStatement
-			for(;;) {
-				String workflowSystemTaskQueueName = queue.poll(60, TimeUnit.SECONDS);
-				if (workflowSystemTaskQueueName != null && !listeningTaskQueues.contains(workflowSystemTaskQueueName) && shouldListen(workflowSystemTaskQueueName)) {
-					listen(workflowSystemTaskQueueName);
-					listeningTaskQueues.add(workflowSystemTaskQueueName);
-				}
-			}
-		}catch(InterruptedException ie) {
-			Monitors.error(className, "listen");
-			logger.warn("Error listening for workflow system tasks", ie);
-		}
-	}
-
-	private void listen(String queueName) {
-		Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(() -> pollAndExecute(queueName), 1000, pollInterval, TimeUnit.MILLISECONDS);
-		logger.info("Started listening for queue: {}", queueName);
-	}
-
-	@VisibleForTesting
-	void pollAndExecute(String queueName) {
-		try {
-			if(config.disableAsyncWorkers()) {
-				logger.warn("System Task Worker is DISABLED.  Not polling for system task in queue : {}", queueName);
-				return;
-			}
-			// get the remaining capacity of worker queue to prevent queue full exception
-			ExecutionConfig executionConfig = getExecutionConfig(queueName);
-			LinkedBlockingQueue<Runnable> workerQueue = executionConfig.workerQueue;
-			int realPollCount = Math.min(workerQueue.remainingCapacity(), pollCount);
-			if (realPollCount <= 0) {
-                logger.debug("All workers are busy, not polling. queue size: {}, max: {}, task:{}", workerQueue.size(),
-					workerQueueSize, queueName);
-                return;
-			}
-
-			List<String> polledTaskIds = queueDAO.pop(queueName, realPollCount, 200);
-			Monitors.recordTaskPoll(queueName);
-			logger.debug("Polling for {}, got {} tasks", queueName, polledTaskIds.size());
-			for(String taskId : polledTaskIds) {
-				logger.debug("Task: {} from queue: {} being sent to the workflow executor", taskId, queueName);
-				try {
-					String taskName = QueueUtils.getTaskType(queueName);
-					WorkflowSystemTask systemTask = taskNameWorkFlowTaskMapping.get(taskName);
-					ExecutorService executorService = executionConfig.service;
-					executorService.submit(() -> workflowExecutor.executeSystemTask(systemTask, taskId, unackTimeout));
-				} catch(RejectedExecutionException ree) {
-					logger.warn("Queue full for workers. Size: {}, queue:{}", workerQueue.size(), queueName);
-				}
-			}
-		} catch (Exception e) {
-			Monitors.error(className, "pollAndExecute");
-			logger.error("Error executing system task in queue:{}", queueName, e);
-		}
-	}
-
-
-	public boolean isFromCoordinatorExecutionNameSpace(String queueName) {
-		String queueExecutionNameSpace = QueueUtils.getExecutionNameSpace(queueName);
-		return StringUtils.equals(queueExecutionNameSpace, this.executionNameSpace);
-	}
-
-	private boolean shouldListen(String workflowSystemTaskQueueName) {
-		return isFromCoordinatorExecutionNameSpace(workflowSystemTaskQueueName) && isSystemTask(workflowSystemTaskQueueName);
-	}
-
-
-	public static boolean isSystemTask(String queue) {
-
-		String taskType = QueueUtils.getTaskType(queue);
-
-		if(StringUtils.isNotBlank(taskType)) {
-
-			WorkflowSystemTask task = taskNameWorkFlowTaskMapping.get(taskType);
-			return Objects.nonNull(task) && task.isAsync();
-
-		}
-
-		return false;
-	}
-
-
-
-	public ExecutionConfig getExecutionConfig(String taskQueue) {
-
-		if (!QueueUtils.isIsolatedQueue(taskQueue)) {
-			return this.defaultExecutionConfig;
-		}
-
-		return queueExecutionConfigMap.computeIfAbsent(taskQueue, __ -> this.createExecutionConfig());
-
-	}
-
-	private ExecutionConfig createExecutionConfig() {
-
-		int workerQueueSize = config.getIntProperty("workflow.isolated.system.task.worker.queue.size", 100);
-		LinkedBlockingQueue<Runnable> workerQueue = new LinkedBlockingQueue<>(workerQueueSize);
-		int threadCount = config.getIntProperty("workflow.isolated.system.task.worker.thread.count", 1);
-		ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("isolated-system-task-worker-%d").build();
-
-		return new ExecutionConfig(new ThreadPoolExecutor(threadCount, threadCount,
-				0L, TimeUnit.MILLISECONDS,
-				workerQueue,
-				threadFactory), workerQueue);
-
-	}
+    @VisibleForTesting
+    boolean isAsyncSystemTask(String queue) {
+        String taskType = QueueUtils.getTaskType(queue);
+        if (StringUtils.isNotBlank(taskType)) {
+            WorkflowSystemTask task = taskNameWorkflowTaskMapping.get(taskType);
+            return Objects.nonNull(task) && task.isAsync();
+        }
+        return false;
+    }
 }	

--- a/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/QueueUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@ package com.netflix.conductor.core.utils;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import org.apache.commons.lang3.StringUtils;
 
-/**
- * @author visingh
- */
 public class QueueUtils {
 
 	public static final String DOMAIN_SEPARATOR = ":";
@@ -41,10 +38,9 @@ public class QueueUtils {
 	 * @param executionNameSpace
 	 * @return   //domain:taskType@eexecutionNameSpace-isolationGroup
 	 */
-	public static String getQueueName(
-			String taskType, String domain, String isolationGroup, String executionNameSpace) {
+	public static String getQueueName(String taskType, String domain, String isolationGroup, String executionNameSpace) {
 
-		String queueName = null;
+		String queueName;
 		if (domain == null) {
 			queueName = taskType;
 		} else {
@@ -54,7 +50,6 @@ public class QueueUtils {
 		if (executionNameSpace != null) {
 			queueName = queueName + EXECUTION_NAME_SPACE_SEPRATOR + executionNameSpace;
 		}
-
 
 		if (isolationGroup != null) {
 			queueName = queueName + ISOLATION_SEPARATOR + isolationGroup;
@@ -76,15 +71,12 @@ public class QueueUtils {
 		}
 	}
 
-
 	public static boolean isIsolatedQueue(String queue) {
 		return StringUtils.isNotBlank(getIsolationGroup(queue));
 	}
 
 	private static String getIsolationGroup(String queue) {
-
 		return StringUtils.substringAfter(queue, QueueUtils.ISOLATION_SEPARATOR);
-
 	}
 
 	public static String getTaskType(String queue) {

--- a/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.utils;
+
+import java.util.concurrent.Semaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A class wrapping a semaphore which holds the number of permits available for processing.
+ */
+public class SemaphoreUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SemaphoreUtil.class);
+    private Semaphore semaphore;
+
+    public SemaphoreUtil(int numSlots) {
+        LOGGER.debug("Semaphore util initialized with {} permits", numSlots);
+        semaphore = new Semaphore(numSlots);
+    }
+
+    /**
+     * Signals if processing is allowed based on whether a permit can be acquired.
+     *
+     * @return {@code true} - if permit is acquired
+     *         {@code false} - if permit could not be acquired
+     */
+    public boolean canProcess() {
+        boolean acquired = semaphore.tryAcquire();
+        LOGGER.debug("Trying to acquire permit: {}", acquired);
+        return acquired;
+    }
+
+    /**
+     * Signals that processing is complete and the permit can be released.
+     */
+    public void completeProcessing() {
+        LOGGER.debug("Completed execution; releasing permit");
+        semaphore.release();
+    }
+
+    /**
+     * Gets the number of slots available for processing.
+     *
+     * @return number of available permits
+     */
+    public int availableSlots() {
+        int available = semaphore.availablePermits();
+        LOGGER.debug("Number of available permits: {}", available);
+        return available;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-/**
- *
  */
 package com.netflix.conductor.metrics;
 
@@ -245,6 +242,10 @@ public class Monitors {
 		counter(classQualifier, "event_queue_messages_handled", "queueType", queueType, "queueName", queueName);
 	}
 
+	public static void recordEventActionError(String action, String entityName, String event) {
+		counter(classQualifier, "event_action_error", "action", action, "entityName", entityName, "event", event);
+	}
+
 	public static void recordDaoRequests(String dao, String action, String taskType, String workflowType) {
 		counter(classQualifier, "dao_requests", "dao", dao, "action", action, "taskType", taskType, "workflowType", workflowType);
 	}
@@ -282,7 +283,7 @@ public class Monitors {
 	}
 
 	public static void recordDiscardedIndexingCount(String queueType) {
-		getCounter(Monitors.classQualifier, "discarded_index_count", "queueType", queueType).increment();
+		counter(Monitors.classQualifier, "discarded_index_count", "queueType", queueType);
 	}
 
 	public static void recordAcquireLockUnsuccessful() {
@@ -291,5 +292,9 @@ public class Monitors {
 
 	public static void recordAcquireLockFailure(String exceptionClassName) {
 		counter(classQualifier, "acquire_lock_failure", "exceptionType", exceptionClassName);
+	}
+
+	public static void recordSystemTaskWorkerPollingLimited(String queueName) {
+		counter(classQualifier, "system_task_worker_polling_limited", "queueName", queueName);
 	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestIsolatedTaskQueueProducer.java
@@ -14,7 +14,7 @@ public class TestIsolatedTaskQueueProducer {
 	@Test
 	public void addTaskQueuesAddsElementToQueue() throws InterruptedException {
 
-		SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.put("HTTP", Mockito.mock(WorkflowSystemTask.class));
+		SystemTaskWorkerCoordinator.taskNameWorkflowTaskMapping.put("HTTP", Mockito.mock(WorkflowSystemTask.class));
 		MetadataService metadataService = Mockito.mock(MetadataService.class);
 		IsolatedTaskQueueProducer isolatedTaskQueueProducer = new IsolatedTaskQueueProducer(metadataService, Mockito.mock(Configuration.class));
 		TaskDef taskDef = new TaskDef();

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskExecutor.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.execution.tasks;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.QueueDAO;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressWarnings("UnstableApiUsage")
+public class TestSystemTaskExecutor {
+
+    private static final String TEST_TASK = "system_task";
+    private static final String ISOLATED_TASK = "system_task-isolated";
+
+    private WorkflowExecutor workflowExecutor;
+    private QueueDAO queueDAO;
+    private ScheduledExecutorService scheduledExecutorService;
+
+    private SystemTaskExecutor systemTaskExecutor;
+
+    @Before
+    public void setUp() {
+        workflowExecutor = mock(WorkflowExecutor.class);
+        queueDAO = mock(QueueDAO.class);
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        createTaskMapping();
+    }
+
+    @After
+    public void tearDown() {
+        shutdownExecutorService(scheduledExecutorService);
+        shutdownExecutorService(systemTaskExecutor.defaultExecutionConfig.getExecutorService());
+        systemTaskExecutor.queueExecutionConfigMap.values()
+            .forEach(e -> shutdownExecutorService(e.getExecutorService()));
+    }
+
+    @Test
+    public void testGetExecutionConfigForSystemTask() {
+        System.setProperty("workflow.system.task.worker.thread.count", "5");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+        assertEquals(systemTaskExecutor.getExecutionConfig("").getSemaphoreUtil().availableSlots(), 5);
+    }
+
+    @Test
+    public void testGetExecutionConfigForIsolatedSystemTask() {
+        System.setProperty("workflow.isolated.system.task.worker.thread.count", "7");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+        assertEquals(systemTaskExecutor.getExecutionConfig("test-iso").getSemaphoreUtil().availableSlots(), 7);
+    }
+
+    @Test
+    public void testPollAndExecuteSytemTask() {
+        System.setProperty("workflow.system.task.worker.thread.count", "1");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenReturn(Collections.singletonList("taskId"));
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                latch.countDown();
+                return null;
+            }
+        ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+        scheduledExecutorService.scheduleAtFixedRate(
+            () -> systemTaskExecutor.pollAndExecute(TEST_TASK), 0, 1, TimeUnit.SECONDS);
+
+        Uninterruptibles.awaitUninterruptibly(latch);
+        verify(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+    }
+
+    @Test
+    public void testPollAndExecuteIsolatedSystemTask() {
+        System.setProperty("workflow.isolated.system.task.worker.thread.count", "1");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenReturn(Collections.singletonList("isolated_taskId"));
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                latch.countDown();
+                return null;
+            }
+        ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+        scheduledExecutorService.scheduleAtFixedRate(
+            () -> systemTaskExecutor.pollAndExecute(ISOLATED_TASK), 0, 1, TimeUnit.SECONDS);
+
+        Uninterruptibles.awaitUninterruptibly(latch);
+        verify(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+    }
+
+    @Test
+    public void testPollException() {
+        System.setProperty("workflow.system.task.worker.thread.count", "1");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        when(queueDAO.pop(anyString(), anyInt(), anyInt()))
+            .thenThrow(RuntimeException.class)
+            .thenReturn(Collections.singletonList("taskId"));
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                latch.countDown();
+                return null;
+            }
+        ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+        scheduledExecutorService.scheduleAtFixedRate(
+            () -> systemTaskExecutor.pollAndExecute(TEST_TASK), 0, 1, TimeUnit.SECONDS);
+
+        Uninterruptibles.awaitUninterruptibly(latch);
+        verify(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+    }
+
+    @Test
+    public void testMultipleQueuesExecution() {
+        System.setProperty("workflow.system.task.worker.thread.count", "1");
+        System.setProperty("workflow.isolated.system.task.worker.thread.count", "1");
+        String sysTask = "taskId";
+        String isolatedTask = "isolatedTaskId";
+        Configuration configuration = new SystemPropertiesConfiguration();
+        when(queueDAO.pop(TEST_TASK, 1, 200)).thenReturn(Collections.singletonList(sysTask));
+        when(queueDAO.pop(ISOLATED_TASK, 1, 200)).thenReturn(Collections.singletonList(isolatedTask));
+        systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+        CountDownLatch sysTaskLatch = new CountDownLatch(1);
+        CountDownLatch isolatedTaskLatch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                Object[] args = invocation.getArguments();
+                String taskId = args[1].toString();
+                if (taskId.equals(sysTask)) {
+                    sysTaskLatch.countDown();
+                }
+                if (taskId.equals(isolatedTask)) {
+                    isolatedTaskLatch.countDown();
+                }
+                return null;
+            }
+        ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+        scheduledExecutorService
+            .scheduleAtFixedRate(() -> systemTaskExecutor.pollAndExecute(TEST_TASK), 0, 1, TimeUnit.SECONDS);
+
+        ScheduledExecutorService isoTaskService = Executors.newSingleThreadScheduledExecutor();
+        isoTaskService
+            .scheduleAtFixedRate(() -> systemTaskExecutor.pollAndExecute(ISOLATED_TASK), 0, 1, TimeUnit.SECONDS);
+
+        Uninterruptibles.awaitUninterruptibly(sysTaskLatch);
+        Uninterruptibles.awaitUninterruptibly(isolatedTaskLatch);
+
+        shutdownExecutorService(isoTaskService);
+    }
+
+    private void shutdownExecutorService(ExecutorService executorService) {
+        try {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException ie) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void createTaskMapping() {
+        WorkflowSystemTask mockWorkflowTask = mock(WorkflowSystemTask.class);
+        when(mockWorkflowTask.getName()).thenReturn(TEST_TASK);
+        when(mockWorkflowTask.isAsync()).thenReturn(true);
+        SystemTaskWorkerCoordinator.taskNameWorkflowTaskMapping.put(TEST_TASK, mockWorkflowTask);
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
@@ -1,131 +1,76 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.conductor.core.execution.tasks;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 public class TestSystemTaskWorkerCoordinator {
 
-	public static final String TEST_QUEUE = "test";
-	public static final String ISOLATION_CONSTANT = "-iso";
+    private static final String TEST_QUEUE = "test";
+    private static final String EXECUTION_NAMESPACE_CONSTANT = "@exeNS";
+    private static final String ISOLATION_CONSTANT = "-iso";
 
-	@Test
-	public void testPollAndExecuteForIsolatedQueues() {
+    private QueueDAO queueDAO;
+    private WorkflowExecutor workflowExecutor;
 
-		createTaskMapping();
+    @Before
+    public void setUp() {
+        queueDAO = mock(QueueDAO.class);
+        workflowExecutor = mock(WorkflowExecutor.class);
+    }
 
-		Configuration configuration = Mockito.mock(Configuration.class);
-		QueueDAO queueDao = Mockito.mock(QueueDAO.class);
-		Mockito.when(configuration.getIntProperty(Mockito.anyString(), Mockito.anyInt())).thenReturn(10);
-		Mockito.when(queueDao.pop(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(Arrays.asList("taskId"));
-		WorkflowExecutor wfE = Mockito.mock(WorkflowExecutor.class);
-		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDao, wfE, configuration);
+    @Test
+    public void isSystemTask() {
+        createTaskMapping();
+        SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
+            workflowExecutor, mock(Configuration.class));
+        assertTrue(systemTaskWorkerCoordinator.isAsyncSystemTask(TEST_QUEUE + ISOLATION_CONSTANT));
+    }
 
-		systemTaskWorkerCoordinator.pollAndExecute(TEST_QUEUE + ISOLATION_CONSTANT);
-		shutDownExecutors(systemTaskWorkerCoordinator);
+    @Test
+    public void isSystemTaskNotPresent() {
+        createTaskMapping();
+        SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
+            workflowExecutor, mock(Configuration.class));
+        assertFalse(systemTaskWorkerCoordinator.isAsyncSystemTask(null));
+    }
 
-		Mockito.verify(wfE, Mockito.times(1)).executeSystemTask(Mockito.any(), Mockito.anyString(), Mockito.anyInt());
+    @Test
+    public void testIsFromCoordinatorExecutionNameSpace() {
+        System.setProperty("workflow.system.task.worker.executionNameSpace", "exeNS");
+        Configuration configuration = new SystemPropertiesConfiguration();
+        SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
+            workflowExecutor, configuration);
+        assertTrue(systemTaskWorkerCoordinator.isFromCoordinatorExecutionNameSpace(TEST_QUEUE + EXECUTION_NAMESPACE_CONSTANT));
+    }
 
-	}
-
-	@Test
-	public void testPollAndExecuteForTaskQueues() {
-
-		createTaskMapping();
-
-		Configuration configuration = Mockito.mock(Configuration.class);
-		QueueDAO queueDao = Mockito.mock(QueueDAO.class);
-		Mockito.when(configuration.getIntProperty(Mockito.any(), Mockito.anyInt())).thenReturn(10);
-		Mockito.when(queueDao.pop(Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(Arrays.asList("taskId"));
-		WorkflowExecutor wfE = Mockito.mock(WorkflowExecutor.class);
-		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDao, wfE, configuration);
-
-		systemTaskWorkerCoordinator.pollAndExecute(TEST_QUEUE);
-		shutDownExecutors(systemTaskWorkerCoordinator);
-
-		Mockito.verify(wfE, Mockito.times(1)).executeSystemTask(Mockito.any(), Mockito.anyString(), Mockito.anyInt());
-
-	}
-
-	private void shutDownExecutors(SystemTaskWorkerCoordinator systemTaskWorkerCoordinator) {
-
-		systemTaskWorkerCoordinator.defaultExecutionConfig.service.shutdown();
-
-		try {
-			systemTaskWorkerCoordinator.defaultExecutionConfig.service.awaitTermination(10, TimeUnit.MILLISECONDS);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-
-		systemTaskWorkerCoordinator.queueExecutionConfigMap.values().stream().forEach(e -> {
-			e.service.shutdown();
-			try {
-				e.service.awaitTermination(10, TimeUnit.MILLISECONDS);
-			} catch (InterruptedException ie) {
-
-			}
-		});
-
-	}
-
-	@Test
-	public void isSystemTask() {
-
-		createTaskMapping();
-		Assert.assertTrue(SystemTaskWorkerCoordinator.isSystemTask(TEST_QUEUE + ISOLATION_CONSTANT));
-
-	}
-
-	@Test
-	public void isSystemTaskNotPresent() {
-
-		createTaskMapping();
-		Assert.assertFalse(SystemTaskWorkerCoordinator.isSystemTask(null));
-
-	}
-
-	private void createTaskMapping() {
-
-		WorkflowSystemTask mockWfTask = Mockito.mock(WorkflowSystemTask.class);
-		Mockito.when(mockWfTask.getName()).thenReturn(TEST_QUEUE);
-		Mockito.when(mockWfTask.isAsync()).thenReturn(true);
-		SystemTaskWorkerCoordinator.taskNameWorkFlowTaskMapping.put(TEST_QUEUE, mockWfTask);
-
-	}
-
-	@Test
-	public void testGetExecutionConfigForSystemTask() {
-
-		Configuration configuration = Mockito.mock(Configuration.class);
-		Mockito.when(configuration.getIntProperty(Mockito.anyString(), Mockito.anyInt())).thenReturn(1);
-		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
-		Assert.assertEquals(systemTaskWorkerCoordinator.getExecutionConfig("").workerQueue.remainingCapacity(), 1);
-
-	}
-
-	@Test
-	public void testGetExecutionConfigForIsolatedSystemTask() {
-
-		Configuration configuration = new SystemPropertiesConfiguration();
-		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
-		Assert.assertEquals(systemTaskWorkerCoordinator.getExecutionConfig("test-iso").workerQueue.remainingCapacity(), 100);
-
-	}
-
-
-	@Test
-	public void testIsFromCoordinatorDomain() {
-		System.setProperty("workflow.system.task.worker.domain","domain");
-		Configuration configuration = new SystemPropertiesConfiguration();
-		SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(Mockito.mock(QueueDAO.class), Mockito.mock(WorkflowExecutor.class), configuration);
-		Assert.assertEquals(systemTaskWorkerCoordinator.isFromCoordinatorExecutionNameSpace("domain:testTaskType"), true);
-
-	}
+    private void createTaskMapping() {
+        WorkflowSystemTask mockWorkflowTask = mock(WorkflowSystemTask.class);
+        when(mockWorkflowTask.getName()).thenReturn(TEST_QUEUE);
+        when(mockWorkflowTask.isAsync()).thenReturn(true);
+        SystemTaskWorkerCoordinator.taskNameWorkflowTaskMapping.put(TEST_QUEUE, mockWorkflowTask);
+    }
 }

--- a/core/src/test/java/com/netflix/conductor/core/utils/SemaphoreUtilTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/SemaphoreUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.core.utils;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+@SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
+public class SemaphoreUtilTest {
+    @Test
+    public void testBlockAfterAvailablePermitsExhausted() throws Exception {
+        int threads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        SemaphoreUtil semaphoreUtil = new SemaphoreUtil(threads);
+
+        List<CompletableFuture<Void>> futuresList = new ArrayList<>();
+        IntStream.range(0, threads).forEach(
+            t -> futuresList.add(CompletableFuture.runAsync(semaphoreUtil::canProcess, executorService)));
+
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(
+            futuresList.toArray(new CompletableFuture[futuresList.size()]));
+
+        allFutures.get();
+
+        assertEquals(0, semaphoreUtil.availableSlots());
+        assertFalse(semaphoreUtil.canProcess());
+
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testAllowsPollingWhenPermitBecomesAvailable() throws Exception {
+        int threads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        SemaphoreUtil semaphoreUtil = new SemaphoreUtil(threads);
+
+        List<CompletableFuture<Void>> futuresList = new ArrayList<>();
+        IntStream.range(0, threads).forEach(
+            t -> futuresList.add(CompletableFuture.runAsync(semaphoreUtil::canProcess, executorService)));
+
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(
+            futuresList.toArray(new CompletableFuture[futuresList.size()]));
+        allFutures.get();
+
+        assertEquals(0, semaphoreUtil.availableSlots());
+        semaphoreUtil.completeProcessing();
+
+        assertTrue(semaphoreUtil.availableSlots() > 0);
+        assertTrue(semaphoreUtil.canProcess());
+
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
Instead of relying on in memory LinkedBlockingQueue to store dequeued task ids and execute them asynchronously using a threadpool, this PR provides an implementation to use a semaphore to control when a task id will be dequeued from a given system task queue based on if a thread is available for processing the task. The processing of the task will still happen asynchronously.

In the case of isolated system task queues, instead of using a separate LinkedBlockingQueue to feed the threadpool, each isolated task queue uses a separate semaphore to gate the processing of tasks in its threadpool.