### PR TITLE
Make the task definition optional for the DO_WHILE task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -76,10 +76,7 @@ public class DoWhileTaskMapper implements TaskMapper {
         int retryCount = taskMapperContext.getRetryCount();
         TaskDef taskDefinition = Optional.ofNullable(taskMapperContext.getTaskDefinition())
                 .orElseGet(() -> Optional.ofNullable(metadataDAO.getTaskDef(taskToSchedule.getName()))
-                        .orElseThrow(() -> {
-                            String reason = String.format("Invalid task specified. Cannot find task by name %s in the task definitions", taskToSchedule.getName());
-                            return new TerminateWorkflowException(reason);
-                        }));
+                .orElseGet(() -> new TaskDef()));
 
         Task loopTask = new Task();
         loopTask.setTaskType(SystemTaskType.DO_WHILE.name());


### PR DESCRIPTION
As a System task, the DO_WHILE task should not be required to have a task definition as it makes it difficult to have it not time out. This PR makes it optional.