### PR TITLE
Check if Cassandra session is closed before using

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraEventHandlerDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraEventHandlerDAO.java
@@ -118,6 +118,10 @@ public class CassandraEventHandlerDAO extends CassandraBaseDAO implements EventH
     }
 
     private void refreshEventHandlersCache() {
+        if (session.isClosed()) {
+            LOGGER.warn("session is closed");
+            return;
+        }
         try {
             Map<String, EventHandler> map = new HashMap<>();
             getAllEventHandlersFromDB().forEach(eventHandler -> map.put(eventHandler.getName(), eventHandler));

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraMetadataDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraMetadataDAO.java
@@ -266,6 +266,10 @@ public class CassandraMetadataDAO extends CassandraBaseDAO implements MetadataDA
     }
 
     private void refreshTaskDefsCache() {
+        if (session.isClosed()) {
+            LOGGER.warn("session is closed");
+            return;
+        }
         try {
             Map<String, TaskDef> map = new HashMap<>();
             getAllTaskDefsFromDB().forEach(taskDef -> map.put(taskDef.getName(), taskDef));

--- a/cassandra-persistence/src/test/java/com/netflix/conductor/dao/cassandra/CassandraDAOTest.java
+++ b/cassandra-persistence/src/test/java/com/netflix/conductor/dao/cassandra/CassandraDAOTest.java
@@ -74,7 +74,6 @@ public class CassandraDAOTest {
 
     @Before
     public void setUp() {
-        session = embeddedCassandra.getSession();
         Statements statements = new Statements(testConfiguration);
         metadataDAO = new CassandraMetadataDAO(session, objectMapper, testConfiguration, statements);
         executionDAO = new CassandraExecutionDAO(session, objectMapper, testConfiguration, statements);

--- a/cassandra-persistence/src/test/java/com/netflix/conductor/dao/cassandra/CassandraDAOTest.java
+++ b/cassandra-persistence/src/test/java/com/netflix/conductor/dao/cassandra/CassandraDAOTest.java
@@ -57,7 +57,7 @@ public class CassandraDAOTest {
     private final ObjectMapper objectMapper = new JsonMapperProvider().get();
 
     private static EmbeddedCassandra embeddedCassandra;
-    private Session session;
+    private static Session session;
 
     private CassandraMetadataDAO metadataDAO;
     private CassandraExecutionDAO executionDAO;
@@ -69,6 +69,7 @@ public class CassandraDAOTest {
     @BeforeClass
     public static void init() throws Exception {
         embeddedCassandra = new EmbeddedCassandra();
+        session = embeddedCassandra.getSession();
     }
 
     @Before
@@ -83,6 +84,7 @@ public class CassandraDAOTest {
     @AfterClass
     public static void teardown() {
         embeddedCassandra.cleanupData();
+        session.close();
     }
 
     @Test


### PR DESCRIPTION
In teardown of CassandraDAOTest "session is closed" errors occur. This happens because CassandraMetadataDAO and CassandraEventHandlerDAO launch threads that use session w/o checking if its closed. This PR adds a check to ensure session is not closed before using.