### PR TITLE
Refactored Subworkflow processing to leverage asyncComplete, and othe…

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -737,11 +737,20 @@ public class Task {
     }
 
     public String getSubWorkflowId() {
-        return subWorkflowId;
+        // For backwards compatibility
+        if (StringUtils.isNotBlank(subWorkflowId)) {
+            return subWorkflowId;
+        } else {
+            return this.getOutputData() != null ? (String) this.getOutputData().get("subWorkflowId") : null;
+        }
     }
 
     public void setSubWorkflowId(String subWorkflowId) {
         this.subWorkflowId = subWorkflowId;
+        // For backwards compatibility
+        if (this.getOutputData() != null && this.getOutputData().containsKey("subWorkflowId")) {
+            this.getOutputData().put("subWorkflowId", subWorkflowId);
+        }
     }
 
 

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -35,7 +35,12 @@ public class Workflow extends Auditable{
 
     @ProtoEnum
 	public enum  WorkflowStatus {
-		RUNNING(false, false), COMPLETED(true, true), FAILED(true, false), TIMED_OUT(true, false), TERMINATED(true, false), PAUSED(false, true);
+		RUNNING(false, false),
+		COMPLETED(true, true),
+		FAILED(true, false),
+		TIMED_OUT(true, false),
+		TERMINATED(true, false),
+		PAUSED(false, true);
 
 		private boolean terminal;
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.booleanThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -1082,6 +1083,81 @@ public class TestWorkflowExecutor {
 
         // An asyncComplete task shouldn't be executed through this logic, and the Terminate task should remain IN_PROGRESS.
         assertEquals(Status.IN_PROGRESS, task1.getStatus());
+    }
+
+    @Test
+    public void testUpdateParentWorkflow() {
+        // Case 1: When Subworkflow is in terminal state
+        // 1A: Parent Workflow is IN_PROGRESS
+        // Expectation: Parent workflow's Subworkflow task should complete
+        String workflowId = "test-workflow-Id";
+        String subWorkflowId = "test-subWorkflow-Id";
+        String parentWorkflowSubWFTaskId = "test-subworkflow-taskId";
+        WorkflowTask subWorkflowTask = new WorkflowTask();
+        subWorkflowTask.setWorkflowTaskType(TaskType.SUB_WORKFLOW);
+        subWorkflowTask.setType(TaskType.SUB_WORKFLOW.name());
+        subWorkflowTask.setTaskReferenceName("sub-workflow");
+        Task task = new Task();
+        task.setTaskType(subWorkflowTask.getType());
+        task.setTaskDefName(subWorkflowTask.getName());
+        task.setReferenceTaskName(subWorkflowTask.getTaskReferenceName());
+        task.setWorkflowInstanceId(workflowId);
+        task.setScheduledTime(System.currentTimeMillis());
+        task.setTaskId(parentWorkflowSubWFTaskId);
+        task.setStatus(Status.IN_PROGRESS);
+        task.setRetryCount(0);
+        task.setWorkflowTask(subWorkflowTask);
+        task.setOutputData(new HashMap<>());
+        task.setSubWorkflowId(subWorkflowId);
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName("test");
+
+        Workflow parentWorkflow = new Workflow();
+        parentWorkflow.setWorkflowId(workflowId);
+        parentWorkflow.setWorkflowDefinition(def);
+        parentWorkflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        parentWorkflow.setTasks(Arrays.asList(task));
+
+        Workflow subWorkflow = new Workflow();
+        subWorkflow.setWorkflowId("subworkflowId");
+        subWorkflow.setStatus(Workflow.WorkflowStatus.COMPLETED);
+        subWorkflow.setParentWorkflowTaskId(parentWorkflowSubWFTaskId);
+        subWorkflow.setWorkflowId(subWorkflowId);
+
+        when(executionDAOFacade.getTaskById(anyString())).thenReturn(task);
+        when(workflowExecutor.getWorkflow(subWorkflowId, false)).thenReturn(subWorkflow);
+
+        workflowExecutor.updateParentWorkflow(task, subWorkflow, parentWorkflow);
+        assertEquals(Status.COMPLETED, task.getStatus());
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, subWorkflow.getStatus());
+        // updateParentWorkflow shouldn't call the decide on workflow, and hence it should still remain IN_PROGRESS
+        assertEquals(Workflow.WorkflowStatus.RUNNING, parentWorkflow.getStatus());
+
+        // 1B: Parent Workflow is in FAILED state
+        // Expectation: return false
+        parentWorkflow.setStatus(Workflow.WorkflowStatus.FAILED);
+        assertFalse(workflowExecutor.updateParentWorkflow(task, subWorkflow, parentWorkflow));
+
+        // Case 2: When Subworkflow is in non-terminal state
+        // 2A: Parent Workflow is in terminal state
+        // Expectation: Parent workflow and subworkflow task should be reset to IN_PROGRESS and RUNNING state respectively.
+        subWorkflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        parentWorkflow.setStatus(Workflow.WorkflowStatus.FAILED);
+        workflowExecutor.updateParentWorkflow(task, subWorkflow, parentWorkflow);
+        assertEquals(Workflow.WorkflowStatus.RUNNING, subWorkflow.getStatus());
+        assertEquals(Status.IN_PROGRESS, task.getStatus());
+        assertEquals(Workflow.WorkflowStatus.RUNNING, parentWorkflow.getStatus());
+
+        // 2B: Parent Workflow is in non-terminal state
+        // Expectation: Parent workflow, Subworkflow and subworkflow task should remain in same state.
+        subWorkflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        parentWorkflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        task.setStatus(Status.IN_PROGRESS);
+        workflowExecutor.updateParentWorkflow(task, subWorkflow, parentWorkflow);
+        assertEquals(Workflow.WorkflowStatus.RUNNING, subWorkflow.getStatus());
+        assertEquals(Status.IN_PROGRESS, task.getStatus());
+        assertEquals(Workflow.WorkflowStatus.RUNNING, parentWorkflow.getStatus());
     }
 
     private Workflow generateSampleWorkflow() {

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
@@ -211,7 +211,7 @@ public class TestSubWorkflow {
         subWorkflowInstance.setStatus(Workflow.WorkflowStatus.TIMED_OUT);
         subWorkflowInstance.setReasonForIncompletion("unit2");
         assertTrue(subWorkflow.execute(workflowInstance, task, workflowExecutor));
-        assertEquals(Task.Status.FAILED, task.getStatus());
+        assertEquals(Task.Status.TIMED_OUT, task.getStatus());
         assertEquals("unit2", task.getReasonForIncompletion());
 
         subWorkflowInstance.setStatus(Workflow.WorkflowStatus.TERMINATED);

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -5075,8 +5075,6 @@ public abstract class AbstractWorkflowServiceTest {
         task.setStatus(FAILED);
         workflowExecutionService.updateTask(task);
 
-        workflowExecutor.executeSystemTask(subworkflow, subWorkflowTaskId, 1);
-
         workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
         assertNotNull(workflow);
         assertEquals(WorkflowStatus.FAILED, workflow.getStatus());
@@ -5087,9 +5085,9 @@ public abstract class AbstractWorkflowServiceTest {
         task.setStatus(COMPLETED);
         workflowExecutionService.updateTask(task);
 
-        workflow = workflowExecutionService.getExecutionStatus(subWorkflowId, true);
-        assertNotNull(workflow);
-        assertEquals(RUNNING, workflow.getStatus());
+        subWorkflow = workflowExecutionService.getExecutionStatus(subWorkflowId, true);
+        assertNotNull(subWorkflow);
+        assertEquals(RUNNING, subWorkflow.getStatus());
 
         task = workflowExecutionService.poll("junit_task_2", "test");
         assertEquals(subWorkflowId, task.getWorkflowInstanceId());


### PR DESCRIPTION
These changes complement the existing async processing of Subworkflow changes introduced in https://github.com/Netflix/conductor/pull/1438.

With Subworkflow task being `async`, it is polled for and executed by System task workers every 30 seconds (Default call back after seconds for System tasks). This introduced a bottleneck on Subworkflow task queue, especially when there are large number of long running Subworkflows.

We can further optimize this by making Subworkflow task `asyncComplete`, meaning the task will only be polled for and executed twice overall in it's lifecycle, keeping the task in IN_PROGRESS state, until Subworkflow's completion. `asyncComplete` detaches the task from task queue, and expects the task to be completed by external trigger.

In Subworkflow task's case, the Subworkflow terminal state would be the external trigger that updates the Subworkflow task on completion with result.

Other improvements like checking the Subworkflow's validity for restarts and retries are incorporated in this PR.