### PR TITLE
Workflow decider not properly scheduling next tasks after a decision

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -74,7 +74,8 @@ public class DeciderService {
 
     private final Map<String, TaskMapper> taskMappers;
 
-    private final Predicate<Task> isNonPendingTask = task -> !task.isRetried() && !task.getStatus().equals(SKIPPED) && !task.isExecuted() ||  task.getWorkflowTask() != null && task.getWorkflowTask().getType() == TaskType.DECISION.name();
+    private final Predicate<Task> isNonPendingTask = task -> (!task.isRetried() && !task.getStatus().equals(SKIPPED) && !task.isExecuted()) ||
+            (task.getWorkflowTask() != null && task.getWorkflowTask().getType().equals(TaskType.DECISION.name()));
 
     private static final String PENDING_TASK_TIME_THRESHOLD_PROPERTY_NAME = "workflow.task.pending.time.threshold.minutes";
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -183,8 +183,6 @@ public class DeciderService {
                 getTasksToBeScheduled(workflow, pendingTask.getWorkflowTask(), 0).forEach(nextTask -> {
                     tasksToBeScheduled.putIfAbsent(nextTask.getReferenceTaskName(), nextTask);
                 });
-
-                continue;
             }
 
             if (!pendingTask.getStatus().isSuccessful()) {


### PR DESCRIPTION
In the event the workflow sweeper runs before tasks get queued by result of a decision task, it's possible for the sweeper to mark the workflow as completed too early. This issue surfaces itself more under high-load, due to the nature of the bug.

Given the following workflow:
```json
[
  {
    "schemaVersion": 2,
    "name": "test-workflow",
    "version": 3,
    "tasks": [
      {
        "type": "SIMPLE",
        "name": "t1",
        "taskReferenceName": "t1"
      },
      {
        "type": "DECISION",
        "name": "d1",
        "taskReferenceName": "has_something",
        "inputParameters": {
          "count": "${t1.output.count}"
        },
        "caseExpression": "$.count > 0 ? 'true' : 'false'",
        "decisionCases": {
          "true": [
            {
              "type": "SIMPLE",
              "name": "t2",
              "taskReferenceName": "t2"
            }
          ]
        }
      }
    ]
  }
]
```

Assuming task `t1` and decision `d1` have already been marked as completed, if the workflow sweeper runs before the decider can queue up task `t2`, the workflow will be marked as completed.

After looking at the code, this makes sense why. The [decision task mapper](https://github.com/Netflix/conductor/blob/v2.26.1/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java#L108) handles this, however that's never executed when `DeciderService.decide()` runs. This is partly due to `DeciderService.isNonPendingTask` not ever picking up a completed decision task, so it sees that there are no tasks to schedule. After correcting this conditional, additional logic needed to be added to call the `DeciderService.getTasksToBeScheduled()` function, as that's what ultimately computes the next tasks from a decision task.

I've also went ahead and added tests for this case. This was tested locally by slamming the living heck out of Conductor to ensure no more issues.

Please let me know if you need anything else regarding this PR.