### PR TITLE
Fix kitchensink example

### DIFF
--- a/docs/docs/labs/kitchensink.md
+++ b/docs/docs/labs/kitchensink.md
@@ -157,6 +157,7 @@ An example kitchensink workflow that demonstrates the usage of all the schema co
     "statues": "${get_es_1.output..status}",
     "workflowIds": "${get_es_1.output..workflowId}"
   },
+  "ownerEmail": "example@email.com",
   "schemaVersion": 2
 }
 ```

--- a/docs/docs/labs/kitchensink.md
+++ b/docs/docs/labs/kitchensink.md
@@ -226,7 +226,7 @@ curl -H 'Content-Type:application/json' -H 'Accept:application/json' -X POST htt
 	"taskId": "b9eea7dd-3fbd-46b9-a9ff-b00279459476",
 	"workflowInstanceId": "b0d1a935-3d74-46fd-92b2-0ca1e388659f",
 	"status": "COMPLETED",
-	"output": {
+	"outputData": {
 	    "mod": 5,
 	    "taskToExecute": "task_1",
 	    "oddEven": 0,

--- a/server/src/main/java/com/netflix/conductor/jetty/server/JettyServer.java
+++ b/server/src/main/java/com/netflix/conductor/jetty/server/JettyServer.java
@@ -106,10 +106,16 @@ public class JettyServer implements Lifecycle {
         ObjectMapper objectMapper = new JsonMapperProvider().get();
 
         List<TaskDef> taskDefs = new LinkedList<>();
+        TaskDef taskDef;
         for (int i = 0; i < 40; i++) {
-            taskDefs.add(new TaskDef("task_" + i, "task_" + i, 1, 0));
+            taskDef = new TaskDef("task_" + i, "task_" + i, 1, 0);
+            taskDef.setOwnerEmail("example@email.com");
+            taskDefs.add(taskDef);
         }
-        taskDefs.add(new TaskDef("search_elasticsearch", "search_elasticsearch", 1, 0));
+
+        taskDef = new TaskDef("search_elasticsearch", "search_elasticsearch", 1, 0);
+        taskDef.setOwnerEmail("example@email.com");
+        taskDefs.add(taskDef);
 
         client.resource("http://localhost:" + port + "/api/metadata/taskdefs").type(MediaType.APPLICATION_JSON).post(objectMapper.writeValueAsString(taskDefs));
 

--- a/server/src/main/resources/kitchenSink-ephemeralWorkflowWithEphemeralTasks.json
+++ b/server/src/main/resources/kitchenSink-ephemeralWorkflowWithEphemeralTasks.json
@@ -249,7 +249,8 @@
       "statues": "${get_es_1.output..status}",
       "workflowIds": "${get_es_1.output..workflowId}"
     },
-    "schemaVersion": 2
+    "schemaVersion": 2,
+    "ownerEmail": "example@email.com"
   },
   "input": {
     "task2Name": "task_10005"

--- a/server/src/main/resources/kitchenSink-ephemeralWorkflowWithStoredTasks.json
+++ b/server/src/main/resources/kitchenSink-ephemeralWorkflowWithStoredTasks.json
@@ -154,7 +154,8 @@
       "statues": "${get_es_1.output..status}",
       "workflowIds": "${get_es_1.output..workflowId}"
     },
-    "schemaVersion": 2
+    "schemaVersion": 2,
+    "ownerEmail": "example@email.com"
   },
   "input": {
     "task2Name": "task_5"

--- a/server/src/main/resources/kitchensink.json
+++ b/server/src/main/resources/kitchensink.json
@@ -152,5 +152,6 @@
     "statues": "${get_es_1.output..status}",
     "workflowIds": "${get_es_1.output..workflowId}"
   },
+  "ownerEmail": "example@email.com",
   "schemaVersion": 2
 }

--- a/server/src/main/resources/sub_flow_1.json
+++ b/server/src/main/resources/sub_flow_1.json
@@ -16,5 +16,6 @@
     }
   ],
   "outputParameters": {},
-  "schemaVersion": 2
+  "schemaVersion": 2,
+  "ownerEmail": "example@email.com"
 }


### PR DESCRIPTION
Fix kitchensink example:

- set output of the task with `outputData` key
- set `ownerEmail` property to workflow and task definitions since it is mandatory