### PR TITLE
get subWorkflowId from inputData if it is an old SUB_WORKFLOW task

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -741,7 +741,9 @@ public class Task {
         if (StringUtils.isNotBlank(subWorkflowId)) {
             return subWorkflowId;
         } else {
-            return this.getOutputData() != null ? (String) this.getOutputData().get("subWorkflowId") : null;
+            return 
+               	this.getOutputData() != null && (String) this.getOutputData().get("subWorkflowId") != null ? (String) this.getOutputData().get("subWorkflowId") : 
+               	this.getInputData() != null ? (String) this.getInputData().get("subWorkflowId") : null;
         }
     }
 


### PR DESCRIPTION
Recently a change was made to put the subWorkflowId attribute of Task.java at the root of the Task JSON. Prior to this it was stored in the inputData of the Task. The getSubWorkflowId() method was changed to get it from the root now but that doesn't account for sub_workflow tasks that were created before the change. This PR checks both places so that new code expecting it at the root level will still work with older sub_workflow tasks.