### PR TITLE
Initialize workflow monitor

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
@@ -13,6 +13,7 @@ import com.netflix.conductor.service.WorkflowBulkService;
 import com.netflix.conductor.service.WorkflowBulkServiceImpl;
 import com.netflix.conductor.service.WorkflowService;
 import com.netflix.conductor.service.WorkflowServiceImpl;
+import com.netflix.conductor.service.WorkflowMonitor;
 
 /**
  * Default implementation for the workflow status listener
@@ -30,5 +31,6 @@ public class WorkflowExecutorModule extends AbstractModule {
         bind(TaskService.class).to(TaskServiceImpl.class);
         bind(EventService.class).to(EventServiceImpl.class);
         bind(MetadataService.class).to(MetadataServiceImpl.class);
+        bind(WorkflowMonitor.class).asEagerSingleton();
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
@@ -13,7 +13,6 @@ import com.netflix.conductor.service.WorkflowBulkService;
 import com.netflix.conductor.service.WorkflowBulkServiceImpl;
 import com.netflix.conductor.service.WorkflowService;
 import com.netflix.conductor.service.WorkflowServiceImpl;
-import com.netflix.conductor.service.WorkflowMonitor;
 
 /**
  * Default implementation for the workflow status listener
@@ -31,6 +30,5 @@ public class WorkflowExecutorModule extends AbstractModule {
         bind(TaskService.class).to(TaskServiceImpl.class);
         bind(EventService.class).to(EventServiceImpl.class);
         bind(MetadataService.class).to(MetadataServiceImpl.class);
-        bind(WorkflowMonitor.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -12,13 +12,11 @@
  */
 package com.netflix.conductor.server;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.matcher.Matchers;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.conductor.annotations.Service;
-import com.netflix.conductor.common.utils.JsonMapperProvider;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.CoreModule;
 import com.netflix.conductor.core.config.ValidationModule;
@@ -27,6 +25,7 @@ import com.netflix.conductor.dyno.SystemPropertiesDynomiteConfiguration;
 import com.netflix.conductor.grpc.server.GRPCModule;
 import com.netflix.conductor.interceptors.ServiceInterceptor;
 import com.netflix.conductor.jetty.server.JettyModule;
+import com.netflix.conductor.service.WorkflowMonitor;
 import com.netflix.runtime.health.guice.HealthModule;
 
 import javax.validation.Validator;
@@ -50,5 +49,6 @@ public class ServerModule extends AbstractModule {
         bind(Configuration.class).to(SystemPropertiesDynomiteConfiguration.class);
         bind(ExecutorService.class).toProvider(ExecutorServiceProvider.class).in(Scopes.SINGLETON);
         bind(WorkflowSweeper.class).asEagerSingleton();
+        bind(WorkflowMonitor.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
Monitor for calculating metrics `com.netflix.conductor.service.WorkflowMonitor`is not initialized and so metrics like `task_queue_depth`, `workflow_running` are not captured. So initializing it in `WorkflowExecutorModule`.