### PR TITLE
Fixing table in documentation

### DIFF
--- a/docs/docs/externalpayloadstorage.md
+++ b/docs/docs/externalpayloadstorage.md
@@ -29,6 +29,7 @@ In such cases, conductor will reject such payloads and will terminate/fail the w
 Set the following properties to the desired values in the JVM system properties:
 
 | Property | Description | default value |
+| -- | -- | -- |
 | conductor.workflow.input.payload.threshold.kb | Soft barrier for workflow input payload in KB | 5120 |
 | conductor.max.workflow.input.payload.threshold.kb | Hard barrier for workflow input payload in KB | 10240 |
 | conductor.workflow.output.payload.threshold.kb | Soft barrier for workflow output payload in KB | 5120 |


### PR DESCRIPTION
Tiny improvement to docs:

Before:
<img width="692" alt="Before_fix" src="https://user-images.githubusercontent.com/59887806/82067432-54314f80-9696-11ea-89ee-48193e9f9941.png">

After:
<img width="730" alt="After_fix" src="https://user-images.githubusercontent.com/59887806/82067435-5693a980-9696-11ea-9c32-97a29b13fead.png">
