### PR TITLE
Upgrade jackson-jq from 0.0.11 to 1.0.0-preview.20191208

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/json/JsonJqTransform.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/json/JsonJqTransform.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.Scope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,8 @@ public class JsonJqTransform extends WorkflowSystemTask {
         try {
             final JsonNode input = objectMapper.valueToTree(taskInput);
             final JsonQuery query = queryCache.get(queryExpression);
-            final List<JsonNode> result = query.apply(input);
+            final Scope jsonScope = Scope.newEmptyScope();
+            final List<JsonNode> result = query.apply(jsonScope, input);
 
             task.setStatus(Task.Status.COMPLETED);
             if (result == null) {

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -39,7 +39,7 @@ ext {
     revJettyServlet = '9.4.22.v20191022'
     revJUnit = '4.12'
     revJsr311Api = '1.1.1'
-    revJq = '0.0.11'
+    revJq = '1.0.0-preview.20191208'
     revLog4jApi = '2.9.1'
     revLog4jCore = '2.9.1'
     revMockito = '3.1.0'


### PR DESCRIPTION
Upgrade JQ library to the latest version (used by `JSON_JQ_TRANSFORM` task).

Update the deprecated syntax of `apply` function.

Comparison between the 2 versions:
https://github.com/eiiches/jackson-jq/compare/0.0.11...1.0.0-preview.20191208