### PR TITLE
use fallback domain if pollDataDAO is unavailable

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1245,12 +1245,12 @@ public class WorkflowExecutor {
     }
 
     @VisibleForTesting
-    void setTaskDomains(List<Task> tasks, Workflow wf) {
-        Map<String, String> taskToDomain = wf.getTaskToDomain();
+    void setTaskDomains(List<Task> tasks, Workflow workflow) {
+        Map<String, String> taskToDomain = workflow.getTaskToDomain();
         if (taskToDomain != null) {
             // Step 1: Apply * mapping to all tasks, if present.
             String domainstr = taskToDomain.get("*");
-            if (domainstr != null) {
+            if (StringUtils.isNotBlank(domainstr)) {
                 String[] domains = domainstr.split(",");
                 tasks.forEach(task -> {
                     // Filter out SystemTask
@@ -1260,7 +1260,6 @@ public class WorkflowExecutor {
                         task.setDomain(getActiveDomain(task.getTaskType(), domains));
                     }
                 });
-
             }
             // Step 2: Override additional mappings.
             tasks.forEach(task -> {

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.events.ScriptEvaluator;
 import com.netflix.conductor.core.execution.SystemTaskType;
 import com.netflix.conductor.core.execution.TerminateWorkflowException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,7 @@ public class DecisionTaskMapper implements TaskMapper {
     String getEvaluatedCaseValue(WorkflowTask taskToSchedule, Map<String, Object> taskInput) {
         String expression = taskToSchedule.getCaseExpression();
         String caseValue;
-        if (expression != null) {
+        if (StringUtils.isNotBlank(expression)) {
             logger.debug("Case being evaluated using decision expression: {}", expression);
             try {
                 //Evaluate the expression by using the Nashhorn based script evaluator

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -371,7 +371,12 @@ public class ExecutionDAOFacade {
     }
 
     public PollData getTaskPollDataByDomain(String taskName, String domain) {
-        return pollDataDAO.getPollData(taskName, domain);
+        try {
+            return pollDataDAO.getPollData(taskName, domain);
+        } catch (Exception e) {
+            LOGGER.error("Error fetching pollData for task: '{}', domain: '{}'", taskName, domain, e);
+            return null;
+        }
     }
 
     public void updateTaskLastPoll(String taskName, String domain, String workerId) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -28,7 +28,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.booleanThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -836,6 +835,12 @@ public class TestWorkflowExecutor {
 
         activeDomain = workflowExecutor.getActiveDomain(taskType, null);
         assertNull(activeDomain);
+
+        domains = new String[]{"test-domain"};
+        when(executionDAOFacade.getTaskPollDataByDomain(anyString(), anyString())).thenReturn(null);
+        activeDomain = workflowExecutor.getActiveDomain(taskType, domains);
+        assertNotNull(activeDomain);
+        assertEquals("test-domain", activeDomain);
     }
 
     @Test
@@ -859,7 +864,7 @@ public class TestWorkflowExecutor {
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[0])).thenReturn(pollData1);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[1])).thenReturn(null);
         String activeDomain = workflowExecutor.getActiveDomain(taskType, domains);
-        assertEquals(null, activeDomain);
+        assertNull(activeDomain);
     }
 
     @Test

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisPollDataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisPollDataDAO.java
@@ -62,7 +62,7 @@ public class RedisPollDataDAO extends BaseDynoDAO implements PollDataDAO {
         recordRedisDaoPayloadSize("getPollData", StringUtils.length(pollDataJsonString), "n/a", "n/a");
 
         PollData pollData = null;
-        if (pollDataJsonString != null) {
+        if (StringUtils.isNotBlank(pollDataJsonString)) {
             pollData = readValue(pollDataJsonString, PollData.class);
         }
         return pollData;


### PR DESCRIPTION
Remove the reliance on PollDataDAO in the critical execution path of a workflow. If the poll data DAO is unavailable, fallback to the last domain in the provided list of domains for a task instead.