### PR TITLE
Support to batch poll system tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -49,6 +49,9 @@ public interface Configuration {
     String SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME = "workflow.isolated.system.task.worker.thread.count";
     int SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE = 1;
 
+    String SYSTEM_TASK_MAX_POLL_COUNT_PROPERTY_NAME = "workflow.system.task.queue.pollCount";
+    int SYSTEM_TASK_MAX_POLL_COUNT_DEFAULT_VALUE = 1;
+
     String ENVIRONMENT_PROPERTY_NAME = "environment";
     String ENVIRONMENT_DEFAULT_VALUE = "test";
 
@@ -184,6 +187,13 @@ public interface Configuration {
      */
     default int getSystemTaskWorkerIsolatedThreadCount() {
         return getIntProperty(SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME, SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return the max number of system task to poll from queues
+     */
+    default int getSystemTaskMaxPollCount() {
+        return getIntProperty(SYSTEM_TASK_MAX_POLL_COUNT_PROPERTY_NAME, SYSTEM_TASK_MAX_POLL_COUNT_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
@@ -25,7 +25,7 @@ class ExecutionConfig {
     private ExecutorService executorService;
     private SemaphoreUtil semaphoreUtil;
 
-    public ExecutionConfig(int threadCount, String threadNameFormat) {
+    ExecutionConfig(int threadCount, String threadNameFormat) {
 
         this.executorService = Executors.newFixedThreadPool(threadCount,
             new ThreadFactoryBuilder().setNameFormat(threadNameFormat).build());

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
@@ -80,7 +80,7 @@ class SystemTaskExecutor {
         try {
             //FIXME: Add documentation and unit tests
             //Since already one slot is acquired, now try if maxSlot-1 is available
-            int numSlots = Math.min(semaphoreUtil.availableSlots() - 1, maxPollCount);
+            int numSlots = Math.min(semaphoreUtil.availableSlots() - 1, maxPollCount-1);
 
             if (semaphoreUtil.acquireSlots(numSlots)) {
                 acquiredSlots += numSlots;
@@ -93,7 +93,7 @@ class SystemTaskExecutor {
             LOGGER.debug("Polling queue:{}, got {} tasks", queueName, polledTaskIds.size());
             if (polledTaskIds.size() > 0) {
                 for (String taskId : polledTaskIds) {
-                    if (StringUtils.isNotBlank(polledTaskIds.get(0))) {
+                    if (StringUtils.isNotBlank(taskId)) {
                         LOGGER.debug("Task: {} from queue: {} being sent to the workflow executor", taskId, queueName);
                         Monitors.recordTaskPollCount(queueName, "", 1);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskExecutor.java
@@ -69,7 +69,7 @@ class SystemTaskExecutor {
         ExecutorService executorService = executionConfig.getExecutorService();
         String taskName = QueueUtils.getTaskType(queueName);
 
-        if (!semaphoreUtil.canProcess()) {
+        if (!semaphoreUtil.acquireSlots(1)) {
             // no available permits, do not poll
             Monitors.recordSystemTaskWorkerPollingLimited(queueName);
             return;
@@ -108,9 +108,9 @@ class SystemTaskExecutor {
                                 workflowExecutor.executeSystemTask(systemTask, taskId, callbackTime), executorService);
 
                         // release permit after processing is complete
-                        taskCompletableFuture.whenComplete((r, e) -> semaphoreUtil.completeProcessing());
+                        taskCompletableFuture.whenComplete((r, e) -> semaphoreUtil.completeProcessing(1));
                     } else {
-                        semaphoreUtil.completeProcessing();
+                        semaphoreUtil.completeProcessing(1);
                     }
                 }
             } else {

--- a/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
@@ -62,4 +62,17 @@ public class SemaphoreUtil {
         LOGGER.debug("Number of available permits: {}", available);
         return available;
     }
+
+    public boolean acquireSlots(int numSlots)
+    {
+        return semaphore.tryAcquire(numSlots);
+    }
+
+    /**
+     * Signals that processing is complete and the permit can be released.
+     */
+    public void completeProcessing(int numSlots) {
+        LOGGER.debug("Completed execution; releasing permit");
+        semaphore.release(numSlots);
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
@@ -16,6 +16,7 @@
 package com.netflix.conductor.core.utils;
 
 import java.util.concurrent.Semaphore;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class SemaphoreUtil {
      * Signals if processing is allowed based on whether a permit can be acquired.
      *
      * @return {@code true} - if permit is acquired
-     *         {@code false} - if permit could not be acquired
+     * {@code false} - if permit could not be acquired
      */
     public boolean canProcess() {
         boolean acquired = semaphore.tryAcquire();
@@ -63,13 +64,19 @@ public class SemaphoreUtil {
         return available;
     }
 
-    public boolean acquireSlots(int numSlots)
-    {
+    /**
+     * Signals if processing is allowed based on whether specified number of permits can be acquired.
+     *
+     * @param numSlots the number of permits to acquire
+     * @return {@code true} - if permit is acquired
+     * {@code false} - if permit could not be acquired
+     */
+    public boolean acquireSlots(int numSlots) {
         return semaphore.tryAcquire(numSlots);
     }
 
     /**
-     * Signals that processing is complete and the permit can be released.
+     * Signals that processing is complete and the specified number of permits can be released.
      */
     public void completeProcessing(int numSlots) {
         LOGGER.debug("Completed execution; releasing permit");

--- a/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/SemaphoreUtil.java
@@ -34,23 +34,24 @@ public class SemaphoreUtil {
     }
 
     /**
-     * Signals if processing is allowed based on whether a permit can be acquired.
+     * Signals if processing is allowed based on whether specified number of permits can be acquired.
      *
+     * @param numSlots the number of permits to acquire
      * @return {@code true} - if permit is acquired
      * {@code false} - if permit could not be acquired
      */
-    public boolean canProcess() {
-        boolean acquired = semaphore.tryAcquire();
-        LOGGER.debug("Trying to acquire permit: {}", acquired);
+    public boolean acquireSlots(int numSlots) {
+        boolean acquired = semaphore.tryAcquire(numSlots);
+        LOGGER.debug("Trying to acquire {} permit: {}", numSlots, acquired);
         return acquired;
     }
 
     /**
-     * Signals that processing is complete and the permit can be released.
+     * Signals that processing is complete and the specified number of permits can be released.
      */
-    public void completeProcessing() {
+    public void completeProcessing(int numSlots) {
         LOGGER.debug("Completed execution; releasing permit");
-        semaphore.release();
+        semaphore.release(numSlots);
     }
 
     /**
@@ -62,24 +63,5 @@ public class SemaphoreUtil {
         int available = semaphore.availablePermits();
         LOGGER.debug("Number of available permits: {}", available);
         return available;
-    }
-
-    /**
-     * Signals if processing is allowed based on whether specified number of permits can be acquired.
-     *
-     * @param numSlots the number of permits to acquire
-     * @return {@code true} - if permit is acquired
-     * {@code false} - if permit could not be acquired
-     */
-    public boolean acquireSlots(int numSlots) {
-        return semaphore.tryAcquire(numSlots);
-    }
-
-    /**
-     * Signals that processing is complete and the specified number of permits can be released.
-     */
-    public void completeProcessing(int numSlots) {
-        LOGGER.debug("Completed execution; releasing permit");
-        semaphore.release(numSlots);
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskExecutor.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 @SuppressWarnings("UnstableApiUsage")
 public class TestSystemTaskExecutor {
@@ -84,7 +85,7 @@ public class TestSystemTaskExecutor {
     }
 
     @Test
-    public void testPollAndExecuteSytemTask() {
+    public void testPollAndExecuteSystemTask() {
         System.setProperty("workflow.system.task.worker.thread.count", "1");
         Configuration configuration = new SystemPropertiesConfiguration();
         when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenReturn(Collections.singletonList("taskId"));
@@ -102,6 +103,36 @@ public class TestSystemTaskExecutor {
 
         Uninterruptibles.awaitUninterruptibly(latch);
         verify(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+    }
+
+    @Test
+    public void testBatchPollAndExecuteSystemTask() {
+        try
+        {
+            System.setProperty("workflow.system.task.worker.thread.count", "2");
+            System.setProperty("workflow.system.task.queue.pollCount", "2");
+            Configuration configuration = new SystemPropertiesConfiguration();
+
+            when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenReturn(Collections.nCopies(2, "taskId"));
+            systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+            CountDownLatch latch = new CountDownLatch(10);
+            doAnswer(invocation -> {
+                        latch.countDown();
+                        return null;
+                    }
+            ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+            scheduledExecutorService.scheduleAtFixedRate(
+                    () -> systemTaskExecutor.pollAndExecute(TEST_TASK), 0, 1, TimeUnit.SECONDS);
+
+            Uninterruptibles.awaitUninterruptibly(latch);
+            verify(workflowExecutor, Mockito.times(10)).executeSystemTask(any(), anyString(), anyInt());
+        }
+        finally {
+            //Revert the batch poll settings
+            System.setProperty("workflow.system.task.queue.pollCount", "1");
+        }
     }
 
     @Test
@@ -146,6 +177,37 @@ public class TestSystemTaskExecutor {
 
         Uninterruptibles.awaitUninterruptibly(latch);
         verify(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+    }
+
+    @Test
+    public void testBatchPollException() {
+        try
+        {
+            System.setProperty("workflow.system.task.queue.pollCount", "2");
+            System.setProperty("workflow.system.task.worker.thread.count", "2");
+            Configuration configuration = new SystemPropertiesConfiguration();
+            when(queueDAO.pop(anyString(), anyInt(), anyInt()))
+                    .thenThrow(RuntimeException.class)
+                    .thenReturn(Collections.nCopies(2,"taskId"));
+            systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, configuration);
+
+            CountDownLatch latch = new CountDownLatch(2);
+            doAnswer(invocation -> {
+                        latch.countDown();
+                        return null;
+                    }
+            ).when(workflowExecutor).executeSystemTask(any(), anyString(), anyInt());
+
+            scheduledExecutorService.scheduleAtFixedRate(
+                    () -> systemTaskExecutor.pollAndExecute(TEST_TASK), 0, 1, TimeUnit.SECONDS);
+
+            Uninterruptibles.awaitUninterruptibly(latch);
+            verify(workflowExecutor, Mockito.times(2)).executeSystemTask(any(), anyString(), anyInt());
+        }
+        finally {
+            //Revert the batch poll settings
+            System.setProperty("workflow.system.task.queue.pollCount", "1");
+        }
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/utils/SemaphoreUtilTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/SemaphoreUtilTest.java
@@ -35,7 +35,7 @@ public class SemaphoreUtilTest {
 
         List<CompletableFuture<Void>> futuresList = new ArrayList<>();
         IntStream.range(0, threads).forEach(
-            t -> futuresList.add(CompletableFuture.runAsync(semaphoreUtil::canProcess, executorService)));
+            t -> futuresList.add(CompletableFuture.runAsync(()-> semaphoreUtil.acquireSlots(1), executorService)));
 
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(
             futuresList.toArray(new CompletableFuture[futuresList.size()]));
@@ -43,7 +43,7 @@ public class SemaphoreUtilTest {
         allFutures.get();
 
         assertEquals(0, semaphoreUtil.availableSlots());
-        assertFalse(semaphoreUtil.canProcess());
+        assertFalse(semaphoreUtil.acquireSlots(1));
 
         executorService.shutdown();
     }
@@ -56,17 +56,17 @@ public class SemaphoreUtilTest {
 
         List<CompletableFuture<Void>> futuresList = new ArrayList<>();
         IntStream.range(0, threads).forEach(
-            t -> futuresList.add(CompletableFuture.runAsync(semaphoreUtil::canProcess, executorService)));
+            t -> futuresList.add(CompletableFuture.runAsync(()-> semaphoreUtil.acquireSlots(1), executorService)));
 
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(
             futuresList.toArray(new CompletableFuture[futuresList.size()]));
         allFutures.get();
 
         assertEquals(0, semaphoreUtil.availableSlots());
-        semaphoreUtil.completeProcessing();
+        semaphoreUtil.completeProcessing(1);
 
         assertTrue(semaphoreUtil.availableSlots() > 0);
-        assertTrue(semaphoreUtil.canProcess());
+        assertTrue(semaphoreUtil.acquireSlots(1));
 
         executorService.shutdown();
     }


### PR DESCRIPTION
Using batch polling for system tasks from the queues. It will be very helpful for high throughput scenarios where large number of system tasks are executed and can possibly reduce the i/o (number of lookups in queues). It can be controlled by `workflow.system.task.queue.pollCount` configuration.