### PR TITLE
Optional event execution indexing

### DIFF
--- a/cassandra-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/cassandra-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -43,6 +43,11 @@ public class TestConfiguration implements CassandraConfiguration {
     }
 
     @Override
+    public boolean isEventExecutionIndexingEnabled() {
+        return true;
+    }
+
+    @Override
     public String getServerId() {
         return "server_id";
     }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -90,6 +90,9 @@ public interface Configuration {
     String EVENT_MESSAGE_INDEXING_ENABLED_PROPERTY_NAME = "workflow.event.message.indexing.enabled";
     boolean EVENT_MESSAGE_INDEXING_ENABLED_DEFAULT_VALUE = true;
 
+    String EVENT_EXECUTION_INDEXING_ENABLED_PROPERTY_NAME = "workflow.event.execution.indexing.enabled";
+    boolean EVENT_EXECUTION_INDEXING_ENABLED_DEFAULT_VALUE = true;
+
     String TASKEXECLOG_INDEXING_ENABLED_PROPERTY_NAME = "workflow.taskExecLog.indexing.enabled";
     boolean TASKEXECLOG_INDEXING_ENABLED_DEFAULT_VALUE = true;
 
@@ -207,6 +210,11 @@ public interface Configuration {
      * @return when set to true, message from the event processing are indexed
      */
     boolean isEventMessageIndexingEnabled();
+
+    /**
+     * @return when set to true, event execution results are indexed
+     */
+    boolean isEventExecutionIndexingEnabled();
 
     /**
      * @return ID of the server.  Can be host name, IP address or any other meaningful identifier.  Used for logging

--- a/core/src/main/java/com/netflix/conductor/core/config/SystemPropertiesConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/SystemPropertiesConfiguration.java
@@ -57,6 +57,11 @@ public class SystemPropertiesConfiguration implements Configuration {
     }
 
     @Override
+    public boolean isEventExecutionIndexingEnabled() {
+        return getBooleanProperty(EVENT_EXECUTION_INDEXING_ENABLED_PROPERTY_NAME, EVENT_EXECUTION_INDEXING_ENABLED_DEFAULT_VALUE);
+    }
+
+    @Override
     public String getServerId() {
         try {
             return InetAddress.getLocalHost().getHostName();

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -406,12 +406,13 @@ public class ExecutionDAOFacade {
         indexEventExecution(eventExecution);
     }
 
-    private void indexEventExecution(EventExecution eventExecution)
-    {
-        if (config.enableAsyncIndexing()) {
-            indexDAO.asyncAddEventExecution(eventExecution);
-        } else {
-            indexDAO.addEventExecution(eventExecution);
+    private void indexEventExecution(EventExecution eventExecution) {
+        if (config.isEventExecutionIndexingEnabled()) {
+            if (config.enableAsyncIndexing()) {
+                indexDAO.asyncAddEventExecution(eventExecution);
+            } else {
+                indexDAO.addEventExecution(eventExecution);
+            }
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
@@ -46,6 +46,11 @@ public class TestConfiguration implements Configuration {
 	}
 
 	@Override
+	public boolean isEventExecutionIndexingEnabled() {
+		return true;
+	}
+
+	@Override
 	public String getServerId() {
 		return "server_id";
 	}

--- a/mysql-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -57,6 +57,11 @@ public class TestConfiguration implements MySQLConfiguration {
 	}
 
 	@Override
+	public boolean isEventExecutionIndexingEnabled() {
+		return true;
+	}
+
+	@Override
 	public String getServerId() {
 		try {
 			return InetAddress.getLocalHost().getHostName();

--- a/postgres-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -57,6 +57,11 @@ public class TestConfiguration implements PostgresConfiguration {
     }
 
     @Override
+    public boolean isEventExecutionIndexingEnabled() {
+        return true;
+    }
+
+    @Override
     public String getServerId() {
         try {
             return InetAddress.getLocalHost().getHostName();

--- a/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/config/TestConfiguration.java
@@ -46,6 +46,11 @@ public class TestConfiguration implements Configuration {
 	}
 
 	@Override
+	public boolean isEventExecutionIndexingEnabled() {
+		return true;
+	}
+
+	@Override
 	public String getServerId() {
 		return "server_id";
 	}

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockConfiguration.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/MockConfiguration.java
@@ -48,6 +48,11 @@ public class MockConfiguration implements Configuration {
     }
 
     @Override
+    public boolean isEventExecutionIndexingEnabled() {
+        return true;
+    }
+
+    @Override
     public String getServerId() {
         try {
             return InetAddress.getLocalHost().getHostName();


### PR DESCRIPTION
Please consider making event execution indexing optional. Since it is not used for any logic directly, it can be made optional and can help reduce i/o.