### PR TITLE
Extend archive module to support TTL and delay

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/dao/cassandra/CassandraExecutionDAO.java
@@ -375,6 +375,15 @@ public class CassandraExecutionDAO extends CassandraBaseDAO implements Execution
     }
 
     /**
+     * This is a dummy implementation and this feature is not yet implemented
+     * for Cassandra backed Conductor
+     */
+    @Override
+    public boolean removeWorkflowWithExpiry(String workflowId, int ttlSeconds) {
+        throw new UnsupportedOperationException("This method is not currently implemented in CassandraExecutionDAO. Please use RedisDAO mode instead now for using TTLs.");
+    }
+
+    /**
      * This is a dummy implementation and this feature is not implemented
      * for Cassandra backed Conductor
      */

--- a/contribs/src/main/java/com/netflix/conductor/contribs/ArchiveWorkflowStatusListenerProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/ArchiveWorkflowStatusListenerProvider.java
@@ -38,7 +38,7 @@ public class ArchiveWorkflowStatusListenerProvider implements Provider<WorkflowS
     @Override
     public WorkflowStatusListener get() {
         if (config.getWorkflowArchivalTTL() > 0) {
-            return new ArchivingWithTTLWorkflowStatusListener(executionDAOFacade, config.getWorkflowArchivalTTL());
+            return new ArchivingWithTTLWorkflowStatusListener(executionDAOFacade, config);
         } else {
             return new ArchivingWorkflowStatusListener(executionDAOFacade);
         }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/ArchiveWorkflowStatusListenerProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/ArchiveWorkflowStatusListenerProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.contribs;
+
+import com.netflix.conductor.contribs.listener.ArchivingWithTTLWorkflowStatusListener;
+import com.netflix.conductor.contribs.listener.ArchivingWorkflowStatusListener;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.WorkflowStatusListener;
+import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+public class ArchiveWorkflowStatusListenerProvider implements Provider<WorkflowStatusListener> {
+
+    private final ExecutionDAOFacade executionDAOFacade;
+    private final Configuration config;
+
+    @Inject
+    ArchiveWorkflowStatusListenerProvider(ExecutionDAOFacade executionDAOFacade, Configuration config) {
+        this.executionDAOFacade = executionDAOFacade;
+        this.config = config;
+    }
+
+    @Override
+    public WorkflowStatusListener get() {
+        if (config.getWorkflowArchivalTTL() > 0) {
+            return new ArchivingWithTTLWorkflowStatusListener(executionDAOFacade, config.getWorkflowArchivalTTL());
+        } else {
+            return new ArchivingWorkflowStatusListener(executionDAOFacade);
+        }
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/ArchivingWorkflowModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/ArchivingWorkflowModule.java
@@ -16,7 +16,6 @@
 package com.netflix.conductor.contribs;
 
 import com.google.inject.AbstractModule;
-import com.netflix.conductor.contribs.listener.ArchivingWorkflowStatusListener;
 import com.netflix.conductor.core.execution.WorkflowStatusListener;
 
 /**
@@ -26,6 +25,6 @@ public class ArchivingWorkflowModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(WorkflowStatusListener.class).to(ArchivingWorkflowStatusListener.class);
+        bind(WorkflowStatusListener.class).toProvider(ArchiveWorkflowStatusListenerProvider.class);
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
@@ -91,23 +91,27 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
     }
 
     private class DelayArchiveWorkflow implements Runnable {
-        private final Workflow workflow;
+        private final String workflowId;
+        private final String workflowName;
+        private final Workflow.WorkflowStatus status;
         private final ExecutionDAOFacade executionDAOFacade;
 
         DelayArchiveWorkflow(Workflow workflow, ExecutionDAOFacade executionDAOFacade) {
-            this.workflow = workflow;
+            this.workflowId = workflow.getWorkflowId();
+            this.workflowName = workflow.getWorkflowName();
+            this.status = workflow.getStatus();
             this.executionDAOFacade = executionDAOFacade;
         }
 
         @Override
         public void run() {
             try {
-                this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
-                LOGGER.info("Archived workflow {}", workflow.getWorkflowId());
-                Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
+                this.executionDAOFacade.removeWorkflowWithExpiry(workflowId, true, archiveTTLSeconds);
+                LOGGER.info("Archived workflow {}", workflowId);
+                Monitors.recordWorkflowArchived(workflowName, status);
                 Monitors.recordArchivalDelayQueueSize(scheduledThreadPoolExecutor.getQueue().size());
             } catch (Exception e) {
-                LOGGER.error("Unable to archive workflow: {}", workflow.getWorkflowId(), e);
+                LOGGER.error("Unable to archive workflow: {}", workflowId, e);
             }
         }
     }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
@@ -16,34 +16,76 @@
 package com.netflix.conductor.contribs.listener;
 
 import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.WorkflowStatusListener;
 import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+import com.netflix.conductor.metrics.Monitors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArchivingWorkflowStatusListener.class);
 
     private final ExecutionDAOFacade executionDAOFacade;
     private final int archiveTTLSeconds;
+    private final int delayArchiveSeconds;
+    private final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
 
     @Inject
-    public ArchivingWithTTLWorkflowStatusListener(ExecutionDAOFacade executionDAOFacade, int archiveTTLSeconds) {
+    public ArchivingWithTTLWorkflowStatusListener(ExecutionDAOFacade executionDAOFacade, Configuration config) {
         this.executionDAOFacade = executionDAOFacade;
-        this.archiveTTLSeconds = archiveTTLSeconds;
+        this.archiveTTLSeconds = config.getWorkflowArchivalTTL();
+        this.delayArchiveSeconds = config.getWorkflowArchivalDelay();
+
+        this.scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(50,
+        (runnable, executor) -> {
+            LOGGER.warn("Request {} to delay archiving index dropped in executor {}", runnable, executor);
+            Monitors.recordDiscardedIndexingCount("delay");
+        });
+        this.scheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
     }
 
     @Override
     public void onWorkflowCompleted(Workflow workflow) {
         LOGGER.info("Archiving workflow {} on completion ", workflow.getWorkflowId());
-        this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+        if (delayArchiveSeconds > 0) {
+            scheduledThreadPoolExecutor.schedule(new DelayArchiveWorkflow(workflow, executionDAOFacade), delayArchiveSeconds, TimeUnit.SECONDS);
+        } else {
+            this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+        }
     }
 
     @Override
     public void onWorkflowTerminated(Workflow workflow) {
         LOGGER.info("Archiving workflow {} on termination", workflow.getWorkflowId());
-        this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+        if (delayArchiveSeconds > 0) {
+            scheduledThreadPoolExecutor.schedule(new DelayArchiveWorkflow(workflow, executionDAOFacade), delayArchiveSeconds, TimeUnit.SECONDS);
+        } else {
+            this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+        }
+    }
+
+    private class DelayArchiveWorkflow implements Runnable {
+        private final Workflow workflow;
+        private final ExecutionDAOFacade executionDAOFacade;
+
+        DelayArchiveWorkflow(Workflow workflow, ExecutionDAOFacade executionDAOFacade) {
+            this.workflow = workflow;
+            this.executionDAOFacade = executionDAOFacade;
+        }
+
+        @Override
+        public void run() {
+            try {
+                this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+                LOGGER.info("Archived workflow {}", workflow.getWorkflowId());
+            } catch (Exception e) {
+                LOGGER.error("Unable to archive workflow: {}", workflow.getWorkflowId(), e);
+            }
+        }
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWithTTLWorkflowStatusListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowStatusListener;
+import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchivingWorkflowStatusListener.class);
+
+    private final ExecutionDAOFacade executionDAOFacade;
+    private final int archiveTTLSeconds;
+
+    @Inject
+    public ArchivingWithTTLWorkflowStatusListener(ExecutionDAOFacade executionDAOFacade, int archiveTTLSeconds) {
+        this.executionDAOFacade = executionDAOFacade;
+        this.archiveTTLSeconds = archiveTTLSeconds;
+    }
+
+    @Override
+    public void onWorkflowCompleted(Workflow workflow) {
+        LOGGER.info("Archiving workflow {} on completion ", workflow.getWorkflowId());
+        this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+    }
+
+    @Override
+    public void onWorkflowTerminated(Workflow workflow) {
+        LOGGER.info("Archiving workflow {} on termination", workflow.getWorkflowId());
+        this.executionDAOFacade.removeWorkflowWithExpiry(workflow.getWorkflowId(), true, archiveTTLSeconds);
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/ArchivingWorkflowStatusListener.java
@@ -18,6 +18,7 @@ package com.netflix.conductor.contribs.listener;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.execution.WorkflowStatusListener;
 import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+import com.netflix.conductor.metrics.Monitors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,11 +44,13 @@ public class ArchivingWorkflowStatusListener implements WorkflowStatusListener {
     public void onWorkflowCompleted(Workflow workflow) {
         LOGGER.info("Archiving workflow {} on completion ", workflow.getWorkflowId());
         this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true);
+        Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
     }
 
     @Override
     public void onWorkflowTerminated(Workflow workflow) {
         LOGGER.info("Archiving workflow {} on termination", workflow.getWorkflowId());
         this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true);
+        Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -108,9 +108,11 @@ public interface Configuration {
     String WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME = "workflow.archival.ttl.seconds";
     int WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE = 0;
 
-    String WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME = "workflow.archival.enabled";
-    boolean WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE = true; //FIXME: Change this to false after testing
+//    String WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME = "workflow.archival.enabled";
+//    boolean WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE = true; //FIXME: Change this to false after testing
 
+    String WORKFLOW_ARCHIVAL_DELAY_SECS_PROPERTY_NAME = "workflow.archival.delay.seconds";
+    int WORKFLOW_ARCHIVAL_DELAY_SECS_DEFAULT_VALUE = 60;
 
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
     boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
@@ -198,6 +200,7 @@ public interface Configuration {
     default int getSystemTaskWorkerIsolatedThreadCount() {
         return getIntProperty(SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME, SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE);
     }
+
 
     /**
      * @return time frequency in seconds, at which the workflow sweeper should run to evaluate running workflows.
@@ -331,9 +334,13 @@ public interface Configuration {
         return getIntProperty(WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE);
     }
 
-    default boolean isWorkflowArchivalEnabled()
-    {
-        return getBooleanProperty(WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME, WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE);
+//    default boolean isWorkflowArchivalEnabled()
+//    {
+//        return getBooleanProperty(WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME, WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE);
+//    }
+
+    default int getWorkflowArchivalDelay() {
+        return getIntProperty(WORKFLOW_ARCHIVAL_DELAY_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_DELAY_SECS_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -105,6 +105,9 @@ public interface Configuration {
     String EVENT_EXECUTION_PERSISTENCE_TTL_SECS_PROPERTY_NAME = "workflow.event.execution.persistence.ttl.seconds";
     int EVENT_EXECUTION_PERSISTENCE_TTL_SECS_DEFAULT_VALUE = 0;
 
+    String WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME = "workflow.archival.ttl.seconds";
+    int WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE = 0;
+
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
     boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
 
@@ -315,6 +318,13 @@ public interface Configuration {
     default String getElasticSearchDocumentTypeOverride() {
         return getProperty(ELASTIC_SEARCH_DOCUMENT_TYPE_OVERRIDE_PROPERTY_NAME,
             ELASTIC_SEARCH_DOCUMENT_TYPE_OVERRIDE_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return The time to live in seconds for workflow archiving module. Currently, only RedisExecutionDAO supports it.
+     */
+    default int getWorkflowArchivalTTL() {
+        return getIntProperty(WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -108,11 +108,10 @@ public interface Configuration {
     String WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME = "workflow.archival.ttl.seconds";
     int WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE = 0;
 
-//    String WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME = "workflow.archival.enabled";
-//    boolean WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE = true; //FIXME: Change this to false after testing
-
     String WORKFLOW_ARCHIVAL_DELAY_SECS_PROPERTY_NAME = "workflow.archival.delay.seconds";
-    int WORKFLOW_ARCHIVAL_DELAY_SECS_DEFAULT_VALUE = 60;
+
+    String WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_PROPERTY_NAME = "workflow.archival.delay.queue.worker.thread.count";
+    int WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_DEFAULT_VALUE = 5;
 
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
     boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
@@ -200,7 +199,6 @@ public interface Configuration {
     default int getSystemTaskWorkerIsolatedThreadCount() {
         return getIntProperty(SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_PROPERTY_NAME, SYSTEM_TASK_WORKER_ISOLATED_THREAD_COUNT_DEFAULT_VALUE);
     }
-
 
     /**
      * @return time frequency in seconds, at which the workflow sweeper should run to evaluate running workflows.
@@ -334,14 +332,20 @@ public interface Configuration {
         return getIntProperty(WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE);
     }
 
-//    default boolean isWorkflowArchivalEnabled()
-//    {
-//        return getBooleanProperty(WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME, WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE);
-//    }
-
+    /**
+     * @return the time to delay the archival of workflow
+     */
     default int getWorkflowArchivalDelay() {
-        return getIntProperty(WORKFLOW_ARCHIVAL_DELAY_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_DELAY_SECS_DEFAULT_VALUE);
+        return getIntProperty(WORKFLOW_ARCHIVAL_DELAY_SECS_PROPERTY_NAME, getAsyncUpdateDelay());
     }
+
+    /**
+     * @return the number of threads to process the delay queue in workflow archival
+     */
+    default int getWorkflowArchivalDelayQueueWorkerThreadCount() {
+        return getIntProperty(WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_PROPERTY_NAME, WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_DEFAULT_VALUE);
+    }
+
 
     /**
      * @param name         Name of the property

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -108,6 +108,10 @@ public interface Configuration {
     String WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME = "workflow.archival.ttl.seconds";
     int WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE = 0;
 
+    String WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME = "workflow.archival.enabled";
+    boolean WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE = true; //FIXME: Change this to false after testing
+
+
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
     boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
 
@@ -325,6 +329,11 @@ public interface Configuration {
      */
     default int getWorkflowArchivalTTL() {
         return getIntProperty(WORKFLOW_ARCHIVAL_TTL_SECS_PROPERTY_NAME, WORKFLOW_ARCHIVAL_TTL_SECS_DEFAULT_VALUE);
+    }
+
+    default boolean isWorkflowArchivalEnabled()
+    {
+        return getBooleanProperty(WORKFLOW_ARCHIVAL_ENABLED_PROPERTY_NAME, WORKFLOW_ARCHIVAL_ENABLED_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -196,8 +196,6 @@ public class ExecutionDAOFacade {
         executionDAO.createWorkflow(workflow);
         // Add to decider queue
         queueDAO.push(DECIDER_QUEUE, workflow.getWorkflowId(), workflow.getPriority(), config.getSweepFrequency());
-        // if (config.enableAsyncIndexing() && !config.isWorkflowArchivalEnabled()) {
-        //FIXME: Add proper doc why archival should not execute this.
         if(config.enableAsyncIndexing()) {
             indexDAO.asyncIndexWorkflow(workflow);
         } else {

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.orchestration;
 
 import static com.netflix.conductor.core.execution.WorkflowExecutor.DECIDER_QUEUE;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.common.metadata.events.EventExecution;
 import com.netflix.conductor.common.metadata.tasks.PollData;
@@ -248,24 +249,49 @@ public class ExecutionDAOFacade {
         try {
             Workflow workflow = getWorkflowById(workflowId, true);
 
-            if (archiveWorkflow) {
-                if (workflow.getStatus().isTerminal()) {
-                    // Only allow archival if workflow is in terminal state
-                    // DO NOT archive async, since if archival errors out, workflow data will be lost
-                    indexDAO.updateWorkflow(workflowId,
-                        new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD},
-                        new Object[]{objectMapper.writeValueAsString(workflow), true});
-                } else {
-                    throw new ApplicationException(Code.INVALID_INPUT, String.format("Cannot archive workflow: %s with status: %s", workflowId, workflow.getStatus()));
-                }
-            } else {
-                // Not archiving, also remove workflow from index
-                indexDAO.asyncRemoveWorkflow(workflowId);
-            }
-
+            removeWorkflowIndex(workflow, archiveWorkflow);
             // remove workflow from DAO
             try {
                 executionDAO.removeWorkflow(workflowId);
+            } catch (Exception ex) {
+                Monitors.recordDaoError("executionDao", "removeWorkflow");
+                throw ex;
+            }
+        } catch (ApplicationException ae) {
+            throw ae;
+        } catch (Exception e) {
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, "Error removing workflow: " + workflowId, e);
+        }
+    }
+
+    private void removeWorkflowIndex(Workflow workflow , boolean archiveWorkflow) throws JsonProcessingException {
+        if (archiveWorkflow) {
+            if (workflow.getStatus().isTerminal()) {
+                // Only allow archival if workflow is in terminal state
+                // DO NOT archive async, since if archival errors out, workflow data will be lost
+                indexDAO.updateWorkflow(workflow.getWorkflowId(),
+                        new String[]{RAW_JSON_FIELD, ARCHIVED_FIELD},
+                        new Object[]{objectMapper.writeValueAsString(workflow), true});
+            } else {
+                throw new ApplicationException(Code.INVALID_INPUT, String.format("Cannot archive workflow: %s with status: %s",
+                        workflow.getWorkflowId(),
+                        workflow.getStatus()));
+            }
+        } else {
+            // Not archiving, also remove workflow from index
+            indexDAO.asyncRemoveWorkflow(workflow.getWorkflowId());
+        }
+    }
+
+    public void removeWorkflowWithExpiry(String workflowId, boolean archiveWorkflow, int ttlSeconds)
+    {
+        try {
+            Workflow workflow = getWorkflowById(workflowId, true);
+
+            removeWorkflowIndex(workflow, archiveWorkflow);
+            // remove workflow from DAO with TTL
+            try {
+                executionDAO.removeWorkflowWithExpiry(workflowId, ttlSeconds);
             } catch (Exception ex) {
                 Monitors.recordDaoError("executionDao", "removeWorkflow");
                 throw ex;
@@ -285,7 +311,7 @@ public class ExecutionDAOFacade {
      */
     public void resetWorkflow(String workflowId) {
         try {
-            Workflow workflow = getWorkflowById(workflowId, true);
+            getWorkflowById(workflowId, true);
             executionDAO.removeWorkflow(workflowId);
             if (config.enableAsyncIndexing()) {
                 indexDAO.asyncRemoveWorkflow(workflowId);

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -196,7 +196,8 @@ public class ExecutionDAOFacade {
         executionDAO.createWorkflow(workflow);
         // Add to decider queue
         queueDAO.push(DECIDER_QUEUE, workflow.getWorkflowId(), workflow.getPriority(), config.getSweepFrequency());
-        if (config.enableAsyncIndexing()) {
+        if (config.enableAsyncIndexing() && !config.isWorkflowArchivalEnabled()) {
+            //FIXME: Add proper doc why archival should not execute this.
             indexDAO.asyncIndexWorkflow(workflow);
         } else {
             indexDAO.indexWorkflow(workflow);

--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -196,8 +196,9 @@ public class ExecutionDAOFacade {
         executionDAO.createWorkflow(workflow);
         // Add to decider queue
         queueDAO.push(DECIDER_QUEUE, workflow.getWorkflowId(), workflow.getPriority(), config.getSweepFrequency());
-        if (config.enableAsyncIndexing() && !config.isWorkflowArchivalEnabled()) {
-            //FIXME: Add proper doc why archival should not execute this.
+        // if (config.enableAsyncIndexing() && !config.isWorkflowArchivalEnabled()) {
+        //FIXME: Add proper doc why archival should not execute this.
+        if(config.enableAsyncIndexing()) {
             indexDAO.asyncIndexWorkflow(workflow);
         } else {
             indexDAO.indexWorkflow(workflow);

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -135,7 +135,17 @@ public interface ExecutionDAO {
 	 * @return true if the deletion is successful, false otherwise
 	 */
 	boolean removeWorkflow(String workflowId);
-	
+
+
+	/**
+	 * Removes the workflow with ttl seconds
+	 *
+	 * @param workflowId workflowId workflow instance id
+	 * @param ttlSeconds time to live in seconds.
+	 * @return
+	 */
+	boolean removeWorkflowWithExpiry(String workflowId, int ttlSeconds);
+
 	/**
 	 * 
 	 * @param workflowType Workflow Type

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -306,6 +306,17 @@ public class Monitors {
 		counter(classQualifier, "acquire_lock_failure", "exceptionType", exceptionClassName);
 	}
 
+	public static void recordWorkflowArchived(String workflowType, WorkflowStatus status) {
+		counter(classQualifier, "workflow_archived", "workflowName", workflowType, "workflowStatus", status.name());
+	}
+
+	public static void recordArchivalDelayQueueSize(int val) {
+		getGauge(classQualifier, "workflow_archival_delay_queue_size").set(val);
+	}
+	public static void recordDiscardedArchivalCount() {
+		counter(classQualifier, "discarded_archival_count");
+	}
+
 	public static void recordSystemTaskWorkerPollingLimited(String queueName) {
 		counter(classQualifier, "system_task_worker_polling_limited", "queueName", queueName);
 	}

--- a/core/src/test/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacadeTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacadeTest.java
@@ -116,7 +116,7 @@ public class ExecutionDAOFacadeTest {
         when(executionDAO.getWorkflow(anyString(), anyBoolean())).thenReturn(workflow);
         executionDAOFacade.removeWorkflow("workflowId", false);
         verify(indexDAO, never()).updateWorkflow(any(), any(), any());
-        verify(indexDAO, times(1)).asyncRemoveWorkflow(anyString());
+        verify(indexDAO, times(1)).asyncRemoveWorkflow(workflow.getWorkflowId());
     }
 
     @Test

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -277,6 +277,14 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
         return removed;
     }
 
+    /**
+     * This is a dummy implementation and this feature is not supported for MySQL backed Conductor
+     */
+    @Override
+    public boolean removeWorkflowWithExpiry(String workflowId, int ttlSeconds) {
+        throw new UnsupportedOperationException("This method is not implemented in MySQLExecutionDAO. Please use RedisDAO mode instead for using TTLs.");
+    }
+
     @Override
     public void removeFromPendingWorkflow(String workflowType, String workflowId) {
         withTransaction(connection -> removePendingWorkflow(connection, workflowType, workflowId));

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
@@ -276,6 +276,14 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
         return removed;
     }
 
+    /**
+     * This is a dummy implementation and this feature is not supported for Postgres backed Conductor
+     */
+    @Override
+    public boolean removeWorkflowWithExpiry(String workflowId, int ttlSeconds) {
+        throw new UnsupportedOperationException("This method is not implemented in MySQLExecutionDAO. Please use RedisDAO mode instead for using TTLs.");
+    }
+
     @Override
     public void removeFromPendingWorkflow(String workflowType, String workflowId) {
         withTransaction(connection -> removePendingWorkflow(connection, workflowType, workflowId));


### PR DESCRIPTION
Added new workflow status listener called `ArchivingWithTTLWorkflowStatusListener` that supports delayed archiving and setting time-to-live for the documents in Redis for now (can be extended to Cassandra later). 

`Delayed Archiving`: It is required in cases where short workflows are indexed after a delay and `updateIndex` will fail in those cases since the document might not exist. Further, when using async indexing, in case of high throughput scenarios, an asynchronous create document index request could be pending in the `indexQueue`, and the synchronous update request will fail due to missing document. 

`Time-to-live`: It is helpful in the case of `TERMINATED` workflows. If the parent workflow is terminated and then sub-workflow is canceled. In those cases, the task worker could still be running the task and when it completes and try to update the status of the task, the task/workflow will be missing in persistence if the workflow is archived immediately after the termination/completion.  So TTL can help in this case.  Also if the parent-workflow need to lookup output from sub-workflow, using TTL can help the data to be available in the memory(Redis case) rather than disk lookup in elasticsearch.