### PR TITLE
fix BETWEEN operator; ensure task cancellation when terminating workflow

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/telemetry/MetricsContainer.java
+++ b/client/src/main/java/com/netflix/conductor/client/telemetry/MetricsContainer.java
@@ -37,7 +37,7 @@ public class MetricsContainer {
     private static final String WORFLOW_TYPE = "workflowType";
     private static final String WORKFLOW_VERSION = "version";
     private static final String EXCEPTION = "exception";
-    private static final String NAME = "name";
+    private static final String ENTITY_NAME = "entityName";
     private static final String OPERATION = "operation";
     private static final String PAYLOAD_TYPE = "payload_type";
 
@@ -162,7 +162,7 @@ public class MetricsContainer {
     }
 
     public static void incrementExternalPayloadUsedCount(String name, String operation, String payloadType) {
-        incrementCount(EXTERNAL_PAYLOAD_USED, NAME, name, OPERATION, operation, PAYLOAD_TYPE, payloadType);
+        incrementCount(EXTERNAL_PAYLOAD_USED, ENTITY_NAME, name, OPERATION, operation, PAYLOAD_TYPE, payloadType);
     }
 
     public static void incrementWorkflowStartErrorCount(String workflowType, Throwable t) {
@@ -177,6 +177,6 @@ public class MetricsContainer {
      * @param className the name of the class which initialized the client
      */
     public static void incrementInitializationCount(String className) {
-        incrementCount(CLIENT_INITIALIZED, NAME, className);
+        incrementCount(CLIENT_INITIALIZED, ENTITY_NAME, className);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -140,13 +140,14 @@ public class ExecutionService {
 				if (task == null || task.getStatus().isTerminal()) {
 					// Remove taskId(s) without a valid Task/terminal state task from the queue
 					queueDAO.remove(queueName, taskId);
-					logger.debug("Removed taskId from the queue: {}, {}", queueName, taskId);
+					logger.debug("Removed task: {} from the queue: {}", taskId, queueName);
 					continue;
 				}
 
 				if (executionDAOFacade.exceedsInProgressLimit(task)) {
 					// Postpone a message, so that it would be available for poll again.
 					queueDAO.postpone(queueName, taskId, task.getWorkflowPriority(), queueTaskMessagePostponeSeconds);
+					logger.debug("Postponed task: {} in queue: {} by {} seconds", taskId, queueName, queueTaskMessagePostponeSeconds);
 					continue;
 				}
 

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
@@ -1,20 +1,14 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -25,11 +19,11 @@ import java.io.InputStream;
  */
 public class ComparisonOp extends AbstractNode {
 
-	public static enum Operators {
+	public enum Operators {
 		BETWEEN("BETWEEN"), EQUALS("="), LESS_THAN("<"), GREATER_THAN(">"), IN("IN"), NOT_EQUALS("!="), IS("IS"),
 		STARTS_WITH("STARTS_WITH");
 
-		private String value;
+		private final String value;
 		Operators(String value){
 			this.value = value;
 		}
@@ -49,8 +43,7 @@ public class ComparisonOp extends AbstractNode {
 
 	private static final int maxOperatorLength;
 
-	private static final int betwnLen = Operators.BETWEEN.value().length();
-
+	private static final int betweenLen = Operators.BETWEEN.value().length();
 	private static final int startsWithLen = Operators.STARTS_WITH.value().length();
 
 	private String value;
@@ -70,7 +63,7 @@ public class ComparisonOp extends AbstractNode {
 			this.value = "IS";
 		}else if(peeked[0] == '!' && peeked[1] == '='){
 			this.value = "!=";
-		}else if(peeked.length == betwnLen && new String(peeked).equals(Operators.BETWEEN.value())) {
+		}else if(peeked.length >= betweenLen && peeked[0] == 'B' && peeked[1] == 'E' && peeked[2] == 'T' && peeked[3] == 'W' && peeked[4] == 'E' && peeked[5] == 'E' && peeked[6] == 'N'){
 			this.value = Operators.BETWEEN.value();
 		}else if(peeked.length == startsWithLen && new String(peeked).equals(Operators.STARTS_WITH.value())) {
 			this.value = Operators.STARTS_WITH.value();

--- a/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
+++ b/es5-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
@@ -1,28 +1,21 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
 
 /**
  * @author Viren
@@ -32,7 +25,7 @@ public class TestComparisonOp extends AbstractParserTest {
 
 	@Test
 	public void test() throws Exception {
-		String[] tests = new String[]{"<",">","=","!=","IN","STARTS_WITH"};
+		String[] tests = new String[]{"<",">","=","!=","IN","BETWEEN","STARTS_WITH"};
 		for(String test : tests){
 			ComparisonOp name = new ComparisonOp(getInputStream(test));
 			String nameVal = name.getOperator();

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/query/parser/ComparisonOp.java
@@ -1,20 +1,14 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
@@ -25,11 +19,11 @@ import java.io.InputStream;
  */
 public class ComparisonOp extends AbstractNode {
 
-	public static enum Operators {
+	public enum Operators {
 		BETWEEN("BETWEEN"), EQUALS("="), LESS_THAN("<"), GREATER_THAN(">"), IN("IN"), NOT_EQUALS("!="), IS("IS"),
 		STARTS_WITH("STARTS_WITH");
 
-		private String value;
+		private final String value;
 		Operators(String value){
 			this.value = value;
 		}
@@ -49,8 +43,7 @@ public class ComparisonOp extends AbstractNode {
 
 	private static final int maxOperatorLength;
 
-	private static final int betwnLen = Operators.BETWEEN.value().length();
-
+	private static final int betweenLen = Operators.BETWEEN.value().length();
 	private static final int startsWithLen = Operators.STARTS_WITH.value().length();
 
 	private String value;
@@ -70,7 +63,7 @@ public class ComparisonOp extends AbstractNode {
 			this.value = "IS";
 		}else if(peeked[0] == '!' && peeked[1] == '='){
 			this.value = "!=";
-		}else if(peeked.length == betwnLen && new String(peeked).equals(Operators.BETWEEN.value())){
+		}else if(peeked.length >= betweenLen && peeked[0] == 'B' && peeked[1] == 'E' && peeked[2] == 'T' && peeked[3] == 'W' && peeked[4] == 'E' && peeked[5] == 'E' && peeked[6] == 'N'){
 			this.value = Operators.BETWEEN.value();
 		}else if(peeked.length == startsWithLen && new String(peeked).equals(Operators.STARTS_WITH.value())) {
 			this.value = Operators.STARTS_WITH.value();
@@ -89,5 +82,4 @@ public class ComparisonOp extends AbstractNode {
 	public String getOperator(){
 		return value;
 	}
-
 }

--- a/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/elasticsearch/query/parser/TestComparisonOp.java
@@ -1,28 +1,21 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2020 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.elasticsearch.query.parser;
 
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
 
 /**
  * @author Viren
@@ -32,7 +25,7 @@ public class TestComparisonOp extends AbstractParserTest {
 
 	@Test
 	public void test() throws Exception {
-		String[] tests = new String[]{"<",">","=","!=","IN","STARTS_WITH"};
+		String[] tests = new String[]{"<",">","=","!=","IN","BETWEEN","STARTS_WITH"};
 		for(String test : tests){
 			ComparisonOp name = new ComparisonOp(getInputStream(test));
 			String nameVal = name.getOperator();


### PR DESCRIPTION
- Fix `BETWEEN` operator
Fix the parsing of the operator

- Ensure task is cancelled when terminating a workflow
Remove tasks from the queue first so that polling for tasks will not retrieve these
Update task status to CANCELED 
Update workflow status to TERMINATED