### PR TITLE
fix reset callbacks api

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -209,7 +209,7 @@ public interface WorkflowService {
     void retryWorkflow(@NotEmpty(message = "WorkflowId cannot be null or empty.") String workflowId);
 
     /**
-     * Resets callback times of all in_progress tasks to 0.
+     * Resets callback times of all non-terminal SIMPLE tasks to 0.
      *
      * @param workflowId WorkflowId of the workflow.
      */

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -348,13 +348,13 @@ public class WorkflowServiceImpl implements WorkflowService {
     }
 
     /**
-     * Resets callback times of all in_progress tasks to 0.
+     * Resets callback times of all non-terminal SIMPLE tasks to 0.
      *
      * @param workflowId WorkflowId of the workflow.
      */
     @Service
     public void resetWorkflow(String workflowId) {
-        workflowExecutor.resetCallbacksForInProgressTasks(workflowId);
+        workflowExecutor.resetCallbacksForWorkflow(workflowId);
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -1,17 +1,14 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.service;
 
@@ -455,7 +452,7 @@ public class WorkflowServiceTest {
     @Test
     public void testResetWorkflow() {
         workflowService.resetWorkflow("w123");
-        verify(mockWorkflowExecutor, times(1)).resetCallbacksForInProgressTasks(anyString());
+        verify(mockWorkflowExecutor, times(1)).resetCallbacksForWorkflow(anyString());
     }
 
     @Test

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java
@@ -195,7 +195,7 @@ public class WorkflowResource {
 
     @POST
     @Path("/{workflowId}/resetcallbacks")
-    @ApiOperation("Resets callback times of all in_progress tasks to 0")
+    @ApiOperation("Resets callback times of all non-terminal SIMPLE tasks to 0")
     @Consumes(MediaType.WILDCARD)
     public void resetWorkflow(@PathParam("workflowId") String workflowId) {
         workflowService.resetWorkflow(workflowId);

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/SimpleWorkflowSpec.groovy
@@ -852,7 +852,7 @@ class SimpleWorkflowSpec extends Specification {
         !pollTaskTry3
 
         when:"The callbackSeconds of the tasks in progress for the workflow are reset"
-        workflowExecutor.resetCallbacksForInProgressTasks(workflowInstanceId)
+        workflowExecutor.resetCallbacksForWorkflow(workflowInstanceId)
 
         and:"the 'integration_task_1' is polled again after all the in progress tasks are reset"
         def task1Try4Tuple = workflowTestUtil.pollAndCompleteTask('integration_task_1',

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -3341,7 +3341,7 @@ public abstract class AbstractWorkflowServiceTest {
         assertNull(task);
 
         // Reset the callbackAfterSeconds
-        workflowExecutor.resetCallbacksForInProgressTasks(workflowId);
+        workflowExecutor.resetCallbacksForWorkflow(workflowId);
 
         // Now Polling for the first task should return the same task as before
         task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");


### PR DESCRIPTION
- Reset the callbacks for only non-terminal tasks in the workflow.
- Reset callbacks for only SIMPLE tasks for which the workers set invisibility callbacks.