### PR TITLE
Removed blocking conditional on ack Task before execution

### DIFF
--- a/client/python/conductor/ConductorWorker.py
+++ b/client/python/conductor/ConductorWorker.py
@@ -87,8 +87,8 @@ class ConductorWorker:
             time.sleep(float(self.polling_interval))
             polled = self.taskClient.pollForTask(taskType, self.worker_id, domain)
             if polled is not None:
-                if self.taskClient.ackTask(polled['taskId'], self.worker_id):
-                    self.execute(polled, exec_function)
+                self.taskClient.ackTask(polled['taskId'], self.worker_id):
+                self.execute(polled, exec_function)
 
     def start(self, taskType, exec_function, wait, domain=None):
         """


### PR DESCRIPTION
The execution of a polled task was conditioned by the return of self.taskClient.ackTask which was required to be True. This was never happening because task Ack has been made a Nop and the python client has been left behind (as per discussion on gitter community).
I don't know whether ack TAsk should be removed altogether but in the meanwhile consider removing the if.

Please consider this as a followup of a discussion on gitter.im:
> > Hi all. I started evaluating Conductor with current docker images (server,ui,dynomite,elasticsearch). I am trying to write a complete rest client starting from python example. After polling succesfully for a task, the ack request returns Always false thus preventing execution. Now I forced the condition to true in the if stmt checking the ack outcome and everything seems to work. What should I check to understand what happens and why ack returns true even of task Is polled correctly? Thank you. 
> 
> Hey @dcore94 , Ack has been made no-op in one of the efforts, and Python client might be left behind, where it is still checking for the ack response to be true, while the client can safely ignore it. Please send us a PR if you could triangulate the issue and find a resolution.
