### PR TITLE
Fix issue in which messages are not handled by event-handler when using 'amqp:' key

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/AMQPModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/AMQPModule.java
@@ -55,7 +55,7 @@ public class AMQPModule extends AbstractModule {
 	}
 
 	@ProvidesIntoMap
-	@StringMapKey("amqp")
+	@StringMapKey("amqp_queue")
 	@Singleton
 	@Named(EVENT_QUEUE_PROVIDERS_QUALIFIER)
 	public EventQueueProvider getAMQQueueEventQueueProvider(Configuration config) {


### PR DESCRIPTION
Rename StringMapKey for amqp queue from "amqp" to amqp_queue"
Issue: https://github.com/Netflix/conductor/issues/1745#issue-642554258

Related comments:
https://github.com/Netflix/conductor/pull/1589#issuecomment-641851944