### PR TITLE
fix input param replacement when workflow is retried

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExecutionConfig.java
@@ -22,8 +22,8 @@ import java.util.concurrent.Executors;
 
 class ExecutionConfig {
 
-    private ExecutorService executorService;
-    private SemaphoreUtil semaphoreUtil;
+    private final ExecutorService executorService;
+    private final SemaphoreUtil semaphoreUtil;
 
     ExecutionConfig(int threadCount, String threadNameFormat) {
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
@@ -79,7 +79,7 @@ public class DoWhileTest {
         executionLockService = Mockito.mock(ExecutionLockService.class);
         config = Mockito.mock(Configuration.class);
         provider = spy(new WorkflowExecutor(deciderService, metadataDAO, queueDAO, metadataMapperService,
-                workflowStatusListener, executionDAOFacade, config, executionLockService));
+                workflowStatusListener, executionDAOFacade, config, executionLockService, parametersUtils));
         loopWorkflowTask1 = new WorkflowTask();
         loopWorkflowTask1.setTaskReferenceName("task1");
         loopWorkflowTask1.setName("task1");

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/SimpleWorkflowSpec.groovy
@@ -647,6 +647,7 @@ class SimpleWorkflowSpec extends Specification {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 1
             tasks[0].status == Task.Status.SCHEDULED
+            tasks[0].getInputData().get("p3") == tasks[0].getTaskId()
         }
         with(metadataService.getWorkflowDef(LINEAR_WORKFLOW_T1_T2, 1)) {
             failureWorkflow
@@ -663,6 +664,7 @@ class SimpleWorkflowSpec extends Specification {
             tasks.size() == 2
             tasks[0].status == Task.Status.FAILED
             tasks[1].status == Task.Status.SCHEDULED
+            tasks[1].getInputData().get("p3") == tasks[1].getTaskId()
         }
 
         when:"The first task 'integration_task_1' is polled and failed for the second time"
@@ -687,6 +689,7 @@ class SimpleWorkflowSpec extends Specification {
             tasks[0].status == Task.Status.FAILED
             tasks[1].status == Task.Status.FAILED
             tasks[2].status == Task.Status.SCHEDULED
+            tasks[2].getInputData().get("p3") == tasks[2].getTaskId()
         }
 
         when:"The 'integration_task_1' task is polled and is completed"

--- a/test-harness/src/test/resources/simple_workflow_1_integration_test.json
+++ b/test-harness/src/test/resources/simple_workflow_1_integration_test.json
@@ -8,6 +8,7 @@
     "inputParameters" : {
       "p1" : "${workflow.input.param1}",
       "p2" : "${workflow.input.param2}",
+      "p3" : "${CPEWF_TASK_ID}",
       "someNullKey" : null
     },
     "type" : "SIMPLE",
@@ -25,7 +26,8 @@
     "taskReferenceName" : "t2",
     "inputParameters" : {
       "tp1" : "${workflow.input.param1}",
-      "tp2" : "${t1.output.op}"
+      "tp2" : "${t1.output.op}",
+      "tp3" : "${CPEWF_TASK_ID}"
     },
     "type" : "SIMPLE",
     "decisionCases" : { },


### PR DESCRIPTION
- Fixed input param replacement in the retried tasks when a workflow a retried
- Allow TIMED_OUT tasks (hence the workflows) to be retried