### PR TITLE
HealthCheck Module implementation for Redis/ElasticSearch persistences

### DIFF
--- a/es-health/README.md
+++ b/es-health/README.md
@@ -1,0 +1,112 @@
+# Elastic Search Health Check 
+
+This module is optional and can compile with `es5-persistence` or `es6-persistence`.
+
+**!! Only tested with es5**
+
+## Build
+
+### Gradle Configuration
+
+Modify the following files
+
+[settings.gradle](https://github.com/Netflix/conductor/blob/master/settings.gradle)
+
+```diff
+@@ -3,6 +3,7 @@ rootProject.name='conductor'
+ include 'client','common','contribs','core', 'es5-persistence','jersey', 'postgres-persistence', 'zookeeper-lock', 'redis-lock'
+ include 'cassandra-persistence', 'mysql-persistence', 'redis-persistence','server','test-harness','ui'
+ include 'grpc', 'grpc-server', 'grpc-client'
++include 'es-health'
+
+ rootProject.children.each {it.name="conductor-${it.name}"}
+
+```
+
+[server/build.gradle](https://github.com/Netflix/conductor/blob/master/server/build.gradle)
+
+```diff
+@@ -38,6 +38,7 @@ dependencies {
+
++   compile project(':conductor-es-health')
+
+    compile "com.netflix.runtime:health-guice:${revHealth}"
+```
+ 
+Delete all dependencies.lock files of all modules and then run at the root folder of the project: 
+
+```
+./gradlew generateLock saveLock -PdependencyLock.includeTransitives=true
+```
+
+Run Build along with the tests
+
+```
+./gradlew conductor:es-health build
+```
+
+## Configuration
+
+In the `.properties` file of conductor `server` you must add the following configurations.
+
+* Add the ElasticSearchHealthModule module. If you have several modules, separate them with a comma.
+```
+conductor.additional.modules=com.netflix.conductor.health.ElasticSearchHealthModule
+```
+
+* Health Indicator can be configured through HealthAggregatorConfiguration. The following attributes can be added to the properties file
+```
+health.aggregator.cacheHealthIndicators=true
+health.aggregator.cacheIntervalInMillis=5000
+health.aggregator.aggregatorWaitIntervalInMillis=1000
+```
+
+### Usage
+
+Request: HTTP GET /api/health
+
+
+* If ElasticSearch is reachable
+
+Response: HTTP 200
+```json
+{
+  "healthResults": [
+    {
+      "details": {
+        "cached": true,
+        "className": "com.netflix.conductor.health.ElasticSearchHealthIndicator"
+      },
+      "healthy": true,
+      "errorMessage": {
+        "present": false
+      }
+    }
+  ],
+  "suppressedHealthResults": [],
+  "healthy": true
+}
+```
+
+* If ElasticSearch is unreachable
+
+Response: HTTP 200
+```json
+{
+  "healthResults": [
+    {
+      "details": {
+        "error": "org.elasticsearch.client.transport.NoNodeAvailableException: None of the configured nodes were available: [{XrEPuUd}{XrEPuUliQnaIliQj2dQ7tx}{a5f_4-JNRoSxxv3Y5Yfj8g}{172.20.0.3}{172.20.0.3:9300}{ml.max_open_jobs=10, ml.enabled=true}]",
+        "cached": true,
+        "className": "com.netflix.conductor.health.ElasticSearchHealthIndicator"
+      },
+      "healthy": false,
+      "errorMessage": {
+        "present": true
+      }
+    }
+  ],
+  "suppressedHealthResults": [],
+  "healthy": false
+}
+```

--- a/es-health/build.gradle
+++ b/es-health/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+
+    compile "org.elasticsearch:elasticsearch:${revElasticSearch5}"
+    compile "org.elasticsearch.client:transport:${revElasticSearch5}"
+    compileOnly "org.elasticsearch:elasticsearch:${revElasticSearch6}"
+    compileOnly "org.elasticsearch.client:transport:${revElasticSearch6}"
+
+    compile "com.netflix.runtime:health-guice:${revHealth}"
+}

--- a/es-health/src/main/java/com/netflix/conductor/health/ElasticSearchHealthIndicator.java
+++ b/es-health/src/main/java/com/netflix/conductor/health/ElasticSearchHealthIndicator.java
@@ -1,0 +1,48 @@
+package com.netflix.conductor.health;
+
+import com.netflix.runtime.health.api.Health;
+import com.netflix.runtime.health.api.HealthIndicator;
+import com.netflix.runtime.health.api.HealthIndicatorCallback;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class ElasticSearchHealthIndicator implements HealthIndicator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticSearchHealthIndicator.class);
+
+    private final Client esClient;
+
+    @Inject
+    public ElasticSearchHealthIndicator(Client esClient) {
+        this.esClient = esClient;
+        LOGGER.info("Health Indicator is Ready");
+   }
+
+    @Override
+    public void check(HealthIndicatorCallback healthIndicatorCallback) {
+        LOGGER.debug("Checking Health");
+        try {
+            ClusterHealthResponse health = this.esClient.admin().cluster().prepareHealth().get();
+
+            if (health.isTimedOut()) {
+                healthIndicatorCallback.inform(
+                    Health
+                        .unhealthy()
+                        .withDetail("clusterHealth", health)
+                        .build()
+                );
+            } else if (health.getStatus().equals(ClusterHealthStatus.GREEN)
+                || health.getStatus().equals(ClusterHealthStatus.YELLOW)) { // Allow YELLOW status (single node)
+                healthIndicatorCallback.inform(Health.healthy().build());
+            } else {
+                healthIndicatorCallback.inform(Health.unhealthy().withDetail("clusterHealth", health).build());
+            }
+        } catch (Exception e) {
+            healthIndicatorCallback.inform(Health.unhealthy().withException(e).build());
+        }
+    }
+}

--- a/es-health/src/main/java/com/netflix/conductor/health/ElasticSearchHealthModule.java
+++ b/es-health/src/main/java/com/netflix/conductor/health/ElasticSearchHealthModule.java
@@ -1,0 +1,19 @@
+package com.netflix.conductor.health;
+
+import com.google.inject.AbstractModule;
+import com.netflix.runtime.health.guice.HealthModule;
+
+public class ElasticSearchHealthModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        install(new HealthModule() {
+            @Override
+            protected void configureHealth() {
+                super.configureHealth();
+                bindAdditionalHealthIndicator().to(ElasticSearchHealthIndicator.class);
+            }
+        });
+    }
+}

--- a/es-health/src/test/java/com/netflix/conductor/health/ElasticSearchHealthModuleTest.java
+++ b/es-health/src/test/java/com/netflix/conductor/health/ElasticSearchHealthModuleTest.java
@@ -1,0 +1,138 @@
+package com.netflix.conductor.health;
+
+import com.google.inject.AbstractModule;
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.governator.InjectorBuilder;
+import com.netflix.governator.LifecycleInjector;
+import com.netflix.runtime.health.api.HealthCheckAggregator;
+import com.netflix.runtime.health.api.HealthCheckStatus;
+import com.netflix.runtime.health.guice.HealthModule;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+//import com.netflix.conductor.dao.elasticsearch.ClientMock;
+
+public class ElasticSearchHealthModuleTest {
+
+    @Test
+    public void testNoIndicators() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new HealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(0, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testHealthyStatusGreenIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                ClusterHealthResponse responseMock = mock(ClusterHealthResponse.class, Mockito.RETURNS_DEEP_STUBS);
+                when(responseMock.isTimedOut()).thenReturn(false);
+                when(responseMock.getStatus()).thenReturn(ClusterHealthStatus.GREEN);
+                Client esClientMock = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+                when(esClientMock.admin().cluster().prepareHealth().get()).thenReturn(responseMock);
+                bind(Client.class).toInstance(esClientMock);
+            }
+        }, new ElasticSearchHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testHealthyStatusYellowIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                ClusterHealthResponse responseMock = mock(ClusterHealthResponse.class, Mockito.RETURNS_DEEP_STUBS);
+                when(responseMock.isTimedOut()).thenReturn(false);
+                when(responseMock.getStatus()).thenReturn(ClusterHealthStatus.YELLOW);
+                Client esClientMock = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+                when(esClientMock.admin().cluster().prepareHealth().get()).thenReturn(responseMock);
+                bind(Client.class).toInstance(esClientMock);
+            }
+        }, new ElasticSearchHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testUnHealthyStatusRedIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                ClusterHealthResponse responseMock = mock(ClusterHealthResponse.class, Mockito.RETURNS_DEEP_STUBS);
+                when(responseMock.isTimedOut()).thenReturn(false);
+                when(responseMock.getStatus()).thenReturn(ClusterHealthStatus.RED);
+                Client esClientMock = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+                when(esClientMock.admin().cluster().prepareHealth().get()).thenReturn(responseMock);
+                bind(Client.class).toInstance(esClientMock);
+            }
+        }, new ElasticSearchHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertFalse(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testUnHealthyTimeoutIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                ClusterHealthResponse responseMock = mock(ClusterHealthResponse.class, Mockito.RETURNS_DEEP_STUBS);
+                when(responseMock.isTimedOut()).thenReturn(true);
+                when(responseMock.getStatus()).thenReturn(ClusterHealthStatus.GREEN);
+                Client esClientMock = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+                when(esClientMock.admin().cluster().prepareHealth().get()).thenReturn(responseMock);
+                bind(Client.class).toInstance(esClientMock);
+            }
+        }, new ElasticSearchHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertFalse(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testUnHealthyExceptionIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                Client esClientMock = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+                when(esClientMock.admin().cluster().prepareHealth().get()).thenThrow(new RuntimeException());
+                bind(Client.class).toInstance(esClientMock);
+            }
+        }, new ElasticSearchHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertFalse(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+}

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/HealthCheckResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/HealthCheckResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.Api;
 
@@ -28,4 +29,22 @@ public class HealthCheckResource {
     public HealthCheckStatus doCheck() throws Exception {
         return healthCheck.check().get();
     }
+
+    @GET
+    @Path("liveness")
+    public Response doLiveness() throws Exception {
+        HealthCheckStatus status = healthCheck.check().get();
+        if (status.isHealthy()) {
+            return Response.ok(status).build();
+        }
+
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(status).build();
+    }
+
+    @GET
+    @Path("readiness")
+    public Response doReadiness() throws Exception {
+        return doLiveness();
+    }
+
 }

--- a/redis-health/README.md
+++ b/redis-health/README.md
@@ -1,0 +1,110 @@
+# Redis Health Check 
+
+This module is optional and depends on `redis-persistence`.
+
+## Build
+
+### Gradle Configuration
+
+Modify the following files
+
+[settings.gradle](https://github.com/Netflix/conductor/blob/master/settings.gradle)
+
+```diff
+@@ -3,6 +3,7 @@ rootProject.name='conductor'
+ include 'client','common','contribs','core', 'es5-persistence','jersey', 'postgres-persistence', 'zookeeper-lock', 'redis-lock'
+ include 'cassandra-persistence', 'mysql-persistence', 'redis-persistence','server','test-harness','ui'
+ include 'grpc', 'grpc-server', 'grpc-client'
++include 'redis-health'
+
+ rootProject.children.each {it.name="conductor-${it.name}"}
+
+```
+
+[server/build.gradle](https://github.com/Netflix/conductor/blob/master/server/build.gradle)
+
+```diff
+@@ -38,6 +38,7 @@ dependencies {
+
++   compile project(':conductor-redis-health')
+
+    compile "com.netflix.runtime:health-guice:${revHealth}"
+```
+ 
+Delete all dependencies.lock files of all modules and then run at the root folder of the project: 
+
+```
+./gradlew generateLock saveLock -PdependencyLock.includeTransitives=true
+```
+
+Run Build along with the tests
+
+```
+./gradlew conductor:redis-health build
+```
+
+## Configuration
+
+In the `.properties` file of conductor `server` you must add the following configurations.
+
+* Add the RedisHealthModule module. If you have several modules, separate them with a comma.
+```
+conductor.additional.modules=com.netflix.conductor.health.RedisHealthModule
+```
+
+* Health Indicator can be configured through HealthAggregatorConfiguration. The following attributes can be added to the properties file
+```
+health.aggregator.cacheHealthIndicators=true
+health.aggregator.cacheIntervalInMillis=5000
+health.aggregator.aggregatorWaitIntervalInMillis=1000
+```
+
+### Usage
+
+Request: HTTP GET /api/health
+
+
+* If Redis is reachable
+
+Response: HTTP 200
+```json
+{
+  "healthResults": [
+    {
+      "details": {
+        "cached": true,
+        "className": "com.netflix.conductor.health.RedisHealthIndicator"
+      },
+      "healthy": true,
+      "errorMessage": {
+        "present": false
+      }
+    }
+  ],
+  "suppressedHealthResults": [],
+  "healthy": true
+}
+```
+
+* If Redis is unreachable
+
+Response: HTTP 200
+```json
+{
+  "healthResults": [
+    {
+      "details": {
+        "error": "com.netflix.dyno.connectionpool.exception.PoolOfflineException: PoolOfflineException: [host=Host [hostname=UNKNOWN, ipAddress=UNKNOWN, port=0, rack: UNKNOWN, datacenter: UNKNOW, status: Down, hashtag=null, password=null], latency=0(0), attempts=0]host pool is offline and no Racks available for fallback",
+        "cached": true,
+        "className": "com.netflix.conductor.health.RedisHealthIndicator"
+      },
+      "healthy": false,
+      "errorMessage": {
+        "present": true
+      }
+    }
+  ],
+  "suppressedHealthResults": [],
+  "healthy": false
+}
+```

--- a/redis-health/build.gradle
+++ b/redis-health/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+
+    compile "redis.clients:jedis:${revJedis}"
+
+    compile "com.netflix.runtime:health-guice:${revHealth}"
+}

--- a/redis-health/src/main/java/com/netflix/conductor/health/RedisHealthIndicator.java
+++ b/redis-health/src/main/java/com/netflix/conductor/health/RedisHealthIndicator.java
@@ -1,0 +1,33 @@
+package com.netflix.conductor.health;
+
+import com.netflix.runtime.health.api.Health;
+import com.netflix.runtime.health.api.HealthIndicator;
+import com.netflix.runtime.health.api.HealthIndicatorCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.commands.JedisCommands;
+
+import javax.inject.Inject;
+
+public class RedisHealthIndicator implements HealthIndicator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisHealthIndicator.class);
+
+    private final JedisCommands jedisClient;
+
+    @Inject
+    public RedisHealthIndicator(JedisCommands jedisClient) {
+        this.jedisClient = jedisClient;
+        LOGGER.info("Health Indicator is Ready");
+    }
+
+    @Override
+    public void check(HealthIndicatorCallback healthIndicatorCallback) {
+        LOGGER.debug("Checking Health");
+        try {
+            this.jedisClient.exists(""); // Key can be whatever. Only used to test connectivity.
+            healthIndicatorCallback.inform(Health.healthy().build());
+        } catch (Exception e) {
+            healthIndicatorCallback.inform(Health.unhealthy().withException(e).build());
+        }
+    }
+}

--- a/redis-health/src/main/java/com/netflix/conductor/health/RedisHealthModule.java
+++ b/redis-health/src/main/java/com/netflix/conductor/health/RedisHealthModule.java
@@ -1,0 +1,19 @@
+package com.netflix.conductor.health;
+
+import com.google.inject.AbstractModule;
+import com.netflix.runtime.health.guice.HealthModule;
+
+public class RedisHealthModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        install(new HealthModule() {
+            @Override
+            protected void configureHealth() {
+                super.configureHealth();
+                bindAdditionalHealthIndicator().to(RedisHealthIndicator.class);
+            }
+        });
+    }
+}

--- a/redis-health/src/test/java/com/netflix/conductor/health/RedisHealthModuleTest.java
+++ b/redis-health/src/test/java/com/netflix/conductor/health/RedisHealthModuleTest.java
@@ -1,0 +1,92 @@
+package com.netflix.conductor.health;
+
+import com.google.inject.AbstractModule;
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.governator.InjectorBuilder;
+import com.netflix.governator.LifecycleInjector;
+import com.netflix.runtime.health.api.HealthCheckAggregator;
+import com.netflix.runtime.health.api.HealthCheckStatus;
+import com.netflix.runtime.health.guice.HealthModule;
+import org.junit.Assert;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.concurrent.ExecutionException;
+
+public class RedisHealthModuleTest {
+
+    @Test
+    public void testNoIndicators() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new HealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(0, healthCheckStatus.getHealthResults().size());
+    }
+
+
+    @Test
+    public void testHealthyKeyExistsIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                bind(JedisCommands.class).toInstance(new Jedis() {
+                    @Override public Boolean exists(final String key) {
+                        return true;
+                    }
+                });
+            }
+        }, new RedisHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testHealthyKeyNotExistsIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                bind(JedisCommands.class).toInstance(new Jedis() {
+                    @Override public Boolean exists(final String key) {
+                        return false;
+                    }
+                });
+            }
+        }, new RedisHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertTrue(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+    @Test
+    public void testUnHealthyExceptionIndicator() throws InterruptedException, ExecutionException {
+        LifecycleInjector injector = InjectorBuilder.fromModules(new AbstractModule() {
+            @Override
+            public void configure() {
+                bind(JedisCommands.class).toInstance(new Jedis() {
+                   @Override public Boolean exists(final String key) {
+                       throw new JedisException(new Exception());
+                   }
+                });
+            }
+        }, new RedisHealthModule(), new ArchaiusModule()).createInjector();
+        HealthCheckAggregator aggregator = injector.getInstance(HealthCheckAggregator.class);
+
+        Assert.assertNotNull(aggregator);
+        HealthCheckStatus healthCheckStatus = aggregator.check().get();
+        Assert.assertFalse(healthCheckStatus.isHealthy());
+        Assert.assertEquals(1, healthCheckStatus.getHealthResults().size());
+    }
+
+}


### PR DESCRIPTION
*This is currently a work in progress, i suggest it to be a feature or an example in the documentation depending of the broad usage of people since "healthy" may not mean the same thing for everyone*

**Context:** We use conductor in k8s env and we wanted a single endpoint to check the readiness/liveness of conductor and the stack built around it. The aim is to prevent access to conductor if part of the stack are degraded and raise an event with a readable error.

**Process:** I saw that the route `/api/health` was exposed but didn't find any implementation or mention in the documentation. Then i found health-api doc on https://github.com/Netflix/runtime-health and started to implement two modules for the main persistence.

So feel free to give me your feedback on package naming or HealthIndicator's implementations !

