### PR TITLE
Make ExternalStorageLocation doc more readable

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/ExternalStorageLocation.java
@@ -18,11 +18,13 @@ package com.netflix.conductor.common.run;
 
 /**
  * Describes the location where the JSON payload is stored in external storage.
- * <ul>
- * <li>
+ *
+ * <p>
  * The location is described using the following fields:
- * <li>uri: The uri of the json file in external storage</li>
- * <li>path: The relative path of the file in external storage</li>
+ *
+ * <ul>
+ * <li> uri: The uri of the json file in external storage.
+ * <li> path: The relative path of the file in external storage.
  * </ul>
  */
 public class ExternalStorageLocation {


### PR DESCRIPTION
fix typo about <li> , make `ExternalStorageLocation` doc more readable.