### PR TITLE
Better error handling when trying to create a workflow

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -400,9 +400,16 @@ public class WorkflowExecutor {
             decide(workflowId);
             return workflowId;
         } catch (Exception e) {
-            executionDAOFacade.removeWorkflow(workflowId, false);
             Monitors.recordWorkflowStartError(workflowDefinition.getName(), WorkflowContext.get().getClientApp());
             LOGGER.error("Unable to start workflow: {}", workflowDefinition.getName(), e);
+
+            // It's possible the remove workflow call hits an exception as well, in that case we want to log both
+            // errors to help diagnosis.
+            try {
+                executionDAOFacade.removeWorkflow(workflowId, false);
+            } catch (Exception rwe) {
+                LOGGER.error("Could not remove the workflowId: " + workflowId, rwe);
+            }
             throw e;
         }
     }


### PR DESCRIPTION
We hit an issue where the actual exception was being ghosted/overriden by the fact that the remove workflow call would throw an exception as well (because the workflow was not able to be inserted). This can happen if there's a DB exception (like when we are using Mysql). In this case, we want to be able to get *both* exceptions logged so we can figure out what's happening :)

Before this fix, all that we would get in the log was
```
1825727 [qtp988170450-308] ERROR com.netflix.conductor.core.execution.WorkflowExecutor  - Could not remove the workflowId: eae62d92-9e28-49b1-8b35-091042ebbfe4
com.netflix.conductor.core.execution.ApplicationException: No such workflow found by id: eae62d92-9e28-49b1-8b35-091042ebbfe4
	at com.netflix.conductor.core.orchestration.ExecutionDAOFacade.getWorkflowById(ExecutionDAOFacade.java:126)
	at com.netflix.conductor.core.orchestration.ExecutionDAOFacade.removeWorkflow(ExecutionDAOFacade.java:249)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:404)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:328)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:196)
	at com.netflix.conductor.service.WorkflowServiceImpl.startWorkflow(WorkflowServiceImpl.java:124)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba.CGLIB$startWorkflow$1(<generated>)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba$$FastClassByGuice$$e4f50776.invoke(<generated>)
	at com.google.inject.internal.cglib.proxy.$MethodProxy.invokeSuper(MethodProxy.java:228)
	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:76)
	at com.netflix.conductor.interceptors.ServiceInterceptor.invoke(ServiceInterceptor.java:52)
	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:77)
	at com.google.inject.internal.InterceptorStackCallback.intercept(InterceptorStackCallback.java:55)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba.startWorkflow(<genera
```

After this fix, we now get both correctly

```
1825718 [qtp988170450-308] ERROR com.netflix.conductor.core.execution.WorkflowExecutor  - Unable to start workflow: homeservices.update_workitem_status
com.netflix.conductor.core.execution.ApplicationException: BACKEND_ERROR - BACKEND_ERROR - Data truncation: Data too long for column 'correlation_id' at row 1
	at com.netflix.conductor.dao.mysql.MySQLBaseDAO.getWithTransaction(MySQLBaseDAO.java:114)
	at com.netflix.conductor.dao.mysql.MySQLBaseDAO.lambda$getWithRetriedTransactions$3(MySQLBaseDAO.java:128)
	at com.github.rholder.retry.AttemptTimeLimiters$NoAttemptTimeLimit.call(AttemptTimeLimiters.java:78)
	at com.github.rholder.retry.Retryer.call(Retryer.java:160)
	at com.netflix.conductor.common.utils.RetryUtil.retryOnException(RetryUtil.java:117)
	at com.netflix.conductor.dao.mysql.MySQLBaseDAO.getWithRetriedTransactions(MySQLBaseDAO.java:127)
	at com.netflix.conductor.dao.mysql.MySQLBaseDAO.withTransaction(MySQLBaseDAO.java:178)
	at com.netflix.conductor.dao.mysql.MySQLExecutionDAO.insertOrUpdateWorkflow(MySQLExecutionDAO.java:491)
	at com.netflix.conductor.dao.mysql.MySQLExecutionDAO.createWorkflow(MySQLExecutionDAO.java:251)
	at com.netflix.conductor.core.orchestration.ExecutionDAOFacade.createWorkflow(ExecutionDAOFacade.java:195)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:395)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:328)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:196)
	at com.netflix.conductor.service.WorkflowServiceImpl.startWorkflow(WorkflowServiceImpl.java:124)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba.CGLIB$startWorkflow$1(<generated>)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba$$FastClassByGuice$$e4f50776.invoke(<generated>)
	at com.google.inject.internal.cglib.proxy.$MethodProxy.invokeSuper(MethodProxy.java:228)
	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:76)

......
1825727 [qtp988170450-308] INFO  com.netflix.conductor.dao.es5.index.ElasticSearchDAOV5  - Unable to find Workflow: eae62d92-9e28-49b1-8b35-091042ebbfe4 in ElasticSearch index: conductor.
1825727 [qtp988170450-308] ERROR com.netflix.conductor.core.orchestration.ExecutionDAOFacade  - No such workflow found by id: eae62d92-9e28-49b1-8b35-091042ebbfe4
1825727 [qtp988170450-308] ERROR com.netflix.conductor.core.execution.WorkflowExecutor  - Could not remove the workflowId: eae62d92-9e28-49b1-8b35-091042ebbfe4
com.netflix.conductor.core.execution.ApplicationException: No such workflow found by id: eae62d92-9e28-49b1-8b35-091042ebbfe4
	at com.netflix.conductor.core.orchestration.ExecutionDAOFacade.getWorkflowById(ExecutionDAOFacade.java:126)
	at com.netflix.conductor.core.orchestration.ExecutionDAOFacade.removeWorkflow(ExecutionDAOFacade.java:249)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:404)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:328)
	at com.netflix.conductor.core.execution.WorkflowExecutor.startWorkflow(WorkflowExecutor.java:196)
	at com.netflix.conductor.service.WorkflowServiceImpl.startWorkflow(WorkflowServiceImpl.java:124)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba.CGLIB$startWorkflow$1(<generated>)
	at com.netflix.conductor.service.WorkflowServiceImpl$$EnhancerByGuice$$7b6371ba$$FastClassByGuice$$e4f50776.invoke(<generated>)
	at com.google.inject.internal.cglib.proxy.$MethodProxy.invokeSuper(MethodProxy.java:228)
	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.j
```
