### PR TITLE
added back the changes necessary to handle subworkflow termination

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -55,6 +55,7 @@ import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.service.ExecutionLockService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -994,14 +995,36 @@ public class WorkflowExecutor {
                     if (!workflowSystemTask.isAsync() && workflowSystemTask.execute(workflowInstance, task, this)) {
                         // FIXME: temporary hack to workaround TERMINATE task
                         if (TERMINATE.name().equals(task.getTaskType())) {
-                            deciderService.externalizeTaskData(task);
-                            executionDAOFacade.updateTask(task);
-                            if (workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
-                                completeWorkflow(workflow);
+                        	deciderService.externalizeTaskData(task);
+                        	executionDAOFacade.updateTask(task);
+                            workflow.setOutput(workflowInstance.getOutput());
+                            List<Task> terminateTasksToBeUpdated = new ArrayList<Task>();
+                            /*
+                             * The TERMINATE task completes the workflow but does not do anything with SCHEDULED or IN_PROGRESS tasks to complete them
+                             */
+                            for(Task workflowTask : workflow.getTasks()) {
+                            	if(workflowTask != task && !workflowTask.getStatus().isTerminal()) {
+                            		workflowTask.setStatus(SKIPPED);
+                            		terminateTasksToBeUpdated.add(workflowTask);
+                            	}
+                            }
+                            /*
+                             * Now find nested subworkflows that also need to have their tasks skipped
+                             */
+                            for(Task workflowTask : workflow.getTasks()) {
+                            	if(TaskType.SUB_WORKFLOW.name().equals(workflowTask.getTaskType()) && StringUtils.isNotBlank(workflowTask.getSubWorkflowId())) {
+                               		Workflow subWorkflow = executionDAOFacade.getWorkflowById(workflowTask.getSubWorkflowId(), true);
+                            		if(subWorkflow != null) {
+                            			skipTasksAffectedByTerminateTask(subWorkflow);                                		
+                            		}
+                            	}
+                            }
+                            executionDAOFacade.updateTasks(terminateTasksToBeUpdated);
+                            if(workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
+                            	completeWorkflow(workflow);
                             } else {
                                 workflow.setStatus(workflowInstance.getStatus());
-                                terminate(workflow, new TerminateWorkflowException(
-                                    "Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
+                                terminate(workflow, new TerminateWorkflowException("Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
                             }
                             return true;
                         }
@@ -1043,6 +1066,36 @@ public class WorkflowExecutor {
             executionLockService.releaseLock(workflowId);
         }
         return false;
+    }
+
+    /**
+     * When a TERMINATE task runs, it only affects the workflow in which it runs; it does not do anything with 
+     * in-progress tasks and subworkflows that are still running. This recursive method will ensure that all tasks within
+     * all subworkflows are set to SKIPPED status so they can complete.
+     * @param workflow a subworkflow within the hierarchy of the original workflow containing the TERMINATE task
+     */
+    private void skipTasksAffectedByTerminateTask(Workflow workflow) {
+    	if(!workflow.getStatus().isTerminal()) {
+	        List<Task> tasksToBeUpdated = new ArrayList<Task>();
+	        for(Task workflowTask : workflow.getTasks()) {
+            	if(!workflowTask.getStatus().isTerminal()) {
+            		workflowTask.setStatus(SKIPPED);
+            		tasksToBeUpdated.add(workflowTask);
+            	}
+	        	if(TaskType.SUB_WORKFLOW.name().equals(workflowTask.getTaskType()) && StringUtils.isNotBlank(workflowTask.getSubWorkflowId())) {
+	           		Workflow subWorkflow = executionDAOFacade.getWorkflowById(workflowTask.getSubWorkflowId(), true);
+	           		if(subWorkflow != null) {
+	           			skipTasksAffectedByTerminateTask(subWorkflow);
+	           		}
+	        	}
+	        }
+	        if (!tasksToBeUpdated.isEmpty()) {
+	            executionDAOFacade.updateTasks(tasksToBeUpdated);
+	            workflow.setStatus(Workflow.WorkflowStatus.TERMINATED);
+	            workflow.setReasonForIncompletion("Parent workflow was terminated with a TERMINATE task");
+	            executionDAOFacade.updateWorkflow(workflow);
+	        }
+    	}
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -995,14 +995,36 @@ public class WorkflowExecutor {
                     if (!workflowSystemTask.isAsync() && workflowSystemTask.execute(workflowInstance, task, this)) {
                         // FIXME: temporary hack to workaround TERMINATE task
                         if (TERMINATE.name().equals(task.getTaskType())) {
-                            deciderService.externalizeTaskData(task);
-                            executionDAOFacade.updateTask(task);
-                            if (workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
-                                completeWorkflow(workflow);
+                        	deciderService.externalizeTaskData(task);
+                        	executionDAOFacade.updateTask(task);
+                            workflow.setOutput(workflowInstance.getOutput());
+                            List<Task> terminateTasksToBeUpdated = new ArrayList<Task>();
+                            /*
+                             * The TERMINATE task completes the workflow but does not do anything with SCHEDULED or IN_PROGRESS tasks to complete them
+                             */
+                            for(Task workflowTask : workflow.getTasks()) {
+                            	if(workflowTask != task && !workflowTask.getStatus().isTerminal()) {
+                            		workflowTask.setStatus(SKIPPED);
+                            		terminateTasksToBeUpdated.add(workflowTask);
+                            	}
+                            }
+                            /*
+                             * Now find nested subworkflows that also need to have their tasks skipped
+                             */
+                            for(Task workflowTask : workflow.getTasks()) {
+                            	if(TaskType.SUB_WORKFLOW.name().equals(workflowTask.getTaskType()) && StringUtils.isNotBlank(workflowTask.getSubWorkflowId())) {
+                               		Workflow subWorkflow = executionDAOFacade.getWorkflowById(workflowTask.getSubWorkflowId(), true);
+                            		if(subWorkflow != null) {
+                            			skipTasksAffectedByTerminateTask(subWorkflow);                                		
+                            		}
+                            	}
+                            }
+                            executionDAOFacade.updateTasks(terminateTasksToBeUpdated);
+                            if(workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
+                            	completeWorkflow(workflow);
                             } else {
                                 workflow.setStatus(workflowInstance.getStatus());
-                                terminate(workflow, new TerminateWorkflowException(
-                                    "Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
+                                terminate(workflow, new TerminateWorkflowException("Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
                             }
                             return true;
                         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -995,36 +995,14 @@ public class WorkflowExecutor {
                     if (!workflowSystemTask.isAsync() && workflowSystemTask.execute(workflowInstance, task, this)) {
                         // FIXME: temporary hack to workaround TERMINATE task
                         if (TERMINATE.name().equals(task.getTaskType())) {
-                        	deciderService.externalizeTaskData(task);
-                        	executionDAOFacade.updateTask(task);
-                            workflow.setOutput(workflowInstance.getOutput());
-                            List<Task> terminateTasksToBeUpdated = new ArrayList<Task>();
-                            /*
-                             * The TERMINATE task completes the workflow but does not do anything with SCHEDULED or IN_PROGRESS tasks to complete them
-                             */
-                            for(Task workflowTask : workflow.getTasks()) {
-                            	if(workflowTask != task && !workflowTask.getStatus().isTerminal()) {
-                            		workflowTask.setStatus(SKIPPED);
-                            		terminateTasksToBeUpdated.add(workflowTask);
-                            	}
-                            }
-                            /*
-                             * Now find nested subworkflows that also need to have their tasks skipped
-                             */
-                            for(Task workflowTask : workflow.getTasks()) {
-                            	if(TaskType.SUB_WORKFLOW.name().equals(workflowTask.getTaskType()) && StringUtils.isNotBlank(workflowTask.getSubWorkflowId())) {
-                               		Workflow subWorkflow = executionDAOFacade.getWorkflowById(workflowTask.getSubWorkflowId(), true);
-                            		if(subWorkflow != null) {
-                            			skipTasksAffectedByTerminateTask(subWorkflow);                                		
-                            		}
-                            	}
-                            }
-                            executionDAOFacade.updateTasks(terminateTasksToBeUpdated);
-                            if(workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
-                            	completeWorkflow(workflow);
+                            deciderService.externalizeTaskData(task);
+                            executionDAOFacade.updateTask(task);
+                            if (workflowInstance.getStatus().equals(WorkflowStatus.COMPLETED)) {
+                                completeWorkflow(workflow);
                             } else {
                                 workflow.setStatus(workflowInstance.getStatus());
-                                terminate(workflow, new TerminateWorkflowException("Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
+                                terminate(workflow, new TerminateWorkflowException(
+                                    "Workflow is FAILED by TERMINATE task: " + task.getTaskId()));
                             }
                             return true;
                         }

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -142,7 +142,6 @@ class LambdaAndTerminalTaskSpec extends Specification {
             tasks[2].referenceTaskName == 'lambdaTask2'
             tasks[3].status == Task.Status.IN_PROGRESS
             tasks[3].taskType == 'JOIN'
-            tasks[4].status == Task.Status.IN_PROGRESS || task[4].status == Task.Status.SCHEDULED
             tasks[4].taskType == 'SUB_WORKFLOW'
             tasks[5].status == Task.Status.IN_PROGRESS
             tasks[5].taskType == 'WAIT'

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -142,6 +142,7 @@ class LambdaAndTerminalTaskSpec extends Specification {
             tasks[2].referenceTaskName == 'lambdaTask2'
             tasks[3].status == Task.Status.IN_PROGRESS
             tasks[3].taskType == 'JOIN'
+            tasks[4].status == Task.Status.SCHEDULED || tasks[4].status == Task.Status.IN_PROGRESS
             tasks[4].taskType == 'SUB_WORKFLOW'
             tasks[5].status == Task.Status.IN_PROGRESS
             tasks[5].taskType == 'WAIT'
@@ -164,9 +165,9 @@ class LambdaAndTerminalTaskSpec extends Specification {
             tasks[2].status == Task.Status.COMPLETED
             tasks[2].taskType == 'LAMBDA'
             tasks[2].referenceTaskName == 'lambdaTask2'
-            tasks[3].status != Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.SKIPPED
             tasks[3].taskType == 'JOIN'
-            tasks[4].status != Task.Status.IN_PROGRESS
+            tasks[4].status == Task.Status.SKIPPED
             tasks[4].taskType == 'SUB_WORKFLOW'
             tasks[5].status == Task.Status.COMPLETED
             tasks[5].taskType == 'WAIT'

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -49,12 +49,20 @@ class LambdaAndTerminalTaskSpec extends Specification {
     @Shared
     def  WORKFLOW_WITH_LAMBDA_TASK = 'test_lambda_wf'
 
+    @Shared
+    def PARENT_WORKFLOW_WITH_TERMINATE_TASK = 'test_terminate_task_parent_wf'
+
+    @Shared
+    def SUBWORKFLOW_FOR_TERMINATE_TEST = 'test_terminate_task_sub_wf'
+
     def setup() {
         workflowTestUtil.registerWorkflows(
                 'failure_workflow_for_terminate_task_workflow.json',
                 'terminate_task_completed_workflow_integration_test.json',
                 'terminate_task_failed_workflow_integration.json',
-                'simple_lambda_workflow_integration_test.json'
+                'simple_lambda_workflow_integration_test.json',
+                'terminate_task_parent_workflow.json',
+                'terminate_task_sub_workflow.json'
         )
     }
 

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.counductor.integration.test
 
 import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.metadata.tasks.TaskResult
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.core.execution.WorkflowExecutor
 import com.netflix.conductor.service.ExecutionService

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -142,7 +142,7 @@ class LambdaAndTerminalTaskSpec extends Specification {
             tasks[2].referenceTaskName == 'lambdaTask2'
             tasks[3].status == Task.Status.IN_PROGRESS
             tasks[3].taskType == 'JOIN'
-            tasks[4].status in [Task.Status.IN_PROGRESS, Task.Status.SCHEDULED]
+            tasks[4].status == Task.Status.IN_PROGRESS || task[4].status == Task.Status.SCHEDULED
             tasks[4].taskType == 'SUB_WORKFLOW'
             tasks[5].status == Task.Status.IN_PROGRESS
             tasks[5].taskType == 'WAIT'

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/LambdaAndTerminalTaskSpec.groovy
@@ -142,7 +142,7 @@ class LambdaAndTerminalTaskSpec extends Specification {
             tasks[2].referenceTaskName == 'lambdaTask2'
             tasks[3].status == Task.Status.IN_PROGRESS
             tasks[3].taskType == 'JOIN'
-            tasks[4].status == Task.Status.IN_PROGRESS
+            tasks[4].status in [Task.Status.IN_PROGRESS, Task.Status.SCHEDULED]
             tasks[4].taskType == 'SUB_WORKFLOW'
             tasks[5].status == Task.Status.IN_PROGRESS
             tasks[5].taskType == 'WAIT'

--- a/test-harness/src/test/resources/terminate_task_parent_workflow.json
+++ b/test-harness/src/test/resources/terminate_task_parent_workflow.json
@@ -1,0 +1,76 @@
+{
+  "name": "test_terminate_task_parent_wf",
+  "version": 1,
+  "tasks": [
+      {
+         "name": "test_forkjoin",
+         "taskReferenceName": "forkx",
+         "type": "FORK_JOIN",
+         "forkTasks": [
+			[
+				{
+				   "name": "test_lambda_task1",
+				   "taskReferenceName": "lambdaTask1",
+				   "inputParameters": {
+					    "lambdaValue": "${workflow.input.lambdaValue}",
+					   	"scriptExpression": "var i = 10; if ($.lambdaValue == 1){ return {testvalue: 'Lambda value was 1', iValue: i} } else { return {testvalue: 'Lambda value was NOT 1', iValue: i + 3} }"
+				    },
+				   "type": "LAMBDA"
+				},
+				{
+				  "name": "test_terminate_subworkflow",
+				  "taskReferenceName": "test_terminate_subworkflow",
+				  "inputParameters": {
+				  },
+				  "type": "SUB_WORKFLOW",
+				  "subWorkflowParam": {
+				    "name": "test_terminate_task_sub_wf"
+				  }
+				}
+			],
+			[				
+				{
+				   "name": "test_lambda_task2",
+				   "taskReferenceName": "lambdaTask2",
+				   "inputParameters": {
+						"lambdaValue": "${workflow.input.lambdaValue}",
+						"scriptExpression": "var i = 10; if ($.lambdaValue == 1){ return {testvalue: 'Lambda value was 1', iValue: i} } else { return {testvalue: 'Lambda value was NOT 1', iValue: i + 3} }"
+				    },
+				   "type": "LAMBDA"
+				},
+				{
+					"name": "test_wait_task",
+					"taskReferenceName": "basicJavaA",
+					"type": "WAIT"
+				},
+				{
+					"name": "terminate",
+					"taskReferenceName": "terminate0",
+					"inputParameters": {
+						"terminationStatus": "COMPLETED",
+						"workflowOutput": "some output"
+					},
+					"type": "TERMINATE",
+					"startDelay": 0,
+					"optional": false 
+				},
+				{
+					"name": "test_second_wait_task",
+					"taskReferenceName": "basicJavaB",
+					"type": "WAIT"
+				}
+		     ]
+		 ]
+      },
+      {
+		"name": "join",
+		"taskReferenceName": "thejoin",
+		"type": "JOIN",
+		"joinOn": [
+			"basicJavaA",
+			"basicJavaB"
+		]
+      }
+  ],
+  "schemaVersion": 2
+}

--- a/test-harness/src/test/resources/terminate_task_sub_workflow.json
+++ b/test-harness/src/test/resources/terminate_task_sub_workflow.json
@@ -1,0 +1,12 @@
+{
+  "name": "test_terminate_task_sub_wf",
+  "version": 1,
+  "tasks": [
+	{
+		"name": "test_third_wait_task",
+		"taskReferenceName": "basicJavaC",
+		"type": "WAIT"
+	}
+  ],
+  "schemaVersion": 2
+}


### PR DESCRIPTION
@apanicker-nflx Sorry, it looks like you merged my PR #1608 right in the middle of my changes to support Kishore's last request to change an exception message. You merged it right as I had reverted WorkflowExecutor to the dev version so I could merge it. So now it doesn't contain any of my changes. This PR will add that code back. I see you made additional changes after that merge so I honored those changes in this PR.