### PR TITLE
UI LDAP Auth - Add support for nested security groups

### DIFF
--- a/ui/src/auth/strategies/ldapauth.js
+++ b/ui/src/auth/strategies/ldapauth.js
@@ -1,10 +1,26 @@
-const LdapStrategy = require('passport-ldapauth');
+const LdapStrategy = require("passport-ldapauth");
+
+const defaultOptions = {
+  server: {
+    searchAttributes: ["displayName", "mail", "memberOf"]
+  }
+};
 
 /** @type IAuthentication */
 const LDAPAuthentication = {
-
   getStrategy(options) {
-    return new LdapStrategy(options.strategyOptions);
+    const config = {
+      ...defaultOptions,
+      ...options.strategyOptions,
+      server: { ...defaultOptions.server, ...options.strategyOptions.server }
+    };
+    // allow recursively reading all security groups
+    if (!config.server.groupSearchBase) {
+      const LDAP_MATCHING_RULE_IN_CHAIN = "1.2.840.113556.1.4.1941";
+      config.server.groupSearchBase = config.server.searchBase;
+      config.server.groupSearchFilter = `(&(objectclass=group)(member:${LDAP_MATCHING_RULE_IN_CHAIN}:={{dn}}))`;
+    }
+    return new LdapStrategy(config);
   },
 
   getDefaultCookieSecret(options) {
@@ -13,14 +29,18 @@ const LDAPAuthentication = {
   },
 
   getCookieValueFromUser(req, user, options) {
+    const groups = user._groups.map(g => g.dn);
     return {
       name: req.body.username,
       displayName: user.displayName,
       email: user.mail,
       roles: Object.keys(options.strategySettings.rolesRequirements).filter(role =>
-        options.strategySettings.rolesRequirements[role].every(requirement => user.memberOf.includes(requirement)))
+          options.strategySettings.rolesRequirements[role].every(requirement =>
+              groups.includes(requirement)
+          )
+      )
     };
   }
-}
+};
 
 module.exports = LDAPAuthentication;


### PR DESCRIPTION
Currently the groups returned from the LDAP server are only the direct memberships of the user.
Big enterprises usually use nested groups to allow easier creation of new employees.

I modified the ldap initialization script based on [this](https://stackoverflow.com/questions/51270427/passport-ldapauth-get-nested-groups)