### PR TITLE
fix potential problem of database sequences maxing out

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -717,8 +717,8 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
         int rowsUpdated = query(connection, UPDATE_POLL_DATA, q -> q.addJsonParameter(pollData).addParameter(pollData.getQueueName()).addParameter(domain).executeUpdate());
         
        if(rowsUpdated == 0) {
-          String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP)";
-          execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
+           String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE json_data=VALUES(json_data), modified_on=VALUES(modified_on)";
+           execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
                   .addJsonParameter(pollData).executeUpdate());
         }
     }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -558,11 +558,16 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
 
     private void addPendingWorkflow(Connection connection, String workflowType, String workflowId) {
 
-        String INSERT_PENDING_WORKFLOW = "INSERT IGNORE INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?)";
+        String EXISTS_PENDING_WORKFLOW = "SELECT EXISTS(SELECT 1 FROM workflow_pending WHERE workflow_type = ? AND workflow_id = ?)";
 
-        execute(connection, INSERT_PENDING_WORKFLOW,
-                q -> q.addParameter(workflowType).addParameter(workflowId).executeUpdate());
+        boolean exists  = query(connection, EXISTS_PENDING_WORKFLOW, q -> q.addParameter(workflowType).addParameter(workflowId).exists());
 
+        if(!exists) {
+	        String INSERT_PENDING_WORKFLOW = "INSERT IGNORE INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?)";
+
+            execute(connection, INSERT_PENDING_WORKFLOW,
+                    q -> q.addParameter(workflowType).addParameter(workflowId).executeUpdate());
+        }
     }
 
     private void removePendingWorkflow(Connection connection, String workflowType, String workflowId) {
@@ -573,10 +578,17 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
     }
 
     private void insertOrUpdateTaskData(Connection connection, Task task) {
-
-        String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE json_data=VALUES(json_data), modified_on=VALUES(modified_on)";
-        execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
-
+		/*
+		 * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON DUPLICATE KEY update' sql statement. The problem with that
+		 * is that if we try the INSERT first, the sequence will be increased even if the ON DUPLICATE KEY happens.
+		 */
+		String UPDATE_TASK = "UPDATE task SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE task_id=?";
+		int rowsUpdated = query(connection, UPDATE_TASK, q -> q.addJsonParameter(task).addParameter(task.getTaskId()).executeUpdate());
+		
+		if(rowsUpdated == 0) {
+	        String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE json_data=VALUES(json_data), modified_on=VALUES(modified_on)";
+	        execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
+		}
     }
 
     private void removeTaskData(Connection connection, Task task) {
@@ -586,11 +598,16 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
 
     private void addWorkflowToTaskMapping(Connection connection, Task task) {
 
-        String INSERT_WORKFLOW_TO_TASK = "INSERT IGNORE INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?)";
+        String EXISTS_WORKFLOW_TO_TASK = "SELECT EXISTS(SELECT 1 FROM workflow_to_task WHERE workflow_id = ? AND task_id = ?)";
 
-        execute(connection, INSERT_WORKFLOW_TO_TASK,
-                q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeUpdate());
+        boolean exists  = query(connection, EXISTS_WORKFLOW_TO_TASK, q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).exists());
 
+        if(!exists) {
+	        String INSERT_WORKFLOW_TO_TASK = "INSERT IGNORE INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?)";
+	
+	        execute(connection, INSERT_WORKFLOW_TO_TASK,
+	                q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeUpdate());
+        }
     }
 
     private void removeWorkflowToTaskMapping(Connection connection, Task task) {
@@ -619,11 +636,20 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
     @VisibleForTesting
     boolean addScheduledTask(Connection connection, Task task, String taskKey) {
 
-        final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT IGNORE INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?)";
+        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ? AND task_id = ?)";
 
-        int count = query(connection, INSERT_IGNORE_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
-                .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
-        return count > 0;
+        boolean exists = query(connection, EXISTS_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
+                .addParameter(taskKey).addParameter(task.getTaskId()).exists());
+
+        if(!exists) {
+            final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT IGNORE INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?)";
+
+            int count = query(connection, INSERT_IGNORE_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
+                    .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
+            return count > 0;
+        } else {
+        	return true;
+        }
 
     }
 
@@ -636,10 +662,10 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
     private void addTaskInProgress(Connection connection, Task task) {
         String EXISTS_IN_PROGRESS_TASK = "SELECT EXISTS(SELECT 1 FROM task_in_progress WHERE task_def_name = ? AND task_id = ?)";
 
-        boolean exist = query(connection, EXISTS_IN_PROGRESS_TASK,
+        boolean exists = query(connection, EXISTS_IN_PROGRESS_TASK,
                 q -> q.addParameter(task.getTaskDefName()).addParameter(task.getTaskId()).exists());
 
-        if (!exist) {
+        if (!exists) {
             String INSERT_IN_PROGRESS_TASK = "INSERT INTO task_in_progress (task_def_name, task_id, workflow_id) VALUES (?, ?, ?)";
 
             execute(connection, INSERT_IN_PROGRESS_TASK, q -> q.addParameter(task.getTaskDefName())

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -636,10 +636,10 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
     @VisibleForTesting
     boolean addScheduledTask(Connection connection, Task task, String taskKey) {
 
-        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ? AND task_id = ?)";
+        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ?)";
 
         boolean exists = query(connection, EXISTS_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
-                .addParameter(taskKey).addParameter(task.getTaskId()).exists());
+                .addParameter(taskKey).exists());
 
         if(!exists) {
             final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT IGNORE INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?)";
@@ -648,7 +648,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
                     .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
             return count > 0;
         } else {
-        	return true;
+        	return false;
         }
 
     }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -708,9 +708,19 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
 
     private void insertOrUpdatePollData(Connection connection, PollData pollData, String domain) {
 
-        String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE json_data=VALUES(json_data), modified_on=VALUES(modified_on)";
-        execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
-                .addJsonParameter(pollData).executeUpdate());
+    	/*
+    	 * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON DUPLICATE KEY update' sql statement. The problem with that
+    	 * is that if we try the INSERT first, the sequence will be increased even if the ON DUPLICATE KEY happens. Since polling happens *a lot*, the sequence can increase 
+    	 * dramatically even though it won't be used.
+    	 */
+        String UPDATE_POLL_DATA = "UPDATE poll_data SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE queue_name=? AND domain=?";
+        int rowsUpdated = query(connection, UPDATE_POLL_DATA, q -> q.addJsonParameter(pollData).addParameter(pollData.getQueueName()).addParameter(domain).executeUpdate());
+        
+       if(rowsUpdated == 0) {
+          String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP)";
+          execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
+                  .addJsonParameter(pollData).executeUpdate());
+        }
     }
 
     private PollData readPollData(Connection connection, String queueName, String domain) {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -190,7 +190,7 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
         createQueueIfNotExists(connection, queueName);
 
-        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=? WHERE queue_name = ? AND message_id = ?";
+        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=TIMESTAMPADD(SECOND,?,CURRENT_TIMESTAMP) WHERE queue_name = ? AND message_id = ?";
         int rowsUpdated = query(connection, UPDATE_MESSAGE, q -> q.addParameter(payload).addParameter(offsetTimeInSecond)
         	.addParameter(queueName).addParameter(messageId).executeUpdate());
         		

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -188,13 +188,14 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
     private void pushMessage(Connection connection, String queueName, String messageId, String payload, Integer priority,
                              long offsetTimeInSecond) {
 
-        String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES (TIMESTAMPADD(SECOND,?,CURRENT_TIMESTAMP), ?, ?,?,?,?) ON DUPLICATE KEY UPDATE payload=VALUES(payload), deliver_on=VALUES(deliver_on)";
-
         createQueueIfNotExists(connection, queueName);
 
-        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
-                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)
-                .addParameter(payload).executeUpdate());
+        if(!existsMessage(connection, queueName, messageId)) {
+            String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES (TIMESTAMPADD(SECOND,?,CURRENT_TIMESTAMP), ?, ?,?,?,?) ON DUPLICATE KEY UPDATE payload=VALUES(payload), deliver_on=VALUES(deliver_on)";
+	        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
+	                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)
+	                .addParameter(payload).executeUpdate());
+        }
     }
 
     private boolean removeMessage(Connection connection, String queueName, String messageId) {
@@ -256,7 +257,11 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
     private void createQueueIfNotExists(Connection connection, String queueName) {
         logger.trace("Creating new queue '{}'", queueName);
-        final String CREATE_QUEUE = "INSERT IGNORE INTO queue (queue_name) VALUES (?)";
-        execute(connection, CREATE_QUEUE, q -> q.addParameter(queueName).executeUpdate());
+        final String EXISTS_QUEUE = "SELECT EXISTS(SELECT 1 FROM queue WHERE queue_name = ?)";
+        boolean exists = query(connection, EXISTS_QUEUE, q -> q.addParameter(queueName).exists());
+        if(!exists) {
+            final String CREATE_QUEUE = "INSERT IGNORE INTO queue (queue_name) VALUES (?)";
+	        execute(connection, CREATE_QUEUE, q -> q.addParameter(queueName).executeUpdate());
+        }
     }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -190,7 +190,11 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
 
         createQueueIfNotExists(connection, queueName);
 
-        if(!existsMessage(connection, queueName, messageId)) {
+        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=? WHERE queue_name = ? AND message_id = ?";
+        int rowsUpdated = query(connection, UPDATE_MESSAGE, q -> q.addParameter(payload).addParameter(offsetTimeInSecond)
+        	.addParameter(queueName).addParameter(messageId).executeUpdate());
+        		
+        if(rowsUpdated == 0) {
             String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES (TIMESTAMPADD(SECOND,?,CURRENT_TIMESTAMP), ?, ?,?,?,?) ON DUPLICATE KEY UPDATE payload=VALUES(payload), deliver_on=VALUES(deliver_on)";
 	        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
 	                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
@@ -635,10 +635,10 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     @VisibleForTesting
     boolean addScheduledTask(Connection connection, Task task, String taskKey) {
 
-        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ? AND task_id = ?)";
+        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ?)";
 
         boolean exists = query(connection, EXISTS_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
-                .addParameter(taskKey).addParameter(task.getTaskId()).exists());
+                .addParameter(taskKey).exists());
 
         if(!exists) {
             final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?) ON CONFLICT (workflow_id,task_key) DO NOTHING";
@@ -647,7 +647,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
                     .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
             return count > 0;
         } else {
-        	return true;
+        	return false;
         }
 
     }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
@@ -557,11 +557,16 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     private void addPendingWorkflow(Connection connection, String workflowType, String workflowId) {
 
-        String INSERT_PENDING_WORKFLOW = "INSERT INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?) ON CONFLICT (workflow_type,workflow_id) DO NOTHING";
+        String EXISTS_PENDING_WORKFLOW = "SELECT EXISTS(SELECT 1 FROM workflow_pending WHERE workflow_type = ? AND workflow_id = ?)";
 
-        execute(connection, INSERT_PENDING_WORKFLOW,
-                q -> q.addParameter(workflowType).addParameter(workflowId).executeUpdate());
+        boolean exists  = query(connection, EXISTS_PENDING_WORKFLOW, q -> q.addParameter(workflowType).addParameter(workflowId).exists());
 
+        if(!exists) {
+            String INSERT_PENDING_WORKFLOW = "INSERT INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?) ON CONFLICT (workflow_type,workflow_id) DO NOTHING";
+
+            execute(connection, INSERT_PENDING_WORKFLOW,
+                    q -> q.addParameter(workflowType).addParameter(workflowId).executeUpdate());
+        }
     }
 
     private void removePendingWorkflow(Connection connection, String workflowType, String workflowId) {
@@ -572,10 +577,17 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     }
 
     private void insertOrUpdateTaskData(Connection connection, Task task) {
-
-        String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (task_id) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
-        execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
-
+		/*
+		 * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON CONFLICT do update' sql statement. The problem with that
+		 * is that if we try the INSERT first, the sequence will be increased even if the ON CONFLICT happens.
+		 */
+		String UPDATE_TASK = "UPDATE task SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE task_id=?";
+		int rowsUpdated = query(connection, UPDATE_TASK, q -> q.addJsonParameter(task).addParameter(task.getTaskId()).executeUpdate());
+		
+		if(rowsUpdated == 0) {
+		    String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (task_id) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
+		    execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
+		}
     }
 
     private void removeTaskData(Connection connection, Task task) {
@@ -585,11 +597,16 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     private void addWorkflowToTaskMapping(Connection connection, Task task) {
 
-        String INSERT_WORKFLOW_TO_TASK = "INSERT INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?) ON CONFLICT (workflow_id,task_id) DO NOTHING";
+        String EXISTS_WORKFLOW_TO_TASK = "SELECT EXISTS(SELECT 1 FROM workflow_to_task WHERE workflow_id = ? AND task_id = ?)";
 
-        execute(connection, INSERT_WORKFLOW_TO_TASK,
-                q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeUpdate());
+        boolean exists  = query(connection, EXISTS_WORKFLOW_TO_TASK, q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).exists());
 
+        if(!exists) {
+            String INSERT_WORKFLOW_TO_TASK = "INSERT INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?) ON CONFLICT (workflow_id,task_id) DO NOTHING";
+
+            execute(connection, INSERT_WORKFLOW_TO_TASK,
+                    q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).executeUpdate());
+        }
     }
 
     private void removeWorkflowToTaskMapping(Connection connection, Task task) {
@@ -618,11 +635,20 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     @VisibleForTesting
     boolean addScheduledTask(Connection connection, Task task, String taskKey) {
 
-        final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?) ON CONFLICT (workflow_id,task_key) DO NOTHING";
+        final String EXISTS_SCHEDULED_TASK = "SELECT EXISTS(SELECT 1 FROM task_scheduled where workflow_id = ? AND task_key = ? AND task_id = ?)";
 
-        int count = query(connection, INSERT_IGNORE_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
-                .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
-        return count > 0;
+        boolean exists = query(connection, EXISTS_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
+                .addParameter(taskKey).addParameter(task.getTaskId()).exists());
+
+        if(!exists) {
+            final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?) ON CONFLICT (workflow_id,task_key) DO NOTHING";
+
+            int count = query(connection, INSERT_IGNORE_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
+                    .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
+            return count > 0;
+        } else {
+        	return true;
+        }
 
     }
 
@@ -635,10 +661,10 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     private void addTaskInProgress(Connection connection, Task task) {
         String EXISTS_IN_PROGRESS_TASK = "SELECT EXISTS(SELECT 1 FROM task_in_progress WHERE task_def_name = ? AND task_id = ?)";
 
-        boolean exist = query(connection, EXISTS_IN_PROGRESS_TASK,
+        boolean exists = query(connection, EXISTS_IN_PROGRESS_TASK,
                 q -> q.addParameter(task.getTaskDefName()).addParameter(task.getTaskId()).exists());
 
-        if (!exist) {
+        if (!exists) {
             String INSERT_IN_PROGRESS_TASK = "INSERT INTO task_in_progress (task_def_name, task_id, workflow_id) VALUES (?, ?, ?)";
 
             execute(connection, INSERT_IN_PROGRESS_TASK, q -> q.addParameter(task.getTaskDefName())

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
@@ -716,8 +716,8 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
         int rowsUpdated = query(connection, UPDATE_POLL_DATA, q -> q.addJsonParameter(pollData).addParameter(pollData.getQueueName()).addParameter(domain).executeUpdate());
         
        if(rowsUpdated == 0) {
-          String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP)";
-          execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
+           String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP) ON CONFLICT (queue_name,domain) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
+           execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
                   .addJsonParameter(pollData).executeUpdate());
         }
     }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -201,7 +201,11 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         createQueueIfNotExists(connection, queueName);
 
-        if(!existsMessage(connection, queueName, messageId)) {
+        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=? WHERE queue_name = ? AND message_id = ?";
+        int rowsUpdated = query(connection, UPDATE_MESSAGE, q -> q.addParameter(payload).addParameter(offsetTimeInSecond)
+        	.addParameter(queueName).addParameter(messageId).executeUpdate());
+        		
+        if(rowsUpdated == 0) {
             String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES ((current_timestamp + (? ||' seconds')::interval), ?,?,?,?,?) ON CONFLICT (queue_name,message_id) DO UPDATE SET payload=excluded.payload, deliver_on=excluded.deliver_on";
 	        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
 	                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -201,7 +201,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         createQueueIfNotExists(connection, queueName);
 
-        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=? WHERE queue_name = ? AND message_id = ?";
+        String UPDATE_MESSAGE = "UPDATE queue_message SET payload=?, deliver_on=(current_timestamp + (? ||' seconds')::interval) WHERE queue_name = ? AND message_id = ?";
         int rowsUpdated = query(connection, UPDATE_MESSAGE, q -> q.addParameter(payload).addParameter(offsetTimeInSecond)
         	.addParameter(queueName).addParameter(messageId).executeUpdate());
         		

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -199,12 +199,14 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     private void pushMessage(Connection connection, String queueName, String messageId, String payload, Integer priority,
                              long offsetTimeInSecond) {
 
-        String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES ((current_timestamp + (? ||' seconds')::interval), ?,?,?,?,?) ON CONFLICT (queue_name,message_id) DO UPDATE SET payload=excluded.payload, deliver_on=excluded.deliver_on";
         createQueueIfNotExists(connection, queueName);
 
-        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
-                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)
-                .addParameter(payload).executeUpdate());
+        if(!existsMessage(connection, queueName, messageId)) {
+            String PUSH_MESSAGE = "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES ((current_timestamp + (? ||' seconds')::interval), ?,?,?,?,?) ON CONFLICT (queue_name,message_id) DO UPDATE SET payload=excluded.payload, deliver_on=excluded.deliver_on";
+	        execute(connection, PUSH_MESSAGE, q -> q.addParameter(offsetTimeInSecond).addParameter(queueName)
+	                .addParameter(messageId).addParameter(priority).addParameter(offsetTimeInSecond)
+	                .addParameter(payload).executeUpdate());
+        }
     }
 
     private boolean removeMessage(Connection connection, String queueName, String messageId) {
@@ -263,7 +265,11 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
     private void createQueueIfNotExists(Connection connection, String queueName) {
         logger.trace("Creating new queue '{}'", queueName);
-        final String CREATE_QUEUE = "INSERT INTO queue (queue_name) VALUES (?) ON CONFLICT (queue_name) DO NOTHING";
-        execute(connection, CREATE_QUEUE, q -> q.addParameter(queueName).executeUpdate());
+        final String EXISTS_QUEUE = "SELECT EXISTS(SELECT 1 FROM queue WHERE queue_name = ?)";
+        boolean exists = query(connection, EXISTS_QUEUE, q -> q.addParameter(queueName).exists());
+        if(!exists) {
+	        final String CREATE_QUEUE = "INSERT INTO queue (queue_name) VALUES (?) ON CONFLICT (queue_name) DO NOTHING";
+	        execute(connection, CREATE_QUEUE, q -> q.addParameter(queueName).executeUpdate());
+        }
     }
 }


### PR DESCRIPTION
The poll_data table is one example of many mysql and postgres tables that have an id column that is generated from a sequence. Most times these tables will be updated, inserts will only happen the first time the resource is inserted, after that many updates will be done. The current sql does an INSERT/ON CONFLICT for postgres and an INSERT/ON DUPLICATE KEY for mysql. This means that even though the error condition happens, the sequence is incremented but that new value is not used because the update happens (not the insert). In a system with large volumes, this causes large gaps in the id column as well as potentially maxing out the sequence (it happened to us).

The fix is to take out the INSERT/ON CONFLICT and replace it by an UPDATE. Only if the update fails does it do an insert.

Note that we have tested this using our Postgres database but we don't have access to a MySQL database to test. It should work but we have no way to validate. The same issues could happen in MySQL so we made changes to both modules.