### PR TITLE
Auth - Change to a better ACL example

### DIFF
--- a/ui/src/auth/README.md
+++ b/ui/src/auth/README.md
@@ -69,12 +69,11 @@ See example of use:
   },
   "audit": true,
   "acl": [
-    "GET /favicon.ico                   *",
-    "GET /(styles|js|images|fonts)/(.*) *",
-    "GET /(.*)                          viewer",
-    "PUT /(.*)                          admin",
     "POST /(.*)                         admin",
-    "DELETE /(.*)                       admin"
+    "PUT /(.*)                          admin",
+    "DELETE /(.*)                       admin",
+    "GET /api/(.*)                      viewer",
+    "GET /(.*)                          *"
   ]
 }
 ```
@@ -115,12 +114,11 @@ See example of use:
   },
   "audit": true,
   "acl": [
-    "GET /favicon.ico                   *",
-    "GET /(styles|js|images|fonts)/(.*) *",
-    "GET /(.*)                          viewer",
-    "PUT /(.*)                          admin",
     "POST /(.*)                         admin",
-    "DELETE /(.*)                       admin"
+    "PUT /(.*)                          admin",
+    "DELETE /(.*)                       admin",
+    "GET /api/(.*)                      viewer",
+    "GET /(.*)                          *"
   ]
 }
 ```


### PR DESCRIPTION
Change to a better ACL example (allowing all GET operations beside /api) for better future compatibility in case people copy and paste that example to their configuration.