### PR TITLE
enable init taskToDomain in TaskRunnerConfigurer

### DIFF
--- a/client/src/test/java/com/netflix/conductor/client/automator/TaskPollExecutorTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/automator/TaskPollExecutorTest.java
@@ -52,7 +52,7 @@ public class TaskPollExecutorTest {
             throw new NoSuchMethodError();
         });
         TaskClient taskClient = Mockito.mock(TaskClient.class);
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-");
 
         when(taskClient.pollTask(any(), any(), any())).thenReturn(testTask());
         when(taskClient.ack(any(), any())).thenReturn(true);
@@ -97,7 +97,7 @@ public class TaskPollExecutorTest {
         });
 
         TaskClient taskClient = Mockito.mock(TaskClient.class);
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-");
         when(taskClient.pollTask(any(), any(), any())).thenReturn(task);
         when(taskClient.ack(any(), any())).thenReturn(true);
         CountDownLatch latch = new CountDownLatch(3);
@@ -146,7 +146,7 @@ public class TaskPollExecutorTest {
             throw new ConductorClientException();
         }).when(taskClient).evaluateAndUploadLargePayload(any(TaskResult.class), any());
 
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 3, "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 3, new HashMap<>(), "test-worker-");
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
                 latch.countDown();
@@ -176,7 +176,7 @@ public class TaskPollExecutorTest {
             .thenThrow(ConductorClientException.class)
             .thenReturn(task);
 
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-");
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
                 Object[] args = invocation.getArguments();
@@ -209,7 +209,7 @@ public class TaskPollExecutorTest {
             .thenReturn(new Task())
             .thenReturn(task);
 
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-");
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
                 Object[] args = invocation.getArguments();
@@ -226,6 +226,33 @@ public class TaskPollExecutorTest {
 
         Uninterruptibles.awaitUninterruptibly(latch);
         verify(taskClient).updateTask(any());
+    }
+
+    @Test
+    public void testTaskPollDomain() {
+        TaskClient taskClient = Mockito.mock(TaskClient.class);
+        String testDomain = "foo";
+        Map<String, String> taskToDomain = new HashMap<>();
+        taskToDomain.put(TEST_TASK_DEF_NAME, testDomain);
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, taskToDomain, "test-worker-");
+
+        String workerName = "test-worker";
+        Worker worker = mock(Worker.class);
+        when(worker.getTaskDefName()).thenReturn(TEST_TASK_DEF_NAME);
+        when(worker.getIdentity()).thenReturn(workerName);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                latch.countDown();
+                return null;
+            }
+        ).when(taskClient).pollTask(TEST_TASK_DEF_NAME, workerName, testDomain);
+
+        Executors.newSingleThreadScheduledExecutor()
+            .scheduleAtFixedRate(() -> taskPollExecutor.pollAndExecute(worker), 0, 1, TimeUnit.SECONDS);
+
+        Uninterruptibles.awaitUninterruptibly(latch);
+        verify(taskClient).pollTask(TEST_TASK_DEF_NAME, workerName, testDomain);
     }
 
     private Task testTask() {


### PR DESCRIPTION
Enable initializing task to domain configuration in the TaskRunnerConfigurer when the client is setup.
This can still be overridden using properties if needed.