### PR TITLE
1696: correct task seq in DO_WHILE

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -810,6 +810,7 @@ public class Task {
     deepCopy.setEndTime(endTime);
     deepCopy.setWorkerId(workerId);
     deepCopy.setReasonForIncompletion(reasonForIncompletion);
+    deepCopy.setSeq(seq);
 
     return deepCopy;
   }


### PR DESCRIPTION
Found the same issue in #1696 

Tasks in DO_WHILE task was not shown in conductor-ui. I found it's because DoWhile.execute() use a copy of workflow, and the tasks' seq in the copied workflow was not assigned.

I add the assignation of `seq` in Task.deepCopy() and the seq of tasks in DO_WHILE task appears in UI.