### PR TITLE
LAMBDA - add support for task definition's inputTemplate

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -222,8 +222,8 @@ public class CoreModule extends AbstractModule {
     @StringMapKey(TASK_TYPE_LAMBDA)
     @Singleton
     @Named(TASK_MAPPERS_QUALIFIER)
-    public TaskMapper getLambdaTaskMapper(ParametersUtils parametersUtils) {
-        return new LambdaTaskMapper(parametersUtils);
+    public TaskMapper getLambdaTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+        return new LambdaTaskMapper(parametersUtils, metadataDAO);
     }
 
     @ProvidesIntoMap

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -122,7 +122,7 @@ public class TestWorkflowExecutor {
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
         taskMappers.put("HTTP", new HTTPTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put("LAMBDA", new LambdaTaskMapper(parametersUtils));
+        taskMappers.put("LAMBDA", new LambdaTaskMapper(parametersUtils, metadataDAO));
 
         DeciderService deciderService = new DeciderService(parametersUtils, metadataDAO, externalPayloadStorageUtils, taskMappers, config);
         MetadataMapperService metadataMapperService = new MetadataMapperService(metadataDAO);

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapperTest.java
@@ -8,6 +8,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.execution.ParametersUtils;
 import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.dao.MetadataDAO;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,17 +21,21 @@ import static org.mockito.Mockito.mock;
 public class LambdaTaskMapperTest {
 
     private ParametersUtils parametersUtils;
+    private MetadataDAO metadataDAO;
 
     @Before
     public void setUp() {
         parametersUtils = mock(ParametersUtils.class);
+        metadataDAO = mock(MetadataDAO.class);
     }
 
     @Test
     public void getMappedTasks() throws Exception {
 
         WorkflowTask taskToSchedule = new WorkflowTask();
+        taskToSchedule.setName("lambda_task");
         taskToSchedule.setType(TaskType.LAMBDA.name());
+        taskToSchedule.setTaskDefinition(new TaskDef("lambda_task"));
         taskToSchedule.setScriptExpression("if ($.input.a==1){return {testValue: true}} else{return {testValue: false} }");
 
         String taskId = IDGenerator.generate();
@@ -49,7 +54,37 @@ public class LambdaTaskMapperTest {
                 .build();
 
 
-        List<Task> mappedTasks = new LambdaTaskMapper(parametersUtils).getMappedTasks(taskMapperContext);
+        List<Task> mappedTasks = new LambdaTaskMapper(parametersUtils, metadataDAO).getMappedTasks(taskMapperContext);
+
+        assertEquals(1, mappedTasks.size());
+        assertNotNull(mappedTasks);
+        assertEquals(TaskType.LAMBDA.name(), mappedTasks.get(0).getTaskType());
+    }
+
+    @Test
+    public void getMappedTasks_WithoutTaskDef() throws Exception {
+
+        WorkflowTask taskToSchedule = new WorkflowTask();
+        taskToSchedule.setType(TaskType.LAMBDA.name());
+        taskToSchedule.setScriptExpression("if ($.input.a==1){return {testValue: true}} else{return {testValue: false} }");
+
+        String taskId = IDGenerator.generate();
+
+        WorkflowDef  wd = new WorkflowDef();
+        Workflow w = new Workflow();
+        w.setWorkflowDefinition(wd);
+
+        TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+                .withWorkflowDefinition(wd)
+                .withWorkflowInstance(w)
+                .withTaskDefinition(null)
+                .withTaskToSchedule(taskToSchedule)
+                .withRetryCount(0)
+                .withTaskId(taskId)
+                .build();
+
+
+        List<Task> mappedTasks = new LambdaTaskMapper(parametersUtils, metadataDAO).getMappedTasks(taskMapperContext);
 
         assertEquals(1, mappedTasks.size());
         assertNotNull(mappedTasks);


### PR DESCRIPTION
Add support for creating task definitions for LAMBDA tasks.

## Motivation

- Use `inputTemplate` for a shared `scriptExpression`
- This way different inputs for the script can be provided per task; utilising the inputs merge process

## What I changed
- I copied the way `HTTPTaskMapper` uses `parametersUtils.getTaskInputV2` providing a reference to a found `taskDefinition` from the `MetadataDAO`

- I also copied the structure of the unit tests of the HTTP mapper (one with task definition and one without) 