### PR TITLE
1816: getNextTask will get wrong task if DO_WHILE task is embed in FORK or DECISION

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -569,6 +569,13 @@ public class WorkflowTask {
 							return nextTask;
 						}
 						if (task.has(taskReferenceName)) {
+							if (TaskType.DO_WHILE.name().equals(task.getType())) {
+								// come here means task is DO_WHILE task and `taskReferenceName` is the last task in
+								// this DO_WHILE task, because DO_WHILE task need to be executed to decide whether to
+								// schedule next iteration, so we just return the DO_WHILE task, and then ignore
+								// generating this task again in deciderService.getNextTask()
+								return task;
+							}
 							break;
 						}
 					}
@@ -592,6 +599,10 @@ public class WorkflowTask {
 							return nextTask;
 						}
 						if (task.has(taskReferenceName)) {
+							if (TaskType.DO_WHILE.name().equals(task.getType())) {
+								// same reason as above
+								return task;
+							}
 							break;
 						}
 					}

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -347,7 +347,8 @@ public class DeciderService {
         return allCompletedSuccessfully && noPendingTasks && noPendingSchedule;
     }
 
-    private List<Task> getNextTask(Workflow workflow, Task task) {
+    @VisibleForTesting
+    List<Task> getNextTask(Workflow workflow, Task task) {
         final WorkflowDef workflowDef = workflow.getWorkflowDefinition();
 
         // Get the following task after the last completed task
@@ -361,6 +362,13 @@ public class DeciderService {
         WorkflowTask taskToSchedule = workflowDef.getNextTask(taskReferenceName);
         while (isTaskSkipped(taskToSchedule, workflow)) {
             taskToSchedule = workflowDef.getNextTask(taskToSchedule.getTaskReferenceName());
+        }
+        if (taskToSchedule != null && TaskType.DO_WHILE.name().equals(taskToSchedule.getType())) {
+            // check if already has this DO_WHILE task, ignore it if it already exists
+            String nextTaskReferenceName = taskToSchedule.getTaskReferenceName();
+            if (workflow.getTasks().stream().anyMatch(runningTask -> runningTask.getReferenceTaskName().equals(nextTaskReferenceName))) {
+                return Collections.emptyList();
+            }
         }
         if (taskToSchedule != null) {
             return getTasksToBeScheduled(workflow, taskToSchedule, 0);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -40,18 +40,7 @@ import com.netflix.conductor.common.utils.JsonMapperProvider;
 import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.DeciderService.DeciderOutcome;
-import com.netflix.conductor.core.execution.mapper.DecisionTaskMapper;
-import com.netflix.conductor.core.execution.mapper.DynamicTaskMapper;
-import com.netflix.conductor.core.execution.mapper.EventTaskMapper;
-import com.netflix.conductor.core.execution.mapper.ForkJoinDynamicTaskMapper;
-import com.netflix.conductor.core.execution.mapper.ForkJoinTaskMapper;
-import com.netflix.conductor.core.execution.mapper.HTTPTaskMapper;
-import com.netflix.conductor.core.execution.mapper.JoinTaskMapper;
-import com.netflix.conductor.core.execution.mapper.SimpleTaskMapper;
-import com.netflix.conductor.core.execution.mapper.SubWorkflowTaskMapper;
-import com.netflix.conductor.core.execution.mapper.TaskMapper;
-import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
-import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
+import com.netflix.conductor.core.execution.mapper.*;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.spectator.api.Counter;
@@ -132,6 +121,7 @@ public class TestDeciderService {
         taskMappers.put("EVENT", new EventTaskMapper(parametersUtils));
         taskMappers.put("WAIT", new WaitTaskMapper(parametersUtils));
         taskMappers.put("HTTP", new HTTPTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put("LAMBDA", new LambdaTaskMapper(parametersUtils));
 
         deciderService = new DeciderService(parametersUtils, metadataDAO, externalPayloadStorageUtils, taskMappers, config);
     }
@@ -1009,6 +999,67 @@ public class TestDeciderService {
         assertEquals(1, counter.count());
     }
 
+    @Test
+    public void testDeciderGetNextTask() {
+        WorkflowDef workflowDef = createDoWhileInForkWorkflow();
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowDefinition(workflowDef);
+
+        Task task1 = new Task();
+        task1.setReferenceTaskName("fork");
+        task1.setStatus(Status.COMPLETED);
+        task1.setTaskId("task1");
+
+        Task task2 = new Task();
+        task2.setReferenceTaskName("loopTask");
+        task2.setStatus(Status.SCHEDULED);
+        task2.setTaskId("task2");
+        task2.setIteration(1);
+
+        Task task3 = new Task();
+        task3.setReferenceTaskName("junit_task_0__1");
+        task3.setStatus(Status.COMPLETED);
+        task3.setTaskId("task3");
+        task3.setIteration(1);
+
+        Task task4 = new Task();
+        task4.setReferenceTaskName("junit_task_3");
+        task4.setStatus(Status.COMPLETED);
+        task4.setTaskId("task4");
+
+        Task task5 = new Task();
+        task5.setReferenceTaskName("join");
+        task5.setStatus(Status.IN_PROGRESS);
+        task5.setTaskId("task5");
+
+        workflow.setTasks(Arrays.asList(task1, task2, task3, task4, task5));
+
+        // verify the next task of first task in DoWhile
+        List<Task> nextTask1 = deciderService.getNextTask(workflow, task3);
+        assertEquals(1, nextTask1.size());
+        assertEquals("junit_task_1", nextTask1.get(0).getReferenceTaskName());
+
+        Task task6 = new Task();
+        task6.setReferenceTaskName("junit_task_1__1");
+        task6.setStatus(Status.COMPLETED);
+        task6.setTaskId("task6");
+        task6.setIteration(1);
+
+        workflow.setTasks(Arrays.asList(task1, task2, task3, task4, task5, task6));
+
+        // verify the next task of last task in DoWhile
+        List<Task> nextTask2 = deciderService.getNextTask(workflow, task6);
+        assertEquals(0, nextTask2.size());
+
+        task2.setStatus(Status.COMPLETED);
+        task2.setIteration(10);
+
+        // verify the next task of last task in DoWhile
+        List<Task> nextTask3 = deciderService.getNextTask(workflow, task2);
+        assertEquals(1, nextTask3.size());
+        assertEquals("junit_task_2", nextTask3.get(0).getReferenceTaskName());
+    }
+
     private WorkflowDef createConditionalWF() {
 
         WorkflowTask workflowTask1 = new WorkflowTask();
@@ -1233,4 +1284,46 @@ public class TestDeciderService {
         return workflowDef;
     }
 
+    private WorkflowDef createDoWhileInForkWorkflow() {
+        String FORK_DOWHILE_TASK_WF = "FORK_DOWHILE_TASK_WF";
+        List<WorkflowTask> workflowTasks = new ArrayList<>(10);
+        for(int i = 0; i < 10; i++){
+            WorkflowTask workflowTask = new WorkflowTask();
+            workflowTask.setTaskReferenceName("junit_task_" + i);
+            workflowTask.setName("junit_task_" + i);
+            workflowTask.setType(TaskType.LAMBDA.name());
+            workflowTasks.add(workflowTask);
+        }
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName(FORK_DOWHILE_TASK_WF);
+        workflowDef.setDescription(FORK_DOWHILE_TASK_WF);
+
+        WorkflowTask doWhileTask = new WorkflowTask();
+        doWhileTask.setType(TaskType.DO_WHILE.name());
+        doWhileTask.setName("loopTask");
+        doWhileTask.setTaskReferenceName("loopTask");
+        doWhileTask.setLoopCondition("$.loopTask.iteration < 10");
+        doWhileTask.setLoopOver(workflowTasks.subList(0, 2));
+
+        WorkflowTask forkTask = new WorkflowTask();
+        forkTask.setType(TaskType.FORK_JOIN.name());
+        forkTask.setName("fork");
+        forkTask.setTaskReferenceName("fork");
+        List<List<WorkflowTask>> wtList = new ArrayList<>();
+        wtList.add(Arrays.asList(doWhileTask, workflowTasks.get(2)));
+        wtList.add(Collections.singletonList(workflowTasks.get(3)));
+        forkTask.setForkTasks(wtList);
+
+        WorkflowTask joinTask = new WorkflowTask();
+        joinTask.setType(TaskType.JOIN.name());
+        joinTask.setName("join");
+        joinTask.setTaskReferenceName("join");
+        joinTask.setJoinOn(Arrays.asList(doWhileTask.getTaskReferenceName(), workflowTasks.get(4).getTaskReferenceName()));
+
+        workflowDef.getTasks().add(forkTask);
+        workflowDef.getTasks().add(joinTask);
+
+        return workflowDef;
+    }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowDef.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowDef.java
@@ -136,6 +136,53 @@ public class TestWorkflowDef {
 		assertEquals("junit_task_1", nextTask.getTaskReferenceName());
 	}
 
+	@Test
+	public void testGetNextTask_DoWhile_In_Fork() {
+		String FORK_DOWHILE_TASK_WF = "FORK_DOWHILE_TASK_WF";
+		List<WorkflowTask> workflowTasks = new ArrayList<>(10);
+		for(int i = 0; i < 10; i++){
+			workflowTasks.add(createWorkflowTask("junit_task_" + i));
+		}
+
+		WorkflowDef workflowDef = new WorkflowDef();
+		workflowDef.setName(FORK_DOWHILE_TASK_WF);
+		workflowDef.setDescription(FORK_DOWHILE_TASK_WF);
+
+		WorkflowTask doWhileTask = new WorkflowTask();
+		doWhileTask.setType(TaskType.DO_WHILE.name());
+		doWhileTask.setName("loopTask");
+		doWhileTask.setTaskReferenceName("loopTask");
+		doWhileTask.setLoopCondition("$.loopTask.iteration < 10");
+		doWhileTask.setLoopOver(workflowTasks.subList(0, 2));
+
+		WorkflowTask forkTask = new WorkflowTask();
+		forkTask.setType(TaskType.FORK_JOIN.name());
+		forkTask.setName("fork");
+		forkTask.setTaskReferenceName("fork");
+		List<List<WorkflowTask>> wtList = new ArrayList<>();
+		wtList.add(Arrays.asList(doWhileTask, workflowTasks.get(2)));
+		wtList.add(Collections.singletonList(workflowTasks.get(3)));
+		forkTask.setForkTasks(wtList);
+
+		WorkflowTask joinTask = new WorkflowTask();
+		joinTask.setType(TaskType.JOIN.name());
+		joinTask.setName("join");
+		joinTask.setTaskReferenceName("join");
+		joinTask.setJoinOn(Arrays.asList(doWhileTask.getTaskReferenceName(), workflowTasks.get(4).getTaskReferenceName()));
+
+		workflowDef.getTasks().add(forkTask);
+		workflowDef.getTasks().add(joinTask);
+
+		WorkflowTask nextTask = workflowDef.getNextTask("junit_task_0");
+		assertEquals("junit_task_1", nextTask.getTaskReferenceName());
+
+		WorkflowTask nextTask1 = workflowDef.getNextTask("junit_task_1");
+		assertEquals("loopTask", nextTask1.getTaskReferenceName());
+
+		WorkflowTask nextTask2 = workflowDef.getNextTask("loopTask");
+		assertEquals("junit_task_2", nextTask2.getTaskReferenceName());
+	}
+
 	private WorkflowTask createWorkflowTask(String name) {
 		WorkflowTask task = new WorkflowTask();
 		task.setName(name);


### PR DESCRIPTION
Patch for #1816.

### What I changed
If the last inner task of DO_WHILE was completed and call getNextTask() in decide(), I return the DO_WHILE task (In current code, it will return the next task of DO_WHILE). 
And then, in DeciderService.getNextTask(), I check if the DO_WHILE task already exists in the workflow's tasks. If it exists, just ignore it.