### PR TITLE
Feature: Task resiliency from QueueDAO failures

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -130,6 +130,9 @@ public interface Configuration {
 
     String EVENT_QUEUE_POLL_SCHEDULER_THREAD_COUNT_PROPERTY_NAME = "workflow.event.queue.scheduler.poll.thread.count";
 
+    String WORKFLOW_REPAIR_SERVICE_ENABLED = "workflow.repairservice.enabled";
+    boolean WORKFLOW_REPAIR_SERVICE_ENABLED_DEFAULT_VALUE = false;
+
     //TODO add constants for input/output external payload related properties.
 
     default DB getDB() {
@@ -374,6 +377,17 @@ public interface Configuration {
     default int getEventSchedulerPollThreadCount()
     {
         return getIntProperty(EVENT_QUEUE_POLL_SCHEDULER_THREAD_COUNT_PROPERTY_NAME, Runtime.getRuntime().availableProcessors());
+    }
+
+    /**
+     * Configuration to enable {@link com.netflix.conductor.core.execution.WorkflowRepairService}, that tries to keep
+     * ExecutionDAO and QueueDAO in sync, based on the task or workflow state.
+     *
+     * This is disabled by default; To enable, the Queueing layer must implement QueueDAO.containsMessage method.
+     * @return
+     */
+    default boolean isWorkflowRepairServiceEnabled() {
+        return getBooleanProperty(WORKFLOW_REPAIR_SERVICE_ENABLED, WORKFLOW_REPAIR_SERVICE_ENABLED_DEFAULT_VALUE);
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowRepairService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowRepairService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.core.utils.QueueUtils;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.metrics.Monitors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+/**
+ * A helper service that tries to keep ExecutionDAO and QueueDAO in sync, based on the
+ * task or workflow state.
+ *
+ * This service expects that the underlying Queueing layer implements QueueDAO.containsMessage method. This can be controlled
+ * with {@link com.netflix.conductor.core.config.Configuration#isWorkflowRepairServiceEnabled()} property.
+ */
+public class WorkflowRepairService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowRepairService.class);
+
+    private final ExecutionDAO executionDAO;
+    private final QueueDAO queueDAO;
+    private final Configuration configuration;
+
+    private final Predicate<Task> isSystemTask = task -> WorkflowSystemTask.is(task.getTaskType());
+
+    @Inject
+    public WorkflowRepairService(
+            ExecutionDAO executionDAO,
+            QueueDAO queueDAO,
+            Configuration configuration
+    ) {
+        this.executionDAO = executionDAO;
+        this.queueDAO = queueDAO;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Verify and repair if the workflowId exists in deciderQueue, and then if each scheduled task has relevant message
+     * in the queue.
+     * @param workflowId
+     * @param includeTasks
+     * @return
+     */
+    public boolean verifyAndRepairWorkflow(String workflowId, boolean includeTasks) {
+        Workflow workflow = executionDAO.getWorkflow(workflowId, includeTasks);
+        AtomicBoolean repaired = new AtomicBoolean(false);
+        repaired.set(verifyAndRepairDeciderQueue(workflow));
+        if (includeTasks) {
+            workflow.getTasks().forEach(task -> {
+                repaired.set(verifyAndRepairTask(task));
+            });
+        }
+        return repaired.get();
+    }
+
+    /**
+     * Verify and repair tasks in a workflow
+     * @param workflowId
+     */
+    public void verifyAndRepairWorkflowTasks(String workflowId) {
+        Workflow workflow = executionDAO.getWorkflow(workflowId, true);
+        workflow.getTasks().forEach(task -> verifyAndRepairTask(task));
+    }
+
+    /**
+     * Verify and fix if Workflow decider queue contains this workflowId.
+     * @param workflow
+     * @return
+     */
+    private boolean verifyAndRepairDeciderQueue(Workflow workflow) {
+        if (!workflow.getStatus().isTerminal()) {
+            String queueName = WorkflowExecutor.DECIDER_QUEUE;
+            if (!queueDAO.containsMessage(queueName, workflow.getWorkflowId())) {
+                queueDAO.push(queueName, workflow.getWorkflowId(), configuration.getSweepFrequency());
+                Monitors.recordQueueMessageRepushFromRepairService(queueName);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Verify if ExecutionDAO and QueueDAO agree for the provided task.
+     * @param task
+     * @return
+     */
+    @VisibleForTesting
+    protected boolean verifyAndRepairTask(Task task) {
+        WorkflowSystemTask workflowSystemTask = WorkflowSystemTask.get(task.getTaskType());
+        if (task.getStatus() == Task.Status.SCHEDULED) {
+            if (isSystemTask.test(task) && !workflowSystemTask.isAsync()) {
+                return false;
+            }
+            // Ensure QueueDAO contains this taskId
+            String taskQueueName = QueueUtils.getQueueName(task);
+            if (!queueDAO.containsMessage(taskQueueName, task.getTaskId())) {
+                queueDAO.push(taskQueueName, task.getTaskId(), task.getCallbackAfterSeconds());
+                Monitors.recordQueueMessageRepushFromRepairService(task.getTaskDefName());
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -188,4 +188,14 @@ public interface QueueDAO {
 		push(queueName, messageId, priority, postponeDurationInSeconds);
 		return true;
 	}
+
+	/**
+	 * Check if the message with given messageId exists in the Queue.
+	 * @param queueName
+	 * @param messageId
+	 * @return
+	 */
+	default boolean containsMessage(String queueName, String messageId) {
+		throw new UnsupportedOperationException("Please ensure your provided Queue implementation overrides and implements this method.");
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -320,4 +320,8 @@ public class Monitors {
 	public static void recordEventQueuePollSize(String queueType, int val) {
 		gauge(Monitors.classQualifier, "event_queue_poll", val, "queueType", queueType);
 	}
+
+	public static void recordQueueMessageRepushFromRepairService(String queueName) {
+		counter(classQualifier, "queue_message_repushed", "queueName", queueName);
+	}
 }

--- a/core/src/main/java/com/netflix/conductor/service/AdminService.java
+++ b/core/src/main/java/com/netflix/conductor/service/AdminService.java
@@ -47,4 +47,11 @@ public interface AdminService {
      */
     List<Task> getListOfPendingTask(@NotEmpty(message = "TaskType cannot be null or empty.") String taskType,
                                     Integer start, Integer count);
+
+    /**
+     * Verify that the Workflow is consistent, and run repairs as needed.
+     * @param workflowId
+     * @return
+     */
+    boolean verifyAndRepairWorkflowConsistency(@NotEmpty(message = "WorkflowId cannot be null or empty.") String workflowId);
 }

--- a/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
@@ -21,12 +21,14 @@ import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.WorkflowRepairService;
 import com.netflix.conductor.dao.QueueDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.validation.constraints.NotEmpty;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -46,15 +48,21 @@ public class AdminServiceImpl implements AdminService {
 
     private final QueueDAO queueDAO;
 
+    private final WorkflowRepairService workflowRepairService;
+
     private String version;
 
     private String buildDate;
 
     @Inject
-    public AdminServiceImpl(Configuration config, ExecutionService executionService, QueueDAO queueDAO) {
+    public AdminServiceImpl(Configuration config,
+                            ExecutionService executionService,
+                            QueueDAO queueDAO,
+                            WorkflowRepairService workflowRepairService) {
         this.config = config;
         this.executionService = executionService;
         this.queueDAO = queueDAO;
+        this.workflowRepairService = workflowRepairService;
         this.version = "UNKNOWN";
         this.buildDate = "UNKNOWN";
 
@@ -95,6 +103,11 @@ public class AdminServiceImpl implements AdminService {
         total = (tasks.size() > total) ? total : tasks.size();
         if (start > tasks.size()) start = tasks.size();
         return tasks.subList(start, total);
+    }
+
+    @Override
+    public boolean verifyAndRepairWorkflowConsistency(@NotEmpty(message = "WorkflowId cannot be null or empty.") String workflowId) {
+        return workflowRepairService.verifyAndRepairWorkflow(workflowId, true);
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -276,6 +276,32 @@ public class TestWorkflowExecutor {
         workflowExecutor.scheduleTask(workflow, tasks);
     }
 
+    /**
+     * Simulate Queue push failures and assert that scheduleTask doesn't throw an exception.
+     */
+    @Test
+    public void testQueueFailuresDuringScheduleTask() {
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowId("wid_01");
+
+        List<Task> tasks = new LinkedList<>();
+
+        Task task1 = new Task();
+        task1.setTaskType(TaskType.TASK_TYPE_SIMPLE);
+        task1.setTaskDefName("task_1");
+        task1.setReferenceTaskName("task_1");
+        task1.setWorkflowInstanceId(workflow.getWorkflowId());
+        task1.setTaskId("tid_01");
+        task1.setStatus(Status.SCHEDULED);
+        task1.setRetryCount(0);
+
+        tasks.add(task1);
+
+        when(executionDAOFacade.createTasks(tasks)).thenReturn(tasks);
+        doThrow(new RuntimeException()).when(queueDAO).push(anyString(), anyString(), anyInt(), anyLong());
+        assertFalse(workflowExecutor.scheduleTask(workflow, tasks));
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testCompleteWorkflow() {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowRepairService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowRepairService.java
@@ -1,0 +1,66 @@
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.tasks.Decision;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.QueueDAO;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestWorkflowRepairService {
+
+    ExecutionDAO executionDAO;
+    QueueDAO queueDAO;
+    Configuration configuration;
+    WorkflowRepairService workflowRepairService;
+
+    @Before
+    public void setUp() {
+        executionDAO = mock(ExecutionDAO.class);
+        queueDAO = mock(QueueDAO.class);
+        configuration = mock(Configuration.class);
+        workflowRepairService = new WorkflowRepairService(executionDAO, queueDAO, configuration);
+    }
+
+    @Test
+    public void verifyAndRepairTask() {
+        Task task = new Task();
+        task.setTaskType("SIMPLE");
+        task.setStatus(Task.Status.SCHEDULED);
+        task.setTaskId("abcd");
+        task.setCallbackAfterSeconds(60);
+
+        when(queueDAO.containsMessage(anyString(), anyString())).thenReturn(false);
+
+        assertTrue(workflowRepairService.verifyAndRepairTask(task));
+        // Verify that a new queue message is pushed for sync system tasks that fails queue contains check.
+        verify(queueDAO, times(1)).push(anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    public void assertSyncSystemTasksAreNotCheckedAgainstQueue() {
+        // Create a Decision object to init WorkflowSystemTask registry.
+        Decision decision = new Decision();
+
+        Task task = new Task();
+        task.setTaskType("DECISION");
+        task.setStatus(Task.Status.SCHEDULED);
+
+        assertFalse(workflowRepairService.verifyAndRepairTask(task));
+        // Verify that queue contains is never checked for sync system tasks
+        verify(queueDAO, never()).containsMessage(anyString(), anyString());
+        // Verify that queue message is never pushed for sync system tasks
+        verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
+    }
+}

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/AdminResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/AdminResource.java
@@ -60,7 +60,7 @@ public class AdminResource {
 	public Map<String, Object> getAllConfig() {
         return adminService.getAllConfig();
 	}
-	
+
 	@GET
 	@Path("/task/{tasktype}")
 	@ApiOperation("Get the list of pending tasks for a given task type")
@@ -78,6 +78,16 @@ public class AdminResource {
 	@Produces({ MediaType.TEXT_PLAIN })
 	public String requeueSweep(@PathParam("workflowId") String workflowId) {
         return adminService.requeueSweep(workflowId);
+	}
+
+
+	@POST
+	@Path("/consistency/verifyAndRepair/{workflowId}")
+	@ApiOperation("Verify and repair workflow consistency")
+	@Consumes({ MediaType.WILDCARD })
+	@Produces({ MediaType.TEXT_PLAIN })
+	public String verifyAndRepairWorkflowConsistency(@PathParam("workflowId") String workflowId) {
+		return String.valueOf(adminService.verifyAndRepairWorkflowConsistency(workflowId));
 	}
 
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/queue/DynoQueueDAO.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -253,5 +254,12 @@ public class DynoQueueDAO implements QueueDAO {
         DynoQueue queue = queues.get(queueName);
         return queue.setTimeout(id, 0);
 
+    }
+
+    @Override
+    public boolean containsMessage(String queueName, String messageId) {
+        DynoQueue queue = queues.get(queueName);
+        Message message = queue.get(messageId);
+        return Objects.nonNull(message);
     }
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
@@ -74,4 +74,12 @@ public interface DynomiteConfiguration extends Configuration {
 
         return prefix;
     }
+
+    /**
+     * WorkflowRepairService is enabled by default for DynoQueues, since this queue receipe supports getMessage feature.
+     * @return
+     */
+    default boolean isWorkflowRepairServiceEnabled() {
+        return true;
+    }
 }

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     testCompile "org.codehaus.groovy:groovy-all:${revGroovy}"
     testCompile "org.spockframework:spock-core:${revSpock}"
+    testCompile "org.spockframework:spock-guice:${revSpock}"
     testCompile 'com.netflix.governator:governator-test-spock:latest.release'
     testCompile "org.elasticsearch:elasticsearch:${revElasticSearch5}"
     testCompile "org.elasticsearch.client:transport:${revElasticSearch5}"

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/util/MockQueueDAOModule.java
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/util/MockQueueDAOModule.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.util;
+
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.dynomite.queue.DynoQueueDAO;
+import com.netflix.conductor.jedis.JedisMock;
+import com.netflix.conductor.tests.utils.TestModule;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.queues.ShardSupplier;
+import com.netflix.dyno.queues.redis.RedisQueues;
+import redis.clients.jedis.commands.JedisCommands;
+import spock.mock.DetachedMockFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Creates a Spock "Spy"'ed QueueDAO Guice injection, that can be used in integration testing.
+ */
+public class MockQueueDAOModule extends TestModule {
+    @Override
+    public void configureQueueDAO() {
+        DetachedMockFactory detachedMockFactory = new DetachedMockFactory();
+
+        JedisCommands jedisMock = new JedisMock();
+        ShardSupplier shardSupplier = new ShardSupplier() {
+            @Override
+            public Set<String> getQueueShards() {
+                return new HashSet<>(Collections.singletonList("a"));
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return "a";
+            }
+
+            @Override
+            public String getShardForHost(Host host) {
+                return "a";
+            }
+        };
+        RedisQueues redisQueues = new RedisQueues(jedisMock, jedisMock, "mockedQueues", shardSupplier, 60000, 120000);
+        DynoQueueDAO dynoQueueDAO = new DynoQueueDAO(redisQueues);
+
+        bind(QueueDAO.class).toInstance(detachedMockFactory.Spy(dynoQueueDAO));
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/util/WorkflowTestUtil.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/util/WorkflowTestUtil.groovy
@@ -260,6 +260,9 @@ class WorkflowTestUtil {
      */
     Tuple pollAndCompleteTask(String taskName, String workerId, Map<String, Object> outputParams = null, int waitAtEndSeconds = 0) {
         def polledIntegrationTask = workflowExecutionService.poll(taskName, workerId)
+        if (polledIntegrationTask == null) {
+            return new Tuple(null, null)
+        }
         def ackPolledIntegrationTask = workflowExecutionService.ackTaskReceived(polledIntegrationTask.taskId)
         polledIntegrationTask.status = COMPLETED
         if (outputParams) {

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/TaskResiliencySpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/TaskResiliencySpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.counductor.integration.test
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.WorkflowExecutor
+import com.netflix.conductor.core.execution.WorkflowRepairService
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.service.ExecutionService
+import com.netflix.conductor.test.util.MockQueueDAOModule
+import com.netflix.conductor.test.util.WorkflowTestUtil
+import spock.guice.UseModules
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
+
+@UseModules(MockQueueDAOModule)
+class TaskResiliencySpec extends Specification {
+
+    @Inject
+    ExecutionService workflowExecutionService
+
+    @Inject
+    WorkflowExecutor workflowExecutor
+
+    @Inject
+    WorkflowTestUtil workflowTestUtil
+
+    @Inject
+    WorkflowRepairService workflowRepairService
+
+    @Inject
+    QueueDAO queueDAO
+
+    @Shared
+    def SIMPLE_TWO_TASK_WORKFLOW = 'integration_test_wf'
+
+    def setup() {
+        workflowTestUtil.taskDefinitions()
+        workflowTestUtil.registerWorkflows(
+                'simple_workflow_1_integration_test.json'
+        )
+    }
+
+    def cleanup() {
+        workflowTestUtil.clearWorkflows()
+    }
+
+    def "Verify that a workflow recovers and completes on schedule task failure from queue push failure"() {
+        when: "Start a simple workflow"
+        def workflowInstanceId = workflowExecutor.startWorkflow(SIMPLE_TWO_TASK_WORKFLOW, 1,
+                '', [:], null, null, null)
+
+        then: "Retrieve the workflow"
+        def workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
+        workflow.status == Workflow.WorkflowStatus.RUNNING
+        workflow.tasks.size() == 1
+        workflow.tasks[0].taskType == 'integration_task_1'
+        workflow.tasks[0].status == Task.Status.SCHEDULED
+        def taskId = workflow.tasks[0].taskId
+
+        // Simulate queue push failure when creating a new task, after completing first task
+        when: "The first task 'integration_task_1' is polled and completed"
+        def task1Try1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker')
+
+        then: "Verify that the task was polled and acknowledged"
+        1 * queueDAO.pop(_, 1, _) >> Collections.singletonList(taskId)
+        1 * queueDAO.ack(*_) >> true
+        1 * queueDAO.push(*_) >> { throw new IllegalStateException("Queue push failed from Spy") }
+        verifyPolledAndAcknowledgedTask(task1Try1)
+
+        and: "Ensure that the next task is SCHEDULED even after failing to push taskId message to queue"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.RUNNING
+            tasks.size() == 2
+            tasks[0].taskType == 'integration_task_1'
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[1].taskType == 'integration_task_2'
+            tasks[1].status == Task.Status.SCHEDULED
+        }
+
+        when: "The second task 'integration_task_2' is polled for"
+        def task1Try2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker')
+
+        then: "Verify that the task was not polled, and the taskId doesn't exist in the queue"
+        task1Try2[0] == null
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.RUNNING
+            tasks.size() == 2
+            tasks[0].taskType == 'integration_task_1'
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[1].taskType == 'integration_task_2'
+            tasks[1].status == Task.Status.SCHEDULED
+            def currentTaskId = tasks[1].getTaskId()
+            queueDAO.containsMessage("integration_task_2", currentTaskId) == false
+        }
+
+        when: "Running a repair and decide on the workflow"
+        workflowRepairService.verifyAndRepairWorkflow(workflowInstanceId, true)
+        workflowExecutor.decide(workflowInstanceId)
+        task1Try2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker')
+
+        then: "verify that the next scheduled task can be polled and executed successfully"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            tasks.size() == 2
+            tasks[1].taskType == 'integration_task_2'
+            tasks[1].status == Task.Status.COMPLETED
+        }
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/WorkflowAndTaskConfigurationSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/WorkflowAndTaskConfigurationSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.core.execution.WorkflowExecutor
+import com.netflix.conductor.core.execution.WorkflowRepairService
 import com.netflix.conductor.core.execution.WorkflowSweeper
 import com.netflix.conductor.dao.QueueDAO
 import com.netflix.conductor.service.ExecutionService
@@ -52,6 +53,9 @@ class WorkflowAndTaskConfigurationSpec extends Specification {
 
     @Inject
     WorkflowSweeper workflowSweeper
+
+    @Inject
+    WorkflowRepairService workflowRepairService
 
     @Inject
     WorkflowTestUtil workflowTestUtil
@@ -203,7 +207,7 @@ class WorkflowAndTaskConfigurationSpec extends Specification {
 
         when: "There is a delay of 3 seconds introduced and the workflow is sweeped to run the evaluation"
         Thread.sleep(3000)
-        workflowSweeper.sweep([workflowInstanceId], workflowExecutor)
+        workflowSweeper.sweep([workflowInstanceId], workflowExecutor, workflowRepairService)
 
         then: "Ensure that the first task has been TIMED OUT and the next task is SCHEDULED"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -226,7 +230,7 @@ class WorkflowAndTaskConfigurationSpec extends Specification {
 
         when: "There is a delay of 3 seconds introduced and the workflow is swept to run the evaluation"
         Thread.sleep(3000)
-        workflowSweeper.sweep([workflowInstanceId], workflowExecutor)
+        workflowSweeper.sweep([workflowInstanceId], workflowExecutor, workflowRepairService)
 
         then: "Ensure that the first task has been TIMED OUT and the next task is SCHEDULED"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -280,7 +284,7 @@ class WorkflowAndTaskConfigurationSpec extends Specification {
 
         when: "There is a delay of 6 seconds introduced and the workflow is swept to run the evaluation"
         Thread.sleep(6000)
-        workflowSweeper.sweep([workflowInstanceId], workflowExecutor)
+        workflowSweeper.sweep([workflowInstanceId], workflowExecutor, workflowRepairService)
 
         then: "Ensure that the workflow has timed out"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -332,7 +336,7 @@ class WorkflowAndTaskConfigurationSpec extends Specification {
 
         when: "There is a delay of 6 seconds introduced and the workflow is swept to run the evaluation"
         Thread.sleep(6000)
-        workflowSweeper.sweep([workflowInstanceId], workflowExecutor)
+        workflowSweeper.sweep([workflowInstanceId], workflowExecutor, workflowRepairService)
 
         then: "Ensure that the workflow has timed out"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -55,6 +55,7 @@ import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.WorkflowContext;
 import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.WorkflowRepairService;
 import com.netflix.conductor.core.execution.WorkflowSweeper;
 import com.netflix.conductor.core.execution.tasks.SubWorkflow;
 import com.netflix.conductor.core.execution.tasks.Terminate;
@@ -139,6 +140,9 @@ public abstract class AbstractWorkflowServiceTest {
 
     @Inject
     protected WorkflowExecutor workflowExecutor;
+
+    @Inject
+    protected WorkflowRepairService workflowRepairService;
 
     @Inject
     protected MetadataMapperService metadataMapperService;
@@ -4446,7 +4450,7 @@ public abstract class AbstractWorkflowServiceTest {
         assertEquals(1, size);
 
         Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
-        workflowSweeper.sweep(Collections.singletonList(workflowId), workflowExecutor);
+        workflowSweeper.sweep(Collections.singletonList(workflowId), workflowExecutor, workflowRepairService);
         workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
         assertNotNull(workflow);
         assertEquals("found: " + workflow.getTasks().stream().map(Task::toString).collect(Collectors.toList()), 2, workflow.getTasks().size());
@@ -4504,7 +4508,7 @@ public abstract class AbstractWorkflowServiceTest {
         assertTrue(workflowExecutionService.ackTaskReceived(task.getTaskId()));
 
         Uninterruptibles.sleepUninterruptibly(6, TimeUnit.SECONDS);
-        workflowSweeper.sweep(Collections.singletonList(workflowId), workflowExecutor);
+        workflowSweeper.sweep(Collections.singletonList(workflowId), workflowExecutor, workflowRepairService);
 
         workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
         assertNotNull(workflow);

--- a/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/utils/TestModule.java
@@ -73,8 +73,8 @@ public class TestModule extends AbstractModule {
         bind(RateLimitingDAO.class).to(RedisRateLimitingDAO.class);
         bind(EventHandlerDAO.class).to(RedisEventHandlerDAO.class);
         bind(PollDataDAO.class).to(RedisPollDataDAO.class);
-        bind(QueueDAO.class).to(DynoQueueDAO.class);
         bind(IndexDAO.class).to(MockIndexDAO.class);
+        configureQueueDAO();
 
         bind(WorkflowStatusListener.class).to(WorkflowStatusListenerStub.class);
 
@@ -99,5 +99,9 @@ public class TestModule extends AbstractModule {
             workflowWorkerThread.setName(String.format("workflow-worker-%d", count.getAndIncrement()));
             return workflowWorkerThread;
         });
+    }
+
+    public void configureQueueDAO() {
+        bind(QueueDAO.class).to(DynoQueueDAO.class);
     }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6350,8 +6350,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6369,13 +6368,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6388,18 +6385,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6502,8 +6496,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6513,7 +6506,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6526,20 +6518,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6556,7 +6545,6 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -6612,8 +6600,7 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -6638,8 +6625,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6649,7 +6635,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6718,8 +6703,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6749,7 +6733,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6767,7 +6750,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6806,13 +6788,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9391,7 +9371,7 @@
     },
     "lazy-debug-legacy": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-debug/-/lazy-debug-0.0.3.tgz",
       "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE=",
       "dev": true
     },


### PR DESCRIPTION
### Problem

In the current implementation:

- Failure to schedule a task will terminate the workflow.
-- A Task scheduling can fail when failing to persist the task, or pushing the taskId to Task Queues.
- A task could remain stuck if the persistence layer and queuing layer doesn’t agree:
-- For eg: if the relevant message is lost in the Task queue.

### Solution

The process for scheduling a task would remain the same as now:

1. Task status is set as SCHEDULED, and persisted.
2. Task is pushed to the Task queue.

In this PR, if Step 1 fails, we'll continue to terminate workflows (which is the existing behavior). If Step 2 fails, The next run of sweeper fixes the inconsistency by verifying the state of the message in the Queue. I.e if the Task is in SCHEDULED state, but a relevant message is not found in the Queue (including those messages in invisible state), a new message will be pushed.

### Major additions

- A new WorkflowRepairService has been introduced, that checks non-terminal workflow and task state with message in queue, and performs necessary actions as required. This will be called from Sweeper service.
- `/consistency/verifyAndRepair/{workflowId}` is added to AdminResource, which verifies and pushes if workflow and tasks have relevant messages in the queue.