### PR TITLE
JSON_JQ_TRANSFORM - complete system task development

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/TaskType.java
@@ -20,7 +20,8 @@ public enum TaskType {
     LAMBDA(true),
     EXCLUSIVE_JOIN(true),
     TERMINATE(true),
-    KAFKA_PUBLISH(true);
+    KAFKA_PUBLISH(true),
+    JSON_JQ_TRANSFORM(true);
 
     /**
      * TaskType constants representing each of the possible enumeration values.
@@ -43,6 +44,7 @@ public enum TaskType {
     public static final String TASK_TYPE_EXCLUSIVE_JOIN = "EXCLUSIVE_JOIN";
     public static final String TASK_TYPE_TERMINATE = "TERMINATE";
     public static final String TASK_TYPE_KAFKA_PUBLISH = "KAFKA_PUBLISH";
+    public static final String TASK_TYPE_JSON_JQ_TRANSFORM = "JSON_JQ_TRANSFORM";
     
     private boolean isSystemTask;
 

--- a/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/CoreModule.java
@@ -48,6 +48,7 @@ import com.netflix.conductor.core.execution.mapper.TerminateTaskMapper;
 import com.netflix.conductor.core.execution.mapper.UserDefinedTaskMapper;
 import com.netflix.conductor.core.execution.mapper.WaitTaskMapper;
 import com.netflix.conductor.core.execution.mapper.DoWhileTaskMapper;
+import com.netflix.conductor.core.execution.mapper.JsonJQTransformTaskMapper;
 import com.netflix.conductor.core.execution.tasks.Event;
 import com.netflix.conductor.core.execution.tasks.IsolatedTaskQueueProducer;
 import com.netflix.conductor.core.execution.tasks.Lambda;
@@ -76,6 +77,7 @@ import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_USER_DEFINED;
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_WAIT;
 import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_DO_WHILE;
+import static com.netflix.conductor.common.metadata.workflow.TaskType.TASK_TYPE_JSON_JQ_TRANSFORM;
 import static com.netflix.conductor.core.events.EventQueues.EVENT_QUEUE_PROVIDERS_QUALIFIER;
 /**
  * @author Viren
@@ -248,6 +250,14 @@ public class CoreModule extends AbstractModule {
     @Named(TASK_MAPPERS_QUALIFIER)
     public TaskMapper getKafkaPublishTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
         return new KafkaPublishTaskMapper(parametersUtils, metadataDAO);
+    }
+
+    @ProvidesIntoMap
+    @StringMapKey(TASK_TYPE_JSON_JQ_TRANSFORM)
+    @Singleton
+    @Named(TASK_MAPPERS_QUALIFIER)
+    public TaskMapper getJsonJQTransformTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+        return new JsonJQTransformTaskMapper(parametersUtils, metadataDAO);
     }
 
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.mapper;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ParametersUtils;
+import com.netflix.conductor.dao.MetadataDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class JsonJQTransformTaskMapper implements TaskMapper {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(JsonJQTransformTaskMapper.class);
+    private final ParametersUtils parametersUtils;
+    private final MetadataDAO metadataDAO;
+
+    public JsonJQTransformTaskMapper(ParametersUtils parametersUtils, MetadataDAO metadataDAO) {
+        this.parametersUtils = parametersUtils;
+        this.metadataDAO = metadataDAO;
+    }
+
+    @Override
+    public List<Task> getMappedTasks(TaskMapperContext taskMapperContext) {
+
+        LOGGER.debug("TaskMapperContext {} in JsonJQTransformTaskMapper", taskMapperContext);
+
+        WorkflowTask taskToSchedule = taskMapperContext.getTaskToSchedule();
+        Workflow workflowInstance = taskMapperContext.getWorkflowInstance();
+        String taskId = taskMapperContext.getTaskId();
+
+        TaskDef taskDefinition = Optional.ofNullable(taskMapperContext.getTaskDefinition())
+                .orElseGet(() -> Optional.ofNullable(metadataDAO.getTaskDef(taskToSchedule.getName()))
+                        .orElse(null));
+
+        Map<String, Object> taskInput = parametersUtils
+                .getTaskInputV2(taskToSchedule.getInputParameters(), workflowInstance, taskId, taskDefinition);
+
+        Task jsonJQTransformTask = new Task();
+        jsonJQTransformTask.setTaskType(taskToSchedule.getType());
+        jsonJQTransformTask.setTaskDefName(taskToSchedule.getName());
+        jsonJQTransformTask.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
+        jsonJQTransformTask.setWorkflowInstanceId(workflowInstance.getWorkflowId());
+        jsonJQTransformTask.setWorkflowType(workflowInstance.getWorkflowName());
+        jsonJQTransformTask.setCorrelationId(workflowInstance.getCorrelationId());
+        jsonJQTransformTask.setStartTime(System.currentTimeMillis());
+        jsonJQTransformTask.setScheduledTime(System.currentTimeMillis());
+        jsonJQTransformTask.setInputData(taskInput);
+        jsonJQTransformTask.setTaskId(taskId);
+        jsonJQTransformTask.setStatus(Task.Status.IN_PROGRESS);
+        jsonJQTransformTask.setWorkflowTask(taskToSchedule);
+        jsonJQTransformTask.setWorkflowPriority(workflowInstance.getPriority());
+
+        return Collections.singletonList(jsonJQTransformTask);
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
@@ -12,7 +12,6 @@ import com.netflix.conductor.dao.MetadataDAO;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
@@ -1,3 +1,18 @@
+ /*
+  * Copyright 2020 Netflix, Inc.
+  * <p>
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * <p>
+  * http://www.apache.org/licenses/LICENSE-2.0
+  * <p>
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package com.netflix.conductor.core.execution.mapper;
 
 import com.netflix.conductor.common.metadata.tasks.Task;

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
@@ -1,0 +1,107 @@
+package com.netflix.conductor.core.execution.mapper;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ParametersUtils;
+import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.dao.MetadataDAO;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+public class JsonJQTransformTaskMapperTest {
+
+    private ParametersUtils parametersUtils;
+    private MetadataDAO metadataDAO;
+
+    @Before
+    public void setUp() {
+        parametersUtils = mock(ParametersUtils.class);
+        metadataDAO = mock(MetadataDAO.class);
+    }
+
+    @Test
+    public void getMappedTasks() throws Exception {
+
+        WorkflowTask taskToSchedule = new WorkflowTask();
+        taskToSchedule.setName("json_jq_transform_task");
+        taskToSchedule.setType(TaskType.JSON_JQ_TRANSFORM.name());
+        taskToSchedule.setTaskDefinition(new TaskDef("json_jq_transform_task"));
+
+        Map<String, Object> taskInput = new HashMap<>();
+        taskInput.put("in1", new String[] {"a", "b"});
+        taskInput.put("in2", new String[] {"c", "d"});
+        taskInput.put("queryExpression", "{ out: (.in1 + .in2) }");
+        taskToSchedule.setInputParameters(taskInput);
+
+        String taskId = IDGenerator.generate();
+
+        WorkflowDef  wd = new WorkflowDef();
+        Workflow w = new Workflow();
+        w.setWorkflowDefinition(wd);
+
+        TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+                .withWorkflowDefinition(wd)
+                .withWorkflowInstance(w)
+                .withTaskDefinition(new TaskDef())
+                .withTaskToSchedule(taskToSchedule)
+                .withTaskInput(taskInput)
+                .withRetryCount(0)
+                .withTaskId(taskId)
+                .build();
+
+        List<Task> mappedTasks = new JsonJQTransformTaskMapper(parametersUtils, metadataDAO).getMappedTasks(taskMapperContext);
+
+        assertEquals(1, mappedTasks.size());
+        assertNotNull(mappedTasks);
+        assertEquals(TaskType.JSON_JQ_TRANSFORM.name(), mappedTasks.get(0).getTaskType());
+    }
+
+    @Test
+    public void getMappedTasks_WithoutTaskDef() throws Exception {
+        WorkflowTask taskToSchedule = new WorkflowTask();
+        taskToSchedule.setName("json_jq_transform_task");
+        taskToSchedule.setType(TaskType.JSON_JQ_TRANSFORM.name());
+
+        Map<String, Object> taskInput = new HashMap<>();
+        taskInput.put("in1", new String[] {"a", "b"});
+        taskInput.put("in2", new String[] {"c", "d"});
+        taskInput.put("queryExpression", "{ out: (.in1 + .in2) }");
+        taskToSchedule.setInputParameters(taskInput);
+
+        String taskId = IDGenerator.generate();
+
+        WorkflowDef  wd = new WorkflowDef();
+        Workflow w = new Workflow();
+        w.setWorkflowDefinition(wd);
+
+        TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+                .withWorkflowDefinition(wd)
+                .withWorkflowInstance(w)
+                .withTaskDefinition(null)
+                .withTaskToSchedule(taskToSchedule)
+                .withTaskInput(taskInput)
+                .withRetryCount(0)
+                .withTaskId(taskId)
+                .build();
+
+        List<Task> mappedTasks = new JsonJQTransformTaskMapper(parametersUtils, metadataDAO).getMappedTasks(taskMapperContext);
+
+        assertEquals(1, mappedTasks.size());
+        assertNotNull(mappedTasks);
+        assertEquals(TaskType.JSON_JQ_TRANSFORM.name(), mappedTasks.get(0).getTaskType());
+    }
+
+}

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -491,6 +491,50 @@ public class WorkflowTaskTypeConstraintTest {
         assertEquals(0, result.size());
     }
 
+    @Test
+    public void testWorkflowTaskTypeJSONJQTransform() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("JSON_JQ_TRANSFORM");
+        workflowTask.getInputParameters().put("queryExpression", ".");
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(0, result.size());
+   }
+
+    @Test
+    public void testWorkflowTaskTypeJSONJQTransformWithQueryParamMissing() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("JSON_JQ_TRANSFORM");
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(1, result.size());
+
+        List<String> validationErrors = new ArrayList<>();
+
+        result.forEach(e -> validationErrors.add(e.getMessage()));
+
+        assertTrue(validationErrors.contains("inputParameters.queryExpression field is required for taskType: JSON_JQ_TRANSFORM taskName: encode"));
+    }
+
+    @Test
+    public void testWorkflowTaskTypeJSONJQTransformWithQueryParamInTaskDef() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("JSON_JQ_TRANSFORM");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("encode");
+        taskDef.getInputTemplate().put("queryExpression", ".");
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(taskDef);
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(0, result.size());
+    }
+
     private List<String> getErrorMessages(WorkflowTask workflowTask) {
         Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
         List<String> validationErrors = new ArrayList<>();

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -709,7 +709,7 @@ For JQ playground go to https://jqplay.org/
 }
 ```
 
-In the example above the value of `jq_1.output.result` will be `{ "output": ["a","b","c","d"] }`
+In the example above the value of `jq_1.output.result` will be `{ "out": ["a","b","c","d"] }`
 
 The task output can then be referenced in downstream tasks like:
 `"${jq_1.output.result.out}"`

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -675,3 +675,42 @@ Do while task does NOT support domain or isolation group execution. Nesting of D
 ```
 If any of loopover task will be failed then do while task will be failed. In such case retry will start iteration from 1. TaskType SUB_WORKFLOW is not supported as a part of loopover task. Since loopover tasks will be executed in loop inside scope of parent do while task, crossing branching outside of DO_WHILE task will not be respected. Branching inside loopover task will be supported.
 In case of exception while evaluating loopCondition, do while task will be failed with FAILED_WITH_TERMINAL_ERROR.
+
+## JSON JQ Transform Task
+
+JSON JQ Transform task allows transforming a JSON input to another JSON structure using a query expression.
+
+The input for the query (`.`) will be the `inputParameters` of the task.
+
+For JQ playground go to https://jqplay.org/
+
+**Parameters:**
+
+|name|description|
+|---|---|
+|queryExpression|JQ query expression
+
+**Example**
+
+```json
+ {
+      "name": "jq_1",
+      "taskReferenceName": "jq_1",
+      "type": "JSON_JQ_TRANSFORM",
+      "inputParameters": {
+        "in1": {
+          "arr": [ "a", "b" ]
+        },
+        "in2": {
+          "arr": [ "c", "d" ]
+        },
+        "queryExpression": "{ out: (.in1.arr + .in2.arr) }"
+      }
+}
+```
+
+In the example above the value of `jq_1.output.result` will be `{ "output": ["a","b","c","d"] }`
+
+The task output can then be referenced in downstream tasks like:
+`"${jq_1.output.result.out}"`
+ 

--- a/test-harness/src/test/groovy/com/netflix/counductor/integration/test/JsonJQTransformTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/counductor/integration/test/JsonJQTransformTaskSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.counductor.integration.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.archaius.guice.ArchaiusModule
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.common.utils.JsonMapperProvider
+import com.netflix.conductor.contribs.json.JsonJqTransform
+import com.netflix.conductor.core.execution.WorkflowExecutor
+import com.netflix.conductor.service.ExecutionService
+import com.netflix.conductor.test.util.WorkflowTestUtil
+import com.netflix.conductor.tests.utils.TestModule
+import com.netflix.governator.guice.test.ModulesForTesting
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@ModulesForTesting([TestModule.class, ArchaiusModule.class])
+class JsonJQTransformTaskSpec extends Specification {
+
+    @Inject
+    ExecutionService workflowExecutionService
+
+    @Inject
+    WorkflowExecutor workflowExecutor
+
+    @Inject
+    WorkflowTestUtil workflowTestUtil
+
+    @Shared
+    ObjectMapper objectMapper = new JsonMapperProvider().get()
+
+    @Shared
+    def JSON_JQ_TRANSFORM_WF = 'test_json_jq_transform_wf'
+
+    def setup() {
+        // We do this to register the JSON JQ TRANSFORM task type as a system task since it's in the contrib module
+        new JsonJqTransform(objectMapper)
+
+        workflowTestUtil.registerWorkflows(
+            'simple_json_jq_transform_integration_test.json',
+        )
+    }
+
+    def cleanup() {
+        workflowTestUtil.clearWorkflows()
+    }
+
+    /**
+     * Given the following input JSON
+     * {
+     *   "in1": {
+     *     "array": [ "a", "b" ]
+     *   },
+     *   "in2": {
+     *     "array": [ "c", "d" ]
+     *   }
+     * }
+     * expect the workflow task to transform to following result:
+     * {
+     *     out: [ "a", "b", "c", "d" ]
+     * }
+     */
+    def "Test workflow with json jq transform task succeeds"() {
+        given: "workflow input"
+        def workflowInput = new HashMap()
+        workflowInput['in1'] = new HashMap()
+        workflowInput['in1']['array'] = ["a", "b"]
+        workflowInput['in2'] = new HashMap()
+        workflowInput['in2']['array'] = ["c", "d"]
+
+        when: "workflow which has the json jq transform task has started"
+        def workflowInstanceId = workflowExecutor.startWorkflow(JSON_JQ_TRANSFORM_WF, 1,
+                '', workflowInput, null, null, null)
+
+        then:"verify that the workflow and task are completed with expected output"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            tasks.size() == 1
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'JSON_JQ_TRANSFORM'
+            tasks[0].outputData as String == "[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]"
+        }
+    }
+
+    /**
+     * Given the following input JSON
+     * {
+     *   "in1": "a",
+     *   "in2": "b"
+     * }
+     * using the same query from the success test, jq will try to get in1['array']
+     * and fail since 'in1' is a string
+     */
+    def "Test workflow with json jq transform task fails"() {
+        given: "workflow input"
+        def workflowInput = new HashMap()
+        workflowInput['in1'] = "a"
+        workflowInput['in2'] = "b"
+
+        when: "workflow which has the json jq transform task has started"
+        def workflowInstanceId = workflowExecutor.startWorkflow(JSON_JQ_TRANSFORM_WF, 1,
+                '', workflowInput, null, null, null)
+
+        then:"verify that the workflow and task failed with expected error"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 1
+            tasks[0].status == Task.Status.FAILED
+            tasks[0].taskType == 'JSON_JQ_TRANSFORM'
+            tasks[0].reasonForIncompletion as String == "Cannot index string with string \"array\""
+        }
+    }
+
+}

--- a/test-harness/src/test/resources/simple_json_jq_transform_integration_test.json
+++ b/test-harness/src/test/resources/simple_json_jq_transform_integration_test.json
@@ -1,0 +1,29 @@
+{
+  "name" : "test_json_jq_transform_wf",
+  "version" : 1,
+  "tasks" : [ {
+    "name" : "jq",
+    "taskReferenceName" : "jq_1",
+    "inputParameters" : {
+      "input" : "${workflow.input}",
+      "queryExpression": ".input as $_ | { out: ($_.in1.array + $_.in2.array) }"
+    },
+    "type" : "JSON_JQ_TRANSFORM",
+    "decisionCases" : { },
+    "defaultCase" : [ ],
+    "forkTasks" : [ ],
+    "startDelay" : 0,
+    "joinOn" : [ ],
+    "optional" : false,
+    "defaultExclusiveJoinTask" : [ ],
+    "asyncComplete" : false,
+    "loopOver" : [ ]
+  } ],
+  "inputParameters" : [ ],
+  "outputParameters" : { },
+  "schemaVersion" : 2,
+  "restartable" : true,
+  "workflowStatusListenerEnabled" : false,
+  "timeoutPolicy" : "ALERT_ONLY",
+  "timeoutSeconds" : 0
+}


### PR DESCRIPTION
Complete JSON_JQ_TRANSFORM development

- [X] Add to `TaskType` enum
- [X] Create `TaskMapper` (& unit test)
- [X] Add mapper to `CoreModule`
- [X] Add constraint validation to required `queryExpression` input parameter (& unit test)
- [X] Add spock integration test 
- [X] Add new system task to docs

Since this change JSON_JQ_TRANSFORM will no longer require a task definition (optional)