### PR TITLE
Add support for long classpaths on Windows

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4'
+    id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
 }
 
 configurations.all {


### PR DESCRIPTION
Fix for windows gradle long classpath issue. Fixes JavaExec tasks that error out with message "CreateProcess error=206, The filename or extension is too long"

Related:
#817 