### PR TITLE
Fix/mysql workflow dao update / remove

### DIFF
--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLMetadataDAOTest.java
@@ -80,7 +80,7 @@ public class MySQLMetadataDAOTest {
         WorkflowDef found = dao.getWorkflowDef("test", 1).get();
         assertTrue(EqualsBuilder.reflectionEquals(def, found));
 
-        def.setVersion(2);
+        def.setVersion(3);
         dao.createWorkflowDef(def);
 
         all = dao.getAllWorkflowDefs();
@@ -92,13 +92,13 @@ public class MySQLMetadataDAOTest {
         found = dao.getLatestWorkflowDef(def.getName()).get();
         assertEquals(def.getName(), found.getName());
         assertEquals(def.getVersion(), found.getVersion());
-        assertEquals(2, found.getVersion());
+        assertEquals(3, found.getVersion());
 
         all = dao.getAllLatest();
         assertNotNull(all);
         assertEquals(1, all.size());
         assertEquals("test", all.get(0).getName());
-        assertEquals(2, all.get(0).getVersion());
+        assertEquals(3, all.get(0).getVersion());
 
         all = dao.getAllVersions(def.getName());
         assertNotNull(all);
@@ -106,7 +106,7 @@ public class MySQLMetadataDAOTest {
         assertEquals("test", all.get(0).getName());
         assertEquals("test", all.get(1).getName());
         assertEquals(1, all.get(0).getVersion());
-        assertEquals(2, all.get(1).getVersion());
+        assertEquals(3, all.get(1).getVersion());
 
         def.setDescription("updated");
         dao.updateWorkflowDef(def);
@@ -118,9 +118,28 @@ public class MySQLMetadataDAOTest {
         assertEquals(1, allnames.size());
         assertEquals(def.getName(), allnames.get(0));
 
-        dao.removeWorkflowDef("test", 1);
-        Optional<WorkflowDef> deleted = dao.getWorkflowDef("test", 1);
+        def.setVersion(2);
+        dao.createWorkflowDef(def);
+
+        found = dao.getLatestWorkflowDef(def.getName()).get();
+        assertEquals(def.getName(), found.getName());
+        assertEquals(3, found.getVersion());
+
+        dao.removeWorkflowDef("test", 3);
+        Optional<WorkflowDef> deleted = dao.getWorkflowDef("test", 3);
         assertFalse(deleted.isPresent());
+
+        found = dao.getLatestWorkflowDef(def.getName()).get();
+        assertEquals(def.getName(), found.getName());
+        assertEquals(2, found.getVersion());
+
+        dao.removeWorkflowDef("test", 1);
+        deleted = dao.getWorkflowDef("test", 1);
+        assertFalse(deleted.isPresent());
+
+        found = dao.getLatestWorkflowDef(def.getName()).get();
+        assertEquals(def.getName(), found.getName());
+        assertEquals(2, found.getVersion());
     }
 
     @Test

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresMetadataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresMetadataDAO.java
@@ -349,6 +349,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
      * Update the latest version for the workflow with name {@code WorkflowDef} to the version provided in {@literal version}.
      *
      * @param tx  The {@link Connection} to use for queries.
+     * @param name Workflow def name to update
      * @param version The new latest {@code version} value.
      */
     private void updateLatestVersion(Connection tx, String name, int version) {


### PR DESCRIPTION
Duplication of the fix for MySql based on problems discovered in our testing of v28.0 with Postgres:

- adding workflow for a given name but not in increasing version order does not work - workflow out of order will not get added to the database but will incorrectly cause the latest_version column in the db to be set to its version.

- removing workflow does not update latest_version column

The first problem can cause a workflow not found when trying to retrieve the latest version of the workflow via the API - i.e. version number is not supplied.

Reference original PR #1826 for Postgres fix for the same.