### PR TITLE
fix workerNamePrefix problem

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/automator/TaskPollExecutor.java
+++ b/client/src/main/java/com/netflix/conductor/client/automator/TaskPollExecutor.java
@@ -66,11 +66,9 @@ class TaskPollExecutor {
 
         LOGGER.info("Initialized the TaskPollExecutor with {} threads", threadCount);
 
-        AtomicInteger count = new AtomicInteger(0);
-
         this.executorService = Executors.newFixedThreadPool(threadCount,
             new BasicThreadFactory.Builder()
-                .namingPattern(workerNamePrefix + count.getAndIncrement())
+                .namingPattern(workerNamePrefix)
                 .uncaughtExceptionHandler(uncaughtExceptionHandler)
                 .build());
 

--- a/client/src/main/java/com/netflix/conductor/client/automator/TaskRunnerConfigurer.java
+++ b/client/src/main/java/com/netflix/conductor/client/automator/TaskRunnerConfigurer.java
@@ -66,7 +66,7 @@ public class TaskRunnerConfigurer {
      */
     public static class Builder {
 
-        private String workerNamePrefix = "workflow-worker-";
+        private String workerNamePrefix = "workflow-worker-%d";
         private int sleepWhenRetry = 500;
         private int updateRetryCount = 3;
         private int threadCount = -1;

--- a/client/src/test/java/com/netflix/conductor/client/automator/TaskPollExecutorTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/automator/TaskPollExecutorTest.java
@@ -52,13 +52,13 @@ public class TaskPollExecutorTest {
             throw new NoSuchMethodError();
         });
         TaskClient taskClient = Mockito.mock(TaskClient.class);
-        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-");
+        TaskPollExecutor taskPollExecutor = new TaskPollExecutor(null, taskClient, 1, 1, new HashMap<>(), "test-worker-%d");
 
         when(taskClient.pollTask(any(), any(), any())).thenReturn(testTask());
         when(taskClient.ack(any(), any())).thenReturn(true);
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
-                assertEquals("test-worker-0", Thread.currentThread().getName());
+                assertEquals("test-worker-1", Thread.currentThread().getName());
                 Object[] args = invocation.getArguments();
                 TaskResult result = (TaskResult) args[0];
                 assertEquals(TaskResult.Status.FAILED, result.getStatus());


### PR DESCRIPTION
the atomic count var is misused, Apache BasicThreadFactory will format the thread count to the thread name if the namingPattern is a regexp，maybe it's better to rename to workerNamePattern.