### PR TITLE
In processAllUnacks, change it so only the unacks from the past get reset

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
@@ -50,7 +50,7 @@ public class StartWorkflowRequest {
 	@ProtoField(id = 8)
 	@Min(value = 0, message = "priority: ${validatedValue} should be minimum {value}")
 	@Max(value = 99, message = "priority: ${validatedValue} should be maximum {value}")
-	private Integer priority;
+	private Integer priority = 0;
 
     public String getName() {
 		return name;

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -73,8 +73,9 @@ public class WorkflowServiceImpl implements WorkflowService {
      */
     @Service
     public String startWorkflow(StartWorkflowRequest startWorkflowRequest) {
-        return startWorkflow(startWorkflowRequest.getName(), startWorkflowRequest.getVersion(), startWorkflowRequest.getCorrelationId(), startWorkflowRequest.getInput(),
-                startWorkflowRequest.getExternalInputPayloadStoragePath(), startWorkflowRequest.getTaskToDomain(), startWorkflowRequest.getWorkflowDef());
+        return startWorkflow(startWorkflowRequest.getName(), startWorkflowRequest.getVersion(), startWorkflowRequest.getCorrelationId(),
+            startWorkflowRequest.getPriority(), startWorkflowRequest.getInput(), startWorkflowRequest.getExternalInputPayloadStoragePath(),
+            startWorkflowRequest.getTaskToDomain(), startWorkflowRequest.getWorkflowDef());
     }
 
     /**

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -78,6 +78,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "tasklog.elasticsearch.query.size";
     int ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE = 10;
 
+    String ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME = "workflow.elasticsearch.rest.client.connectionRequestTimeout.milliseconds";
+    int ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_DEFAULT_VALUE = -1;
+
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
     }
@@ -128,6 +131,11 @@ public interface ElasticSearchConfiguration extends Configuration {
 
     default String getEmbeddedSettingsFile() {
         return getProperty(EMBEDDED_SETTINGS_FILE_PROPERTY_NAME, EMBEDDED_SETTINGS_FILE_DEFAULT_VALUE);
+    }
+
+    default int getElasticsearchRestClientConnectionRequestTimeout() {
+        return getIntProperty(ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME,
+                ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_DEFAULT_VALUE);
     }
 
     default ElasticSearchInstanceType getElasticSearchInstanceType() {

--- a/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
@@ -19,6 +19,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 
 public class ElasticSearchRestClientProvider implements Provider<RestClient> {
     private final ElasticSearchConfiguration configuration;
@@ -30,7 +31,13 @@ public class ElasticSearchRestClientProvider implements Provider<RestClient> {
 
     @Override
     public RestClient get() {
-        return RestClient.builder(convertToHttpHosts(configuration.getURIs())).build();
+        RestClientBuilder restClientBuilder = RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+
+        if (configuration.getElasticsearchRestClientConnectionRequestTimeout() > 0) {
+            restClientBuilder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setConnectionRequestTimeout(configuration.getElasticsearchRestClientConnectionRequestTimeout()));
+        }
+
+        return restClientBuilder.build();
     }
 
     private HttpHost[] convertToHttpHosts(List<URI> hosts) {

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchConfiguration.java
@@ -78,6 +78,9 @@ public interface ElasticSearchConfiguration extends Configuration {
     String ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT = "tasklog.elasticsearch.query.size";
     int ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE = 10;
 
+    String ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME = "workflow.elasticsearch.rest.client.connectionRequestTimeout.milliseconds";
+    int ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_DEFAULT_VALUE = -1;
+
     default String getURL() {
         return getProperty(ELASTIC_SEARCH_URL_PROPERTY_NAME, ELASTIC_SEARCH_URL_DEFAULT_VALUE);
     }
@@ -180,5 +183,10 @@ public interface ElasticSearchConfiguration extends Configuration {
     default int getElasticSearchTasklogLimit() {
         return getIntProperty(ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT,
                 ELASTIC_SEARCH_TASK_LOG_RESULT_LIMIT_DEFAULT_VALUE);
+    }
+
+    default int getElasticsearchRestClientConnectionRequestTimeout() {
+        return getIntProperty(ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME,
+                ELASTIC_SEARCH_REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_DEFAULT_VALUE);
     }
 }

--- a/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/elasticsearch/ElasticSearchRestClientProvider.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.elasticsearch;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -32,7 +33,14 @@ public class ElasticSearchRestClientProvider implements Provider<RestClient> {
 
     @Override
     public RestClient get() {
-        return RestClient.builder(convertToHttpHosts(configuration.getURIs())).build();
+        RestClientBuilder restClientBuilder = RestClient.builder(convertToHttpHosts(configuration.getURIs()));
+
+        if (configuration.getElasticsearchRestClientConnectionRequestTimeout() > 0) {
+            restClientBuilder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setConnectionRequestTimeout(configuration.getElasticsearchRestClientConnectionRequestTimeout()));
+        }
+
+        return restClientBuilder.build();
+
     }
 
     private HttpHost[] convertToHttpHosts(List<URI> hosts) {

--- a/grpc-server/src/main/java/com/netflix/conductor/grpc/server/service/WorkflowServiceImpl.java
+++ b/grpc-server/src/main/java/com/netflix/conductor/grpc/server/service/WorkflowServiceImpl.java
@@ -62,6 +62,7 @@ public class WorkflowServiceImpl extends WorkflowServiceGrpc.WorkflowServiceImpl
         try {
             String id = workflowService.startWorkflow(pbRequest.getName(),
                     GRPC_HELPER.optional(request.getVersion()),request.getCorrelationId(),
+                    request.getPriority(),
                     request.getInput(),
                     request.getExternalInputPayloadStoragePath(),
                     request.getTaskToDomain(), request.getWorkflowDef());

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -160,13 +160,13 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
         logger.trace("processAllUnacks started");
 
 
-        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND TIMESTAMPADD(SECOND,60,CURRENT_TIMESTAMP) > deliver_on";
+        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND TIMESTAMPADD(SECOND,-60,CURRENT_TIMESTAMP) > deliver_on";
         executeWithTransaction(PROCESS_ALL_UNACKS, Query::executeUpdate);
     }
 
     @Override
     public void processUnacks(String queueName) {
-        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND TIMESTAMPADD(SECOND,60,CURRENT_TIMESTAMP)  > deliver_on";
+        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND TIMESTAMPADD(SECOND,-60,CURRENT_TIMESTAMP)  > deliver_on";
         executeWithTransaction(PROCESS_UNACKS, q -> q.addParameter(queueName).executeUpdate());
     }
 

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -171,13 +171,13 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         logger.trace("processAllUnacks started");
 
-        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND (current_timestamp + (60 ||' seconds')::interval) > deliver_on";
+        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND (current_timestamp - (60 ||' seconds')::interval) > deliver_on";
         executeWithTransaction(PROCESS_ALL_UNACKS, Query::executeUpdate);
     }
 
     @Override
     public void processUnacks(String queueName) {
-        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND (current_timestamp + (60 ||' seconds')::interval)  > deliver_on";
+        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND (current_timestamp - (60 ||' seconds')::interval)  > deliver_on";
         executeWithTransaction(PROCESS_UNACKS, q -> q.addParameter(queueName).executeUpdate());
     }
 


### PR DESCRIPTION
This is a solution for Issue #1859. Tasks that were popped had their popped status set to false before they were acked so a future poll could get the same task. This PR only resets the popped flag for tasks that were popped in the past by a minute, not in the future by a minute.