### PR TITLE
In processAllUnacks, change it so only the unacks from the past get reset

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLQueueDAO.java
@@ -160,13 +160,13 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
         logger.trace("processAllUnacks started");
 
 
-        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND TIMESTAMPADD(SECOND,60,CURRENT_TIMESTAMP) > deliver_on";
+        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND TIMESTAMPADD(SECOND,-60,CURRENT_TIMESTAMP) > deliver_on";
         executeWithTransaction(PROCESS_ALL_UNACKS, Query::executeUpdate);
     }
 
     @Override
     public void processUnacks(String queueName) {
-        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND TIMESTAMPADD(SECOND,60,CURRENT_TIMESTAMP)  > deliver_on";
+        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND TIMESTAMPADD(SECOND,-60,CURRENT_TIMESTAMP)  > deliver_on";
         executeWithTransaction(PROCESS_UNACKS, q -> q.addParameter(queueName).executeUpdate());
     }
 

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -310,7 +310,6 @@ public class MySQLQueueDAOTest {
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
 //		assertEquals(size.longValue(), count - unackedCount);
-		assertEquals(size.longValue(), 2);
 		assertEquals(size.longValue(), 3);
 		assertEquals(size.longValue(), 4);
 		assertEquals(size.longValue(), 5);

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), 5);
+		assertEquals(size.longValue(), 6);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -310,7 +310,6 @@ public class MySQLQueueDAOTest {
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
 //		assertEquals(size.longValue(), count - unackedCount);
-		assertEquals(size.longValue(), 4);
 		assertEquals(size.longValue(), 5);
 		assertEquals(size.longValue(), 6);
 		assertEquals(size.longValue(), 7);

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,12 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-//		assertEquals(size.longValue(), count - unackedCount);
-		assertEquals(size.longValue(), 5);
-		assertEquals(size.longValue(), 6);
-		assertEquals(size.longValue(), 7);
-		assertEquals(size.longValue(), 8);
-		assertEquals(size.longValue(), 9);
-		assertEquals(size.longValue(), 10);
+		assertEquals(size.longValue(), count - unackedCount - 1);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - 1);
+		assertEquals(size.longValue(), 0);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,7 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), 0);
+System.out.println("****************** size: " + size);		
+		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -310,7 +310,6 @@ public class MySQLQueueDAOTest {
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
 //		assertEquals(size.longValue(), count - unackedCount);
-		assertEquals(size.longValue(), 3);
 		assertEquals(size.longValue(), 4);
 		assertEquals(size.longValue(), 5);
 		assertEquals(size.longValue(), 6);

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -310,7 +310,6 @@ public class MySQLQueueDAOTest {
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
 //		assertEquals(size.longValue(), count - unackedCount);
-		assertEquals(size.longValue(), 1);
 		assertEquals(size.longValue(), 2);
 		assertEquals(size.longValue(), 3);
 		assertEquals(size.longValue(), 4);

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,16 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - unackedCount);
+//		assertEquals(size.longValue(), count - unackedCount);
+		assertEquals(size.longValue(), 1);
+		assertEquals(size.longValue(), 2);
+		assertEquals(size.longValue(), 3);
+		assertEquals(size.longValue(), 4);
+		assertEquals(size.longValue(), 5);
+		assertEquals(size.longValue(), 6);
+		assertEquals(size.longValue(), 7);
+		assertEquals(size.longValue(), 8);
+		assertEquals(size.longValue(), 9);
+		assertEquals(size.longValue(), 10);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), 6);
+		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,7 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-System.out.println("****************** size: " + size);		
 		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -309,6 +309,6 @@ public class MySQLQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - unackedCount - 1);
+		assertEquals(size.longValue(), 5);
 	}
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLQueueDAOTest.java
@@ -301,11 +301,11 @@ public class MySQLQueueDAOTest {
 		Map<String, Map<String, Map<String, Long>>> details = dao.queuesDetailVerbose();
 		uacked = details.get(queueName).get("a").get("uacked");
 		assertNotNull(uacked);
-		assertEquals("There should be no unacked messages", uacked.longValue(), 0);
+		assertEquals("The messages that were polled should be unacked still", uacked.longValue(), unackedCount - 1);
 
 		Long otherUacked = details.get(otherQueueName).get("a").get("uacked");
 		assertNotNull(otherUacked);
-		assertEquals("Other queue should have unacked messages", otherUacked.longValue(), count);
+		assertEquals("Other queue should have all unacked messages", otherUacked.longValue(), count);
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -171,13 +171,13 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         logger.trace("processAllUnacks started");
 
-        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND (current_timestamp + (60 ||' seconds')::interval) > deliver_on";
+        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND (current_timestamp - (60 ||' seconds')::interval) > deliver_on";
         executeWithTransaction(PROCESS_ALL_UNACKS, Query::executeUpdate);
     }
 
     @Override
     public void processUnacks(String queueName) {
-        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND (current_timestamp + (60 ||' seconds')::interval)  > deliver_on";
+        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND (current_timestamp - (60 ||' seconds')::interval)  > deliver_on";
         executeWithTransaction(PROCESS_UNACKS, q -> q.addParameter(queueName).executeUpdate());
     }
 

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -313,11 +313,11 @@ public class PostgresQueueDAOTest {
 		Map<String, Map<String, Map<String, Long>>> details = dao.queuesDetailVerbose();
 		uacked = details.get(queueName).get("a").get("uacked");
 		assertNotNull(uacked);
-		assertEquals("There should be no unacked messages", uacked.longValue(), 0);
+		assertEquals("The messages that were polled should be unacked still", uacked.longValue(), unackedCount - 1);
 
 		Long otherUacked = details.get(otherQueueName).get("a").get("uacked");
 		assertNotNull(otherUacked);
-		assertEquals("Other queue should have unacked messages", otherUacked.longValue(), count);
+		assertEquals("Other queue should have all unacked messages", otherUacked.longValue(), count);
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,6 +321,6 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - 1);
+		assertEquals(size.longValue(), 0);
 	}
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,6 +321,6 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - unackedCount - 1);
+		assertEquals(size.longValue(), 6);
 	}
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,6 +321,6 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), 6);
+		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,6 +321,7 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), 0);
+System.out.println("****************** size: " + size);		
+		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,7 +321,6 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-System.out.println("****************** size: " + size);		
 		assertEquals(size.longValue(), count - unackedCount);
 	}
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresQueueDAOTest.java
@@ -321,6 +321,6 @@ public class PostgresQueueDAOTest {
 
 		Long size = dao.queuesDetail().get(queueName);
 		assertNotNull(size);
-		assertEquals(size.longValue(), count - unackedCount);
+		assertEquals(size.longValue(), count - unackedCount - 1);
 	}
 }


### PR DESCRIPTION
This is a solution for Issue #1859. Tasks that were popped had their popped status set to false before they were acked so a future poll could get the same task. This PR only resets the popped flag for tasks that were popped in the past by a minute, not in the future by a minute.