### PR TITLE
simplify how we get PollData for all task types at once

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/orchestration/ExecutionDAOFacade.java
@@ -398,6 +398,10 @@ public class ExecutionDAOFacade {
         return pollDataDAO.getPollData(taskName);
     }
 
+    public List<PollData> getAllPollData() {
+        return pollDataDAO.getAllPollData();
+    }
+
     public PollData getTaskPollDataByDomain(String taskName, String domain) {
         try {
             return pollDataDAO.getPollData(taskName, domain);

--- a/core/src/main/java/com/netflix/conductor/dao/PollDataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/PollDataDAO.java
@@ -48,4 +48,13 @@ public interface PollDataDAO {
      * @return the {@link PollData} for the given task queue in all domains
      */
     List<PollData> getPollData(String taskDefName);
+
+    /**
+     * Retrieve the {@link PollData} for all task types
+     *
+     * @return the {@link PollData} for all task types
+     */
+    default List<PollData> getAllPollData() {
+    	throw new UnsupportedOperationException("The selected PollDataDAO (" + this.getClass().getSimpleName() + ") does not implement the getAllPollData() method");
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -196,19 +196,22 @@ public class ExecutionService {
 	}
 
 	public List<PollData> getAllPollData() {
-		Map<String, Long> queueSizes = queueDAO.queuesDetail();
-		List<PollData> allPollData = new ArrayList<>();
-		queueSizes.keySet().forEach(k -> {
-			try {
-				if(!k.contains(QueueUtils.DOMAIN_SEPARATOR)){
-					allPollData.addAll(getPollData(QueueUtils.getQueueNameWithoutDomain(k)));
+		try {
+			return executionDAOFacade.getAllPollData();
+		} catch(UnsupportedOperationException uoe) {
+			List<PollData> allPollData = new ArrayList<>();
+			Map<String, Long> queueSizes = queueDAO.queuesDetail();
+			queueSizes.keySet().forEach(k -> {
+				try {
+					if(!k.contains(QueueUtils.DOMAIN_SEPARATOR)){
+						allPollData.addAll(getPollData(QueueUtils.getQueueNameWithoutDomain(k)));
+					}
+				} catch (Exception e) {
+					logger.error("Unable to fetch all poll data!", e);
 				}
-			} catch (Exception e) {
-				logger.error("Unable to fetch all poll data!", e);
-			}
-		});
-		return allPollData;
-
+			});
+			return allPollData;
+		}
 	}
 
 	public void terminateWorkflow(String workflowId, String reason) {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/dao/mysql/MySQLExecutionDAO.java
@@ -30,7 +30,11 @@ import com.netflix.conductor.metrics.Monitors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.sql.DataSource;
+
+import static com.netflix.conductor.core.execution.ApplicationException.Code.BACKEND_ERROR;
+
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -471,6 +475,24 @@ public class MySQLExecutionDAO extends MySQLBaseDAO implements ExecutionDAO, Rat
     public List<PollData> getPollData(String taskDefName) {
         Preconditions.checkNotNull(taskDefName, "taskDefName name cannot be null");
         return readAllPollData(taskDefName);
+    }
+
+    @Override
+    public List<PollData> getAllPollData() {
+        try(Connection tx = dataSource.getConnection()) {
+            boolean previousAutoCommitMode = tx.getAutoCommit();
+            tx.setAutoCommit(true);
+            try {
+                String GET_ALL_POLL_DATA = "SELECT json_data FROM poll_data ORDER BY queue_name";
+                return query(tx, GET_ALL_POLL_DATA, q -> q.executeAndFetch(PollData.class));
+            } catch (Throwable th) {
+                throw new ApplicationException(BACKEND_ERROR, th.getMessage(), th);
+            } finally {
+                tx.setAutoCommit(previousAutoCommitMode);
+            }
+        } catch (SQLException ex) {
+            throw new ApplicationException(BACKEND_ERROR, ex.getMessage(), ex);
+        }
     }
 
     private List<Task> getTasks(Connection connection, List<String> taskIds) {


### PR DESCRIPTION
The /tasks/queue/polldata/all endpoint has a very convoluted way of getting PollData for all task types at once. In our system with tons of polling, it causes that endpoint to be very slow. This PR greatly simplifies how we do the queries for MySQL and Postgres. Cassandra still does it the old way because I have no way of testing it with that database.