### PR TITLE
Fix the binding for ServerModule to the root SystemProps Configuration

### DIFF
--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -24,6 +24,10 @@ workflow.namespace.queue.prefix=conductor_queues
 # No. of threads allocated to dyno-queues (optional)
 queues.dynomite.threads=10
 
+# By default with dynomite, we want the repairservice enabled
+workflow.repairservice.enabled=true
+
+
 # Non-quorum port used to connect to local redis.  Used by dyno-queues.
 # When using redis directly, set this to the same port as redis server
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -27,6 +27,9 @@ workflow.namespace.queue.prefix=conductor_queues
 # No. of threads allocated to dyno-queues (optional)
 queues.dynomite.threads=10
 
+# By default with dynomite, we want the repairservice enabled
+workflow.repairservice.enabled=true
+
 # Non-quorum port used to connect to local redis.  Used by dyno-queues.
 # When using redis directly, set this to the same port as redis server
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.

--- a/docker/serverAndUI/config/config-local.properties
+++ b/docker/serverAndUI/config/config-local.properties
@@ -20,6 +20,10 @@ workflow.namespace.queue.prefix=conductor_queues
 # No. of threads allocated to dyno-queues (optional)
 queues.dynomite.threads=10
 
+# By default with dynomite, we want the repairservice enabled
+workflow.repairservice.enabled=true
+
+
 # Non-quorum port used to connect to local redis.  Used by dyno-queues.
 # When using redis directly, set this to the same port as redis server
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.

--- a/docker/serverAndUI/config/config.properties
+++ b/docker/serverAndUI/config/config.properties
@@ -23,6 +23,10 @@ workflow.namespace.queue.prefix=conductor_queues
 # No. of threads allocated to dyno-queues (optional)
 queues.dynomite.threads=10
 
+# By default with dynomite, we want the repairservice enabled
+workflow.repairservice.enabled=true
+
+
 # Non-quorum port used to connect to local redis.  Used by dyno-queues.
 # When using redis directly, set this to the same port as redis server
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.

--- a/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
@@ -77,8 +77,9 @@ public interface DynomiteConfiguration extends Configuration {
 
     /**
      * WorkflowRepairService is enabled by default for DynoQueues, since this queue receipe supports getMessage feature.
-     * @return
+     * @return true
      */
+    @Override
     default boolean isWorkflowRepairServiceEnabled() {
         return true;
     }

--- a/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dyno/DynomiteConfiguration.java
@@ -74,13 +74,4 @@ public interface DynomiteConfiguration extends Configuration {
 
         return prefix;
     }
-
-    /**
-     * WorkflowRepairService is enabled by default for DynoQueues, since this queue receipe supports getMessage feature.
-     * @return true
-     */
-    @Override
-    default boolean isWorkflowRepairServiceEnabled() {
-        return true;
-    }
 }

--- a/server/src/main/java/com/netflix/conductor/bootstrap/BootstrapModule.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/BootstrapModule.java
@@ -8,6 +8,5 @@ public class BootstrapModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Configuration.class).to(SystemPropertiesConfiguration.class);
-        bind(ModulesProvider.class);
     }
 }

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -19,6 +19,7 @@ import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.conductor.annotations.Service;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.CoreModule;
+import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
 import com.netflix.conductor.core.config.ValidationModule;
 import com.netflix.conductor.core.execution.WorkflowSweeper;
 import com.netflix.conductor.dyno.SystemPropertiesDynomiteConfiguration;
@@ -46,7 +47,7 @@ public class ServerModule extends AbstractModule {
         install(new GRPCModule());
 
         bindInterceptor(Matchers.any(), Matchers.annotatedWith(Service.class), new ServiceInterceptor(getProvider(Validator.class)));
-        bind(Configuration.class).to(SystemPropertiesDynomiteConfiguration.class);
+        bind(Configuration.class).to(SystemPropertiesConfiguration.class);
         bind(ExecutorService.class).toProvider(ExecutorServiceProvider.class).in(Scopes.SINGLETON);
         bind(WorkflowSweeper.class).asEagerSingleton();
         bind(WorkflowMonitor.class).asEagerSingleton();

--- a/server/src/main/java/com/netflix/conductor/server/ServerModule.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerModule.java
@@ -47,7 +47,7 @@ public class ServerModule extends AbstractModule {
         install(new GRPCModule());
 
         bindInterceptor(Matchers.any(), Matchers.annotatedWith(Service.class), new ServiceInterceptor(getProvider(Validator.class)));
-        bind(Configuration.class).to(SystemPropertiesConfiguration.class);
+        bind(Configuration.class).to(SystemPropertiesConfiguration.class).in(Scopes.SINGLETON);
         bind(ExecutorService.class).toProvider(ExecutorServiceProvider.class).in(Scopes.SINGLETON);
         bind(WorkflowSweeper.class).asEagerSingleton();
         bind(WorkflowMonitor.class).asEagerSingleton();

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -27,6 +27,10 @@ workflow.namespace.queue.prefix=
 #no. of threads allocated to dyno-queues
 queues.dynomite.threads=10
 
+# By default with dynomite, we want the repairservice enabled
+workflow.repairservice.enabled=true
+
+
 #non-quorum port used to connect to local redis.  Used by dyno-queues
 queues.dynomite.nonQuorum.port=22122
 


### PR DESCRIPTION
I think this is an issue that has always existed, but hasn't mattered until now since the `DynomiteConfiguration` is now directly overriding the default behavior of `SystemPropertiesConfiguration`. 

The new change to repair workflows is supposed to default to false, but currently it's always true because all configurations were being set to `SystemPropertiesDynomiteConfiguration`. 

I think that this change is what the intention was, and now makes the default actually be false. 

**NOTE:** This tries to make the property set to true by default in the various pre-existing config properties. But, this setting needs to be only controlled by one of these system properties to work correctly.

I think this was made recently by @kishorebanala 
