### PR TITLE
Mark parent workflow as TERMINATED instead of FAILED, when…

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -391,7 +391,18 @@ public class DeciderService {
             if (workflowTask != null && workflowTask.isOptional()) {
                 return Optional.empty();
             }
-            WorkflowStatus status = task.getStatus().equals(TIMED_OUT) ? WorkflowStatus.TIMED_OUT : WorkflowStatus.FAILED;
+            WorkflowStatus status;
+            switch (task.getStatus()) {
+                case CANCELED:
+                    status = WorkflowStatus.TERMINATED;
+                    break;
+                case TIMED_OUT:
+                    status = WorkflowStatus.TIMED_OUT;
+                    break;
+                default:
+                    status = WorkflowStatus.FAILED;
+                    break;
+            }
             updateWorkflowOutput(workflow, task);
             throw new TerminateWorkflowException(task.getReasonForIncompletion(), status, task);
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -919,14 +919,14 @@ public class WorkflowExecutor {
         taskResult.getLogs().forEach(taskExecLog -> taskExecLog.setTaskId(task.getTaskId()));
         executionDAOFacade.addTaskExecLog(taskResult.getLogs());
 
-        decide(workflowId);
-
         if (task.getStatus().isTerminal()) {
             long duration = getTaskDuration(0, task);
             long lastDuration = task.getEndTime() - task.getStartTime();
             Monitors.recordTaskExecutionTime(task.getTaskDefName(), duration, true, task.getStatus());
             Monitors.recordTaskExecutionTime(task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
+
+        decide(workflowId);
     }
 
     public Task getTask(String taskId) {
@@ -1686,7 +1686,7 @@ public class WorkflowExecutor {
             }
         } else {
             // On workflow retry or restart..
-            if (StringUtils.isBlank(parentDef.getFailureWorkflow()) && parentWorkflow.getStatus().isTerminal() && subWorkflowTask.getStatus().isTerminal()) {
+            if (parentWorkflow.getStatus().isTerminal() && subWorkflowTask.getStatus().isTerminal()) {
                 LOGGER.debug("Subworkflow: {} is {}, resetting failed parent workflow: {}, and Subworkflow task: {} status to IN_PROGRESS",
                         subWorkflow.getWorkflowId(), subWorkflow.getStatus().name(), parentWorkflow.getWorkflowId(), subWorkflow.getParentWorkflowTaskId());
                 subWorkflowTask.setStatus(IN_PROGRESS);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -115,7 +115,7 @@ public class SubWorkflow extends WorkflowSystemTask {
 
 			// Set task status based on current sub-workflow status, as the status can change in recursion by the time we update here.
 			Workflow subWorkflow = provider.getWorkflow(subWorkflowId, false);
-			updateTaskStatus(subWorkflow.getStatus(), task);
+			updateTaskStatus(subWorkflow, task);
 		} catch (Exception e) {
 			task.setStatus(Status.FAILED);
 			task.setReasonForIncompletion(e.getMessage());
@@ -140,10 +140,8 @@ public class SubWorkflow extends WorkflowSystemTask {
 		} else {
 			task.getOutputData().putAll(subWorkflow.getOutput());
 		}
-		if (!subWorkflowStatus.isSuccessful()) {
-			task.setReasonForIncompletion(subWorkflow.getReasonForIncompletion());
-		}
-		updateTaskStatus(subWorkflowStatus, task);
+
+		updateTaskStatus(subWorkflow, task);
 		return true;
 	}
 
@@ -175,7 +173,8 @@ public class SubWorkflow extends WorkflowSystemTask {
         return true;
     }
 
-	private void updateTaskStatus(WorkflowStatus status, Task task) {
+	private void updateTaskStatus(Workflow subworkflow, Task task) {
+    	WorkflowStatus status = subworkflow.getStatus();
 		switch (status) {
 			case RUNNING:
 			case PAUSED:
@@ -185,14 +184,22 @@ public class SubWorkflow extends WorkflowSystemTask {
 				task.setStatus(Status.COMPLETED);
 				break;
 			case FAILED:
-			case TERMINATED:
 				task.setStatus(Status.FAILED);
+				task.setReasonForIncompletion(subworkflow.getReasonForIncompletion());
+				break;
+			case TERMINATED:
+				task.setStatus(Status.CANCELED);
+				task.setReasonForIncompletion(subworkflow.getReasonForIncompletion());
 				break;
 			case TIMED_OUT:
 				task.setStatus(Status.TIMED_OUT);
 				break;
 			default:
 				throw new ApplicationException(ApplicationException.Code.INTERNAL_ERROR, "Subworkflow status does not conform to relevant task status.");
+		}
+
+		if (status.isTerminal() && !status.isSuccessful()) {
+			task.setReasonForIncompletion(subworkflow.getReasonForIncompletion());
 		}
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -185,11 +185,9 @@ public class SubWorkflow extends WorkflowSystemTask {
 				break;
 			case FAILED:
 				task.setStatus(Status.FAILED);
-				task.setReasonForIncompletion(subworkflow.getReasonForIncompletion());
 				break;
 			case TERMINATED:
 				task.setStatus(Status.CANCELED);
-				task.setReasonForIncompletion(subworkflow.getReasonForIncompletion());
 				break;
 			case TIMED_OUT:
 				task.setStatus(Status.TIMED_OUT);

--- a/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
@@ -66,8 +66,9 @@ public class AdminServiceImpl implements AdminService {
         this.version = "UNKNOWN";
         this.buildDate = "UNKNOWN";
 
-        try {
+        try (
             InputStream propertiesIs = this.getClass().getClassLoader().getResourceAsStream("META-INF/conductor-core.properties");
+        ) {
             Properties prop = new Properties();
             prop.load(propertiesIs);
             this.version = prop.getProperty("Implementation-Version");

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
@@ -63,7 +63,7 @@ public class TestSubWorkflow {
         workflow.setStatus(Workflow.WorkflowStatus.TERMINATED);
         subWorkflow.start(workflowInstance, task, workflowExecutor);
         assertEquals("workflow_1", task.getSubWorkflowId());
-        assertEquals(Task.Status.FAILED, task.getStatus());
+        assertEquals(Task.Status.CANCELED, task.getStatus());
 
         workflow.setStatus(Workflow.WorkflowStatus.COMPLETED);
         subWorkflow.start(workflowInstance, task, workflowExecutor);
@@ -217,7 +217,7 @@ public class TestSubWorkflow {
         subWorkflowInstance.setStatus(Workflow.WorkflowStatus.TERMINATED);
         subWorkflowInstance.setReasonForIncompletion("unit3");
         assertTrue(subWorkflow.execute(workflowInstance, task, workflowExecutor));
-        assertEquals(Task.Status.FAILED, task.getStatus());
+        assertEquals(Task.Status.CANCELED, task.getStatus());
         assertEquals("unit3", task.getReasonForIncompletion());
     }
 

--- a/docs/docs/metrics/server.md
+++ b/docs/docs/metrics/server.md
@@ -135,6 +135,7 @@ Another example of metrics collection uses: log4j syslog appender -> fluentd -> 
 
 In this case, a specific log4j properties file needs to be used so that metrics are pushed into a syslog channel:
 
+```
     log4j.rootLogger=INFO,console,file
     
     log4j.appender.console=org.apache.log4j.ConsoleAppender
@@ -157,9 +158,11 @@ In this case, a specific log4j properties file needs to be used so that metrics 
     
     log4j.logger.ConductorMetrics=INFO,console,server
     log4j.additivity.ConductorMetrics=false
+```
 
 And on the fluentd side you need following configuration:
 
+```
     <source>
       @type prometheus
     </source>
@@ -217,7 +220,8 @@ And on the fluentd side you need following configuration:
     <match **>
       @type stdout
     </match>
-    
+```
+
 With above configuration, fluentd will:
 - Listen to raw metrics on 0.0.0.0:5170
 - Collect only workflow_execution TIMER metrics


### PR DESCRIPTION
… a subworkflow is terminated. 
Other refactoring and cleanup.