### PR TITLE
Add mandatory `ownerEmail` json property in example doc

### DIFF
--- a/docs/docs/labs/beginner.md
+++ b/docs/docs/labs/beginner.md
@@ -262,6 +262,7 @@ curl -X POST \
     "description": "Adds Netflix Identation to video files.",
     "version": 2,
     "schemaVersion": 2,
+    "ownerEmail": "type your email here",
     "tasks": [
     	{
     		"name": "verify_if_idents_are_added",


### PR DESCRIPTION
In [Create workflow definition](https://netflix.github.io/conductor/labs/beginner/#creating-workflow-definition) JSON example mandatory `ownerEmail` property is missing