### PR TITLE
Python client - missing mandatory logs attribute

### DIFF
--- a/client/python/conductor/ConductorWorker.py
+++ b/client/python/conductor/ConductorWorker.py
@@ -129,7 +129,7 @@ class ConductorWorker:
 
 def exc(taskType, inputData, startTime, retryCount, status, callbackAfterSeconds, pollCount):
     print('Executing the function')
-    return {'status': 'COMPLETED', 'output': {}}
+    return {'status': 'COMPLETED', 'output': {}, 'logs': []}
 
 
 def main():


### PR DESCRIPTION
Have added the mandatory **_logs_** attribute into response format