### PR TITLE
Fix bug in unique task reference name validation

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/constraints/TaskReferenceNameUniqueConstraint.java
+++ b/common/src/main/java/com/netflix/conductor/common/constraints/TaskReferenceNameUniqueConstraint.java
@@ -64,7 +64,7 @@ public @interface TaskReferenceNameUniqueConstraint {
 
             //check if taskReferenceNames are unique across tasks or not
             HashMap<String, Integer> taskReferenceMap = new HashMap<>();
-            for (WorkflowTask workflowTask : workflowDef.getTasks()) {
+            for (WorkflowTask workflowTask : workflowDef.collectTasks()) {
                 if (taskReferenceMap.containsKey(workflowTask.getTaskReferenceName())) {
                     String message = String.format("taskReferenceName: %s should be unique across tasks for a given workflowDefinition: %s",
                             workflowTask.getTaskReferenceName(), workflowDef.getName());


### PR DESCRIPTION
We hit an issue where I was expecting a validation error on workflow creation, but didnt get one. We had some tasks lower down some decision trees/forks that had the same taskReferenceName...... which shouldnt be allowed, but was.

The problem was that the Validation was just doing getTasks(), but really you need to be doing collectTasks().

Verified we get the correct validation error now.