### PR TITLE
Bump elasticsearch client to 6.8.x

### DIFF
--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -175,7 +175,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -353,7 +353,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -531,7 +531,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -699,7 +699,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -867,7 +867,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1055,7 +1055,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1243,7 +1243,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1431,7 +1431,7 @@
             "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.868",
+            "locked": "1.11.893",
             "requested": "latest.release"
         },
         "com.fasterxml.jackson.core:jackson-core": {

--- a/es6-persistence/dependencies.lock
+++ b/es6-persistence/dependencies.lock
@@ -272,20 +272,20 @@
             "requested": "2.9.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -303,20 +303,20 @@
     },
     "compileOnly": {
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         }
     },
     "default": {
@@ -760,20 +760,20 @@
     },
     "shadow": {
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         }
     },
     "testCompile": {
@@ -914,20 +914,20 @@
             "requested": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1089,20 +1089,20 @@
             "requested": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1264,20 +1264,20 @@
             "requested": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1439,20 +1439,20 @@
             "requested": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.5.1",
-            "requested": "6.5.1"
+            "locked": "6.8.12",
+            "requested": "6.8.12"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -10,7 +10,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -456,7 +456,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -902,7 +902,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -1348,7 +1348,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -1864,7 +1864,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -2310,7 +2310,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -2756,7 +2756,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -3202,7 +3202,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -3656,7 +3656,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -4110,7 +4110,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -4564,7 +4564,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -14,7 +14,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.amazonaws:aws-java-sdk-s3": {
             "firstLevelTransitive": [
@@ -26,7 +26,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -595,7 +595,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.amazonaws:aws-java-sdk-s3": {
             "firstLevelTransitive": [
@@ -607,7 +607,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -1176,7 +1176,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.amazonaws:aws-java-sdk-s3": {
             "firstLevelTransitive": [
@@ -1188,7 +1188,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [
@@ -1757,7 +1757,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.amazonaws:aws-java-sdk-s3": {
             "firstLevelTransitive": [
@@ -1769,7 +1769,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
             ],
-            "locked": "1.11.868"
+            "locked": "1.11.893"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
             "firstLevelTransitive": [

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -13,7 +13,7 @@ ext {
     revDynoQueues = '2.0.13'
     revElasticSearch5 = '5.6.8'
     revElasticSearch5Client = '5.6.8'
-    revElasticSearch6 = '6.5.1'
+    revElasticSearch6 = '6.8.12'
     revEurekaClient = '1.8.7'
     revFlywayCore ='4.0.3'
     revGrpc = '1.14.+'


### PR DESCRIPTION
To allow using latest 6.8.x elasticsearch servers.
ES client should be backwards compatible, so ES versions 6.8.x and below are still supported.

No changes required in the code, just a dependency bump

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>