### PR TITLE
Improve postgresql DAO performance

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresBaseDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresBaseDAO.java
@@ -43,6 +43,7 @@ import static java.lang.System.getProperty;
 public abstract class PostgresBaseDAO {
 
     private static final String ER_LOCK_DEADLOCK = "40P01";
+    private static final String ER_SERIALIZATION_FAILURE = "40001";
     private static final String MAX_RETRY_ON_DEADLOCK_PROPERTY_NAME = "conductor.postgres.deadlock.retry.max";
     private static final String MAX_RETRY_ON_DEADLOCK_PROPERTY_DEFAULT_VALUE = "3";
     private static final int MAX_RETRY_ON_DEADLOCK = getMaxRetriesOnDeadLock();
@@ -254,7 +255,8 @@ public abstract class PostgresBaseDAO {
         if (sqlException == null){
             return false;
         }
-        return ER_LOCK_DEADLOCK.equals(sqlException.getSQLState());
+        return ER_LOCK_DEADLOCK.equals(sqlException.getSQLState())
+                || ER_SERIALIZATION_FAILURE.equals(sqlException.getSQLState());
     }
 
     private SQLException findCauseSQLException(Throwable throwable) {

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAO.java
@@ -68,7 +68,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     public List<Task> getPendingTasksByWorkflow(String taskDefName, String workflowId) {
         // @formatter:off
         String GET_IN_PROGRESS_TASKS_FOR_WORKFLOW = "SELECT json_data FROM task_in_progress tip "
-                + "INNER JOIN task t ON t.task_id = tip.task_id " + "WHERE task_def_name = ? AND workflow_id = ?";
+                + "INNER JOIN task t ON t.task_id = tip.task_id " + "WHERE task_def_name = ? AND workflow_id = ? FOR SHARE";
         // @formatter:on
 
         return queryWithTransaction(GET_IN_PROGRESS_TASKS_FOR_WORKFLOW,
@@ -109,8 +109,8 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     public List<Task> createTasks(List<Task> tasks) {
         List<Task> created = Lists.newArrayListWithCapacity(tasks.size());
 
-        withTransaction(connection -> {
-            for (Task task : tasks) {
+        for (Task task : tasks) {
+            withTransaction(connection -> {
                 validate(task);
 
                 task.setScheduledTime(System.currentTimeMillis());
@@ -122,7 +122,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
                 if (!scheduledTaskAdded) {
                     logger.trace("Task already scheduled, skipping the run " + task.getTaskId() + ", ref="
                             + task.getReferenceTaskName() + ", key=" + taskKey);
-                    continue;
+                    return;
                 }
 
                 insertOrUpdateTaskData(connection, task);
@@ -131,8 +131,8 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
                 updateTask(connection, task);
 
                 created.add(task);
-            }
-        });
+            });
+        }
 
         return created;
     }
@@ -233,7 +233,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
         Preconditions.checkNotNull(taskName, "task name cannot be null");
         // @formatter:off
         String GET_IN_PROGRESS_TASKS_FOR_TYPE = "SELECT json_data FROM task_in_progress tip "
-                + "INNER JOIN task t ON t.task_id = tip.task_id " + "WHERE task_def_name = ?";
+                + "INNER JOIN task t ON t.task_id = tip.task_id " + "WHERE task_def_name = ? FOR UPDATE SKIP LOCKED";
         // @formatter:on
 
         return queryWithTransaction(GET_IN_PROGRESS_TASKS_FOR_TYPE,
@@ -242,7 +242,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     @Override
     public List<Task> getTasksForWorkflow(String workflowId) {
-        String GET_TASKS_FOR_WORKFLOW = "SELECT task_id FROM workflow_to_task WHERE workflow_id = ?";
+        String GET_TASKS_FOR_WORKFLOW = "SELECT task_id FROM workflow_to_task WHERE workflow_id = ? FOR SHARE";
         return getWithRetriedTransactions(tx -> query(tx, GET_TASKS_FOR_WORKFLOW, q -> {
             List<String> taskIds = q.addParameter(workflowId).executeScalarList(String.class);
             return getTasks(tx, taskIds);
@@ -314,14 +314,14 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     /**
      * @param workflowName name of the workflow
-     * @param version the workflow version
+     * @param version      the workflow version
      * @return list of workflow ids that are in RUNNING state
      * <em>returns workflows of all versions for the given workflow name</em>
      */
     @Override
     public List<String> getRunningWorkflowIds(String workflowName, int version) {
         Preconditions.checkNotNull(workflowName, "workflowName cannot be null");
-        String GET_PENDING_WORKFLOW_IDS = "SELECT workflow_id FROM workflow_pending WHERE workflow_type = ?";
+        String GET_PENDING_WORKFLOW_IDS = "SELECT workflow_id FROM workflow_pending WHERE workflow_type = ? FOR SHARE SKIP LOCKED";
 
         return queryWithTransaction(GET_PENDING_WORKFLOW_IDS,
                 q -> q.addParameter(workflowName).executeScalarList(String.class));
@@ -329,7 +329,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     /**
      * @param workflowName Name of the workflow
-     * @param version the workflow version
+     * @param version      the workflow version
      * @return list of workflows that are in RUNNING state
      */
     @Override
@@ -367,7 +367,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
         withTransaction(tx -> {
             // @formatter:off
             String GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF = "SELECT workflow_id FROM workflow_def_to_workflow "
-                    + "WHERE workflow_def = ? AND date_str BETWEEN ? AND ?";
+                    + "WHERE workflow_def = ? AND date_str BETWEEN ? AND ? FOR SHARE SKIP LOCKED";
             // @formatter:on
 
             List<String> workflowIds = query(tx, GET_ALL_WORKFLOWS_FOR_WORKFLOW_DEF, q -> q.addParameter(workflowName)
@@ -390,7 +390,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     @Override
     public List<Workflow> getWorkflowsByCorrelationId(String workflowName, String correlationId, boolean includeTasks) {
         Preconditions.checkNotNull(correlationId, "correlationId cannot be null");
-        String GET_WORKFLOWS_BY_CORRELATION_ID = "SELECT w.json_data FROM workflow w left join workflow_def_to_workflow wd on w.workflow_id = wd.workflow_id  WHERE w.correlation_id = ? and wd.workflow_def = ?";
+        String GET_WORKFLOWS_BY_CORRELATION_ID = "SELECT w.json_data FROM workflow w left join workflow_def_to_workflow wd on w.workflow_id = wd.workflow_id  WHERE w.correlation_id = ? and wd.workflow_def = ? FOR SHARE SKIP LOCKED";
 
         return queryWithTransaction(GET_WORKFLOWS_BY_CORRELATION_ID,
                 q -> q.addParameter(correlationId).addParameter(workflowName).executeAndFetch(Workflow.class));
@@ -581,9 +581,9 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
         String EXISTS_PENDING_WORKFLOW = "SELECT EXISTS(SELECT 1 FROM workflow_pending WHERE workflow_type = ? AND workflow_id = ?)";
 
-        boolean exists  = query(connection, EXISTS_PENDING_WORKFLOW, q -> q.addParameter(workflowType).addParameter(workflowId).exists());
+        boolean exists = query(connection, EXISTS_PENDING_WORKFLOW, q -> q.addParameter(workflowType).addParameter(workflowId).exists());
 
-        if(!exists) {
+        if (!exists) {
             String INSERT_PENDING_WORKFLOW = "INSERT INTO workflow_pending (workflow_type, workflow_id) VALUES (?, ?) ON CONFLICT (workflow_type,workflow_id) DO NOTHING";
 
             execute(connection, INSERT_PENDING_WORKFLOW,
@@ -599,17 +599,17 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
     }
 
     private void insertOrUpdateTaskData(Connection connection, Task task) {
-		/*
-		 * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON CONFLICT do update' sql statement. The problem with that
-		 * is that if we try the INSERT first, the sequence will be increased even if the ON CONFLICT happens.
-		 */
-		String UPDATE_TASK = "UPDATE task SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE task_id=?";
-		int rowsUpdated = query(connection, UPDATE_TASK, q -> q.addJsonParameter(task).addParameter(task.getTaskId()).executeUpdate());
-		
-		if(rowsUpdated == 0) {
-		    String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (task_id) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
-		    execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
-		}
+        /*
+         * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON CONFLICT do update' sql statement. The problem with that
+         * is that if we try the INSERT first, the sequence will be increased even if the ON CONFLICT happens.
+         */
+        String UPDATE_TASK = "UPDATE task SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE task_id=?";
+        int rowsUpdated = query(connection, UPDATE_TASK, q -> q.addJsonParameter(task).addParameter(task.getTaskId()).executeUpdate());
+
+        if (rowsUpdated == 0) {
+            String INSERT_TASK = "INSERT INTO task (task_id, json_data, modified_on) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (task_id) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
+            execute(connection, INSERT_TASK, q -> q.addParameter(task.getTaskId()).addJsonParameter(task).executeUpdate());
+        }
     }
 
     private void removeTaskData(Connection connection, Task task) {
@@ -621,9 +621,9 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
         String EXISTS_WORKFLOW_TO_TASK = "SELECT EXISTS(SELECT 1 FROM workflow_to_task WHERE workflow_id = ? AND task_id = ?)";
 
-        boolean exists  = query(connection, EXISTS_WORKFLOW_TO_TASK, q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).exists());
+        boolean exists = query(connection, EXISTS_WORKFLOW_TO_TASK, q -> q.addParameter(task.getWorkflowInstanceId()).addParameter(task.getTaskId()).exists());
 
-        if(!exists) {
+        if (!exists) {
             String INSERT_WORKFLOW_TO_TASK = "INSERT INTO workflow_to_task (workflow_id, task_id) VALUES (?, ?) ON CONFLICT (workflow_id,task_id) DO NOTHING";
 
             execute(connection, INSERT_WORKFLOW_TO_TASK,
@@ -662,14 +662,14 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
         boolean exists = query(connection, EXISTS_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
                 .addParameter(taskKey).exists());
 
-        if(!exists) {
+        if (!exists) {
             final String INSERT_IGNORE_SCHEDULED_TASK = "INSERT INTO task_scheduled (workflow_id, task_key, task_id) VALUES (?, ?, ?) ON CONFLICT (workflow_id,task_key) DO NOTHING";
 
             int count = query(connection, INSERT_IGNORE_SCHEDULED_TASK, q -> q.addParameter(task.getWorkflowInstanceId())
                     .addParameter(taskKey).addParameter(task.getTaskId()).executeUpdate());
             return count > 0;
         } else {
-        	return false;
+            return false;
         }
 
     }
@@ -755,18 +755,18 @@ public class PostgresExecutionDAO extends PostgresBaseDAO implements ExecutionDA
 
     private void insertOrUpdatePollData(Connection connection, PollData pollData, String domain) {
 
-    	/*
-    	 * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON CONFLICT do update' sql statement. The problem with that
-    	 * is that if we try the INSERT first, the sequence will be increased even if the ON CONFLICT happens. Since polling happens *a lot*, the sequence can increase 
-    	 * dramatically even though it won't be used.
-    	 */
+        /*
+         * Most times the row will be updated so let's try the update first. This used to be an 'INSERT/ON CONFLICT do update' sql statement. The problem with that
+         * is that if we try the INSERT first, the sequence will be increased even if the ON CONFLICT happens. Since polling happens *a lot*, the sequence can increase
+         * dramatically even though it won't be used.
+         */
         String UPDATE_POLL_DATA = "UPDATE poll_data SET json_data=?, modified_on=CURRENT_TIMESTAMP WHERE queue_name=? AND domain=?";
         int rowsUpdated = query(connection, UPDATE_POLL_DATA, q -> q.addJsonParameter(pollData).addParameter(pollData.getQueueName()).addParameter(domain).executeUpdate());
-        
-       if(rowsUpdated == 0) {
-           String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP) ON CONFLICT (queue_name,domain) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
-           execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
-                  .addJsonParameter(pollData).executeUpdate());
+
+        if (rowsUpdated == 0) {
+            String INSERT_POLL_DATA = "INSERT INTO poll_data (queue_name, domain, json_data, modified_on) VALUES (?, ?, ?, CURRENT_TIMESTAMP) ON CONFLICT (queue_name,domain) DO UPDATE SET json_data=excluded.json_data, modified_on=excluded.modified_on";
+            execute(connection, INSERT_POLL_DATA, q -> q.addParameter(pollData.getQueueName()).addParameter(domain)
+                    .addJsonParameter(pollData).executeUpdate());
         }
     }
 

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -80,16 +80,34 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
     @Override
     public List<String> pop(String queueName, int count, int timeout) {
-        List<Message> messages = getWithTransactionWithOutErrorPropagation(tx -> popMessages(tx, queueName, count, timeout));
-        if(messages == null) return new ArrayList<>();
-        return messages.stream().map(Message::getId).collect(Collectors.toList());
+        return pollMessages(queueName, count, timeout).stream().map(Message::getId).collect(Collectors.toList());
     }
 
     @Override
     public List<Message> pollMessages(String queueName, int count, int timeout) {
-        List<Message> messages = getWithTransactionWithOutErrorPropagation(tx -> popMessages(tx, queueName, count, timeout));
-        if(messages == null) return new ArrayList<>();
-        return messages;
+        if (timeout < 1) {
+            List<Message> messages = getWithTransactionWithOutErrorPropagation(tx -> popMessages(tx, queueName, count, timeout));
+            if (messages == null) return new ArrayList<>();
+            return messages;
+        }
+
+        long start = System.currentTimeMillis();
+        final List<Message> messages = new ArrayList<>();
+
+        while (true) {
+            List<Message> messagesSlice = getWithTransactionWithOutErrorPropagation(tx -> popMessages(tx, queueName, count - messages.size(), timeout));
+            if(messagesSlice == null) {
+                logger.warn("Unable to poll {} messages from {} due to tx conflict, only {} popped", count, queueName, messages.size());
+                // conflict could have happened, returned messages popped so far
+                return messages;
+            }
+
+            messages.addAll(messagesSlice);
+            if (messages.size() >= count || ((System.currentTimeMillis() - start) > timeout)) {
+                return messages;
+            }
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override
@@ -127,7 +145,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
     @Override
     public Map<String, Long> queuesDetail() {
-        final String GET_QUEUES_DETAIL = "SELECT queue_name, (SELECT count(*) FROM queue_message WHERE popped = false AND queue_name = q.queue_name) AS size FROM queue q";
+        final String GET_QUEUES_DETAIL = "SELECT queue_name, (SELECT count(*) FROM queue_message WHERE popped = false AND queue_name = q.queue_name) AS size FROM queue q FOR SHARE SKIP LOCKED";
         return queryWithTransaction(GET_QUEUES_DETAIL, q -> q.executeAndFetch(rs -> {
             Map<String, Long> detail = Maps.newHashMap();
             while (rs.next()) {
@@ -145,7 +163,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
         final String GET_QUEUES_DETAIL_VERBOSE = "SELECT queue_name, \n"
                 + "       (SELECT count(*) FROM queue_message WHERE popped = false AND queue_name = q.queue_name) AS size,\n"
                 + "       (SELECT count(*) FROM queue_message WHERE popped = true AND queue_name = q.queue_name) AS uacked \n"
-                + "FROM queue q";
+                + "FROM queue q FOR SHARE SKIP LOCKED";
         // @formatter:on
 
         return queryWithTransaction(GET_QUEUES_DETAIL_VERBOSE, q -> q.executeAndFetch(rs -> {
@@ -171,14 +189,59 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         logger.trace("processAllUnacks started");
 
-        final String PROCESS_ALL_UNACKS = "UPDATE queue_message SET popped = false WHERE popped = true AND (current_timestamp - (60 ||' seconds')::interval) > deliver_on";
-        executeWithTransaction(PROCESS_ALL_UNACKS, Query::executeUpdate);
+        getWithRetriedTransactions(tx -> {
+            String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
+            query(tx, LOCK_TASKS, Query::executeQuery);
+
+            List<String> messages = query(tx, LOCK_TASKS, p -> p.executeAndFetch(rs -> {
+                List<String> results = new ArrayList<>();
+                while (rs.next()) {
+                    results.add(rs.getString("message_id"));
+                }
+                return results;
+            }));
+
+            if (messages.size() == 0) {
+                return 0;
+            }
+            String msgIdsString = String.join(",", messages);
+
+            final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE message_id IN (?)";
+            Integer unacked = query(tx, PROCESS_UNACKS, q -> q.addParameter(msgIdsString).executeUpdate());
+            if (unacked > 0) {
+                logger.debug("Unacked {} messages: {} from all queues", unacked, messages);
+            }
+            return unacked;
+        });
     }
 
     @Override
     public void processUnacks(String queueName) {
-        final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND popped = true AND (current_timestamp - (60 ||' seconds')::interval)  > deliver_on";
-        executeWithTransaction(PROCESS_UNACKS, q -> q.addParameter(queueName).executeUpdate());
+        getWithRetriedTransactions(tx -> {
+            String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
+            query(tx, LOCK_TASKS, q -> q.addParameter(queueName).executeQuery());
+
+            List<String> messages = query(tx, LOCK_TASKS, p -> p.addParameter(queueName)
+                    .executeAndFetch(rs -> {
+                        List<String> results = new ArrayList<>();
+                        while (rs.next()) {
+                            results.add(rs.getString("message_id"));
+                        }
+                        return results;
+                    }));
+
+            if (messages.size() == 0) {
+                return 0;
+            }
+            String msgIdsString = String.join(",", messages);
+
+            final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND message_id IN (?)";
+            Integer unacked = query(tx, PROCESS_UNACKS, q -> q.addParameter(queueName).addParameter(msgIdsString).executeUpdate());
+            if (unacked > 0) {
+                logger.debug("Unacked {} messages: {} from queue: {}", unacked, messages, queueName);
+            }
+            return unacked;
+        });
     }
 
     @Override
@@ -192,7 +255,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     }
 
     private boolean existsMessage(Connection connection, String queueName, String messageId) {
-        final String EXISTS_MESSAGE = "SELECT EXISTS(SELECT 1 FROM queue_message WHERE queue_name = ? AND message_id = ?)";
+        final String EXISTS_MESSAGE = "SELECT EXISTS(SELECT 1 FROM queue_message WHERE queue_name = ? AND message_id = ?) FOR SHARE";
         return query(connection, EXISTS_MESSAGE, q -> q.addParameter(queueName).addParameter(messageId).exists());
     }
 
@@ -223,7 +286,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
         if (count < 1)
             return Collections.emptyList();
 
-        final String PEEK_MESSAGES = "SELECT message_id, priority, payload FROM queue_message WHERE queue_name = ? AND popped = false AND deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) ORDER BY priority DESC, deliver_on, created_on LIMIT ?";
+        final String PEEK_MESSAGES = "SELECT message_id, priority, payload FROM queue_message WHERE queue_name = ? AND popped = false AND deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) ORDER BY priority DESC, deliver_on, created_on LIMIT ? FOR UPDATE SKIP LOCKED";
 
         List<Message> messages = query(connection, PEEK_MESSAGES, p -> p.addParameter(queueName)
                 .addParameter(count).executeAndFetch(rs -> {
@@ -242,13 +305,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     }
 
     private List<Message> popMessages(Connection connection, String queueName, int count, int timeout) {
-        long start = System.currentTimeMillis();
         List<Message> messages = peekMessages(connection, queueName, count);
-
-        while (messages.size() < count && ((System.currentTimeMillis() - start) < timeout)) {
-            Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
-            messages = peekMessages(connection, queueName, count);
-        }
 
         if (messages.isEmpty()) {
             return messages;
@@ -266,21 +323,18 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
         return poppedMessages;
     }
 
+    @Override
+    public boolean containsMessage(String queueName, String messageId) {
+        return getWithRetriedTransactions(tx -> existsMessage(tx, queueName, messageId));
+    }
 
     private void createQueueIfNotExists(Connection connection, String queueName) {
         logger.trace("Creating new queue '{}'", queueName);
-        final String EXISTS_QUEUE = "SELECT EXISTS(SELECT 1 FROM queue WHERE queue_name = ?)";
+        final String EXISTS_QUEUE = "SELECT EXISTS(SELECT 1 FROM queue WHERE queue_name = ?) FOR SHARE";
         boolean exists = query(connection, EXISTS_QUEUE, q -> q.addParameter(queueName).exists());
         if(!exists) {
 	        final String CREATE_QUEUE = "INSERT INTO queue (queue_name) VALUES (?) ON CONFLICT (queue_name) DO NOTHING";
 	        execute(connection, CREATE_QUEUE, q -> q.addParameter(queueName).executeUpdate());
         }
-    }
-
-    @Override
-    public boolean containsMessage(String queueName, String messageId) {
-        final String EXISTS_QUEUE = "SELECT EXISTS(SELECT 1 FROM queue_message WHERE queue_name = ? AND message_id = ? )";
-        boolean exists = queryWithTransaction(EXISTS_QUEUE, q -> q.addParameter(queueName).addParameter(messageId).exists());
-        return exists;
     }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -191,7 +191,6 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         getWithRetriedTransactions(tx -> {
             String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
-            query(tx, LOCK_TASKS, Query::executeQuery);
 
             List<String> messages = query(tx, LOCK_TASKS, p -> p.executeAndFetch(rs -> {
                 List<String> results = new ArrayList<>();
@@ -219,7 +218,6 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     public void processUnacks(String queueName) {
         getWithRetriedTransactions(tx -> {
             String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
-            query(tx, LOCK_TASKS, q -> q.addParameter(queueName).executeQuery());
 
             List<String> messages = query(tx, LOCK_TASKS, p -> p.addParameter(queueName)
                     .executeAndFetch(rs -> {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresExecutionDAOTest.java
@@ -68,6 +68,21 @@ public class PostgresExecutionDAOTest extends ExecutionDAOTest {
         assertEquals(10, bycorrelationId.size());
     }
 
+    @Test
+    public void testRemoveWorkflow() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("workflow");
+
+        Workflow workflow = createTestWorkflow();
+        workflow.setWorkflowDefinition(def);
+
+        List<String> ids = generateWorkflows(workflow, 1);
+
+        assertEquals(1, getExecutionDAO().getPendingWorkflowCount("workflow"));
+        ids.forEach(wfId -> getExecutionDAO().removeWorkflow(wfId));
+        assertEquals(0, getExecutionDAO().getPendingWorkflowCount("workflow"));
+    }
+
     @Override
     public ExecutionDAO getExecutionDAO() {
         return executionDAO;

--- a/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
@@ -1,0 +1,468 @@
+package com.netflix.conductor.performance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.JsonMapperProvider;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.core.execution.TestConfiguration;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.postgres.PostgresExecutionDAO;
+import com.netflix.conductor.dao.postgres.PostgresQueueDAO;
+import com.netflix.conductor.postgres.PostgresConfiguration;
+import com.netflix.conductor.postgres.PostgresDataSourceProvider;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Ignore("This test cannot be automated")
+public class PerformanceTest {
+
+    public static final int MSGS = 1000;
+    public static final int PRODUCER_BATCH = 10; // make sure MSGS % PRODUCER_BATCH == 0
+    public static final int PRODUCERS = 4;
+    public static final int WORKERS = 8;
+    public static final int OBSERVERS = 4;
+    public static final int OBSERVER_DELAY = 5000;
+    public static final int UNACK_RUNNERS = 10;
+    public static final int UNACK_DELAY = 500;
+    public static final int WORKER_BATCH = 10;
+    public static final int WORKER_BATCH_TIMEOUT = 500;
+    public static final int COMPLETION_MONITOR_DELAY = 1000;
+
+    private PostgresConfiguration configuration;
+    private DataSource dataSource;
+    private QueueDAO Q;
+    private ExecutionDAO E;
+
+    private ExecutorService THREADPOOL = Executors.newFixedThreadPool(PRODUCERS + WORKERS + OBSERVERS + UNACK_RUNNERS);
+    private static final Logger logger = LoggerFactory.getLogger(PerformanceTest.class);
+
+    @Before
+    public void setUp() {
+        TestConfiguration testConfiguration = new TestConfiguration();
+        configuration = new TestPostgresConfiguration(testConfiguration,
+                "jdbc:postgresql://localhost:54320/conductor?charset=utf8&parseTime=true&interpolateParams=true",
+                10, 2);
+        PostgresDataSourceProvider dataSource = new PostgresDataSourceProvider(configuration);
+        this.dataSource = dataSource.get();
+        resetAllData(this.dataSource);
+        flywayMigrate(this.dataSource);
+
+        final ObjectMapper objectMapper = new JsonMapperProvider().get();
+        Q = new PostgresQueueDAO(objectMapper, this.dataSource);
+        E = new PostgresExecutionDAO(objectMapper, this.dataSource);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetAllData(dataSource);
+    }
+
+    public static final String QUEUE = "task_queue";
+
+    @Test
+    public void testQueueDaoPerformance() throws InterruptedException {
+        AtomicBoolean stop = new AtomicBoolean(false);
+        Stopwatch start = Stopwatch.createStarted();
+        AtomicInteger poppedCoutner = new AtomicInteger(0);
+        HashMultiset<String> allPopped = HashMultiset.create();
+
+        // Consumers - workers
+        for (int i = 0; i < WORKERS; i++) {
+            THREADPOOL.submit(() -> {
+                while (!stop.get()) {
+                    List<Message> pop = Q.pollMessages(QUEUE, WORKER_BATCH, WORKER_BATCH_TIMEOUT);
+                    logger.info("Popped {} messages", pop.size());
+                    poppedCoutner.accumulateAndGet(pop.size(), Integer::sum);
+
+                    if (pop.size() == 0) {
+                        try {
+                            Thread.sleep(200);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else {
+                        logger.info("Popped {}", pop.stream().map(Message::getId).collect(Collectors.toList()));
+                    }
+
+                    pop.forEach(popped -> {
+                        synchronized (allPopped) {
+                            allPopped.add(popped.getId());
+                        }
+                        boolean exists = Q.containsMessage(QUEUE, popped.getId());
+                        boolean ack = Q.ack(QUEUE, popped.getId());
+
+                        if (ack && exists) {
+                            // OK
+                        } else {
+                            logger.error("Exists & Ack did not succeed for msg: {}", popped);
+                        }
+                    });
+                }
+            });
+        }
+
+        // Producers
+        List<Future<?>> producers = Lists.newArrayList();
+        for (int i = 0; i < PRODUCERS; i++) {
+            Future<?> producer = THREADPOOL.submit(() -> {
+                try {
+                    // N messages
+                    for (int j = 0; j < MSGS / PRODUCER_BATCH; j++) {
+                        List<Message> randomMessages = getRandomMessages(PRODUCER_BATCH);
+                        Q.push(QUEUE, randomMessages);
+                        logger.info("Pushed {} messages", PRODUCER_BATCH);
+                        logger.info("Pushed {}", randomMessages.stream().map(Message::getId).collect(Collectors.toList()));
+                    }
+                    logger.info("Pushed ALL");
+                } catch (Exception e) {
+                    logger.error("Something went wrong with producer", e);
+                    throw new RuntimeException(e);
+                }
+            });
+
+            producers.add(producer);
+        }
+
+        // Observers
+        for (int i = 0; i < OBSERVERS; i++) {
+            THREADPOOL.submit(() -> {
+                while (!stop.get()) {
+                    try {
+                        int size = Q.getSize(QUEUE);
+                        Q.queuesDetail();
+                        logger.info("Size   {} messages", size);
+                    } catch (Exception e) {
+                        logger.info("Queue size failed, nevermind");
+                    }
+
+                    try {
+                        Thread.sleep(OBSERVER_DELAY);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        // Consumers - unack processor
+        for (int i = 0; i < UNACK_RUNNERS; i++) {
+            THREADPOOL.submit(() -> {
+                while (!stop.get()) {
+                    try {
+                        Q.processUnacks(QUEUE);
+                    } catch (Exception e) {
+                        logger.info("Unack failed, nevermind", e);
+                        continue;
+                    }
+                    logger.info("Unacked");
+                    try {
+                        Thread.sleep(UNACK_DELAY);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        long elapsed;
+        while (true) {
+            try {
+                Thread.sleep(COMPLETION_MONITOR_DELAY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            int size = Q.getSize(QUEUE);
+            logger.info("MONITOR SIZE : {}", size);
+
+            if (size == 0 && producers.stream().map(Future::isDone).reduce(true, (b1, b2) -> b1 && b2)) {
+                elapsed = start.elapsed(TimeUnit.MILLISECONDS);
+                stop.set(true);
+                break;
+            }
+        }
+
+        THREADPOOL.awaitTermination(10, TimeUnit.SECONDS);
+        THREADPOOL.shutdown();
+        logger.info("Finished in {} ms", elapsed);
+        logger.info("Throughput {} msgs/second", ((MSGS * PRODUCERS) / (elapsed * 1.0)) * 1000);
+        logger.info("Threads finished");
+        if (poppedCoutner.get() != MSGS * PRODUCERS) {
+            synchronized (allPopped) {
+                List<String> duplicates = allPopped.entrySet().stream()
+                        .filter(stringEntry -> stringEntry.getCount() > 1)
+                        .map(stringEntry -> stringEntry.getElement() + ": " + stringEntry.getCount())
+                        .collect(Collectors.toList());
+
+                logger.error("Found duplicate pops: " + duplicates);
+            }
+            throw new RuntimeException("Popped " + poppedCoutner.get() + " != produced: " + MSGS * PRODUCERS);
+        }
+    }
+
+    @Test
+    public void testExecDaoPerformance() throws InterruptedException {
+        AtomicBoolean stop = new AtomicBoolean(false);
+        Stopwatch start = Stopwatch.createStarted();
+        BlockingDeque<Task> msgQueue = new LinkedBlockingDeque<>(1000);
+        HashMultiset<String> allPopped = HashMultiset.create();
+
+        // Consumers - workers
+        for (int i = 0; i < WORKERS; i++) {
+            THREADPOOL.submit(() -> {
+                while (!stop.get()) {
+                    List<Task> popped = new ArrayList<>();
+                    while (true) {
+                        try {
+                            Task poll;
+                            poll = msgQueue.poll(10, TimeUnit.MILLISECONDS);
+
+                            if (poll == null) {
+                                // poll timed out
+                                continue;
+                            }
+                            synchronized (allPopped) {
+                                allPopped.add(poll.getTaskId());
+                            }
+                            popped.add(poll);
+                            if (stop.get() || popped.size() == WORKER_BATCH) {
+                                break;
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    logger.info("Popped {} messages", popped.size());
+                    logger.info("Popped {}", popped.stream().map(Task::getTaskId).collect(Collectors.toList()));
+
+                    // Polling
+                    popped.stream()
+                            .peek(task -> {
+                                task.setWorkerId("someWorker");
+                                task.setPollCount(task.getPollCount() + 1);
+                                task.setStartTime(System.currentTimeMillis());
+                            })
+                            .forEach(task -> {
+                                try {
+                                    // should always be false
+                                    boolean concurrentLimit = E.exceedsInProgressLimit(task);
+                                    task.setStartTime(System.currentTimeMillis());
+                                    E.updateTask(task);
+                                    logger.info("Polled {}", task.getTaskId());
+                                } catch (Exception e) {
+                                    logger.error("Something went wrong with worker during poll", e);
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+                    popped.forEach(task -> {
+                        try {
+
+                            String wfId = task.getWorkflowInstanceId();
+                            Workflow workflow = E.getWorkflow(wfId, true);
+                            E.getTask(task.getTaskId());
+
+                            task.setStatus(Task.Status.COMPLETED);
+                            task.setWorkerId("someWorker");
+                            task.setOutputData(Collections.singletonMap("a", "b"));
+                            E.updateTask(task);
+                            E.updateWorkflow(workflow);
+                            logger.info("Updated {}", task.getTaskId());
+                        } catch (Exception e) {
+                            logger.error("Something went wrong with worker during update", e);
+                            throw new RuntimeException(e);
+                        }
+                    });
+
+                }
+            });
+        }
+
+        Multiset<String> pushedTasks = HashMultiset.create();
+
+        // Producers
+        List<Future<?>> producers = Lists.newArrayList();
+        for (int i = 0; i < PRODUCERS; i++) {
+            Future<?> producer = THREADPOOL.submit(() -> {
+                // N messages
+                for (int j = 0; j < MSGS / PRODUCER_BATCH; j++) {
+                    List<Task> randomTasks = getRandomTasks(PRODUCER_BATCH);
+
+                    Workflow wf = getWorkflow(randomTasks);
+                    E.createWorkflow(wf);
+
+                    E.createTasks(randomTasks);
+                    randomTasks.forEach(t -> {
+                        try {
+                            boolean offer = false;
+                            while (!offer) {
+                                offer = msgQueue.offer(t, 10, TimeUnit.MILLISECONDS);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    logger.info("Pushed {} messages", PRODUCER_BATCH);
+                    List<String> collect = randomTasks.stream().map(Task::getTaskId).collect(Collectors.toList());
+                    synchronized (pushedTasks) {
+                        pushedTasks.addAll(collect);
+                    }
+                    logger.info("Pushed {}", collect);
+                }
+                logger.info("Pushed ALL");
+            });
+
+            producers.add(producer);
+        }
+
+        // Observers
+        for (int i = 0; i < OBSERVERS; i++) {
+            THREADPOOL.submit(() -> {
+                while (!stop.get()) {
+                    try {
+                        List<Task> size = E.getPendingTasksForTaskType("taskType");
+                        logger.info("Size   {} messages", size.size());
+                        logger.info("Size q {} messages", msgQueue.size());
+                        synchronized (allPopped) {
+                            logger.info("All pp {} messages", allPopped.size());
+                        }
+                        logger.info("Workflows by correlation id size: {}", E.getWorkflowsByCorrelationId("abcd", "1", true).size());
+                        logger.info("Workflows by correlation id size: {}", E.getWorkflowsByCorrelationId("abcd", "2", true).size());
+                        logger.info("Workflows running ids: {}", E.getRunningWorkflowIds("abcd", 1));
+                        logger.info("Workflows pending count: {}", E.getPendingWorkflowCount("abcd"));
+                    } catch (Exception e) {
+                        logger.warn("Observer failed ", e);
+                    }
+                    try {
+                        Thread.sleep(OBSERVER_DELAY);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        long elapsed;
+        while (true) {
+            try {
+                Thread.sleep(COMPLETION_MONITOR_DELAY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            int size;
+            try {
+                size = E.getPendingTasksForTaskType("taskType").size();
+            } catch (Exception e) {
+                logger.warn("Monitor failed", e);
+                continue;
+            }
+            logger.info("MONITOR SIZE : {}", size);
+
+            if (size == 0 && producers.stream().map(Future::isDone).reduce(true, (b1, b2) -> b1 && b2)) {
+                elapsed = start.elapsed(TimeUnit.MILLISECONDS);
+                stop.set(true);
+                break;
+            }
+        }
+
+        THREADPOOL.awaitTermination(10, TimeUnit.SECONDS);
+        THREADPOOL.shutdown();
+        logger.info("Finished in {} ms", elapsed);
+        logger.info("Throughput {} msgs/second", ((MSGS * PRODUCERS) / (elapsed * 1.0)) * 1000);
+        logger.info("Threads finished");
+
+        List<String> duplicates = pushedTasks.entrySet().stream()
+                .filter(stringEntry -> stringEntry.getCount() > 1)
+                .map(stringEntry -> stringEntry.getElement() + ": " + stringEntry.getCount())
+                .collect(Collectors.toList());
+
+        logger.error("Found duplicate pushes: " + duplicates);
+    }
+
+    private Workflow getWorkflow(List<Task> randomTasks) {
+        Workflow wf = new Workflow();
+        wf.setWorkflowId(randomTasks.get(0).getWorkflowInstanceId());
+        wf.setCorrelationId(wf.getWorkflowId());
+        wf.setTasks(randomTasks);
+        WorkflowDef workflowDefinition = new WorkflowDef();
+        workflowDefinition.setName("abcd");
+        wf.setWorkflowDefinition(workflowDefinition);
+        wf.setStartTime(System.currentTimeMillis());
+        return wf;
+    }
+
+    private List<Task> getRandomTasks(int i) {
+        String timestamp = Long.toString(System.nanoTime());
+        return IntStream.range(0, i).mapToObj(j -> {
+            String id = Thread.currentThread().getId() + "_" + timestamp + "_" + j;
+            Task task = new Task();
+            task.setTaskId(id);
+            task.setCorrelationId(Integer.toString(j));
+            task.setTaskType("taskType");
+            task.setReferenceTaskName("refName" + j);
+            task.setWorkflowType("task_wf");
+            task.setWorkflowInstanceId(Thread.currentThread().getId() + "_" + timestamp);
+            return task;
+        }).collect(Collectors.toList());
+    }
+
+    private List<Message> getRandomMessages(int i) {
+        String timestamp = Long.toString(System.nanoTime());
+        return IntStream.range(0, i).mapToObj(j -> {
+            String id = Thread.currentThread().getId() + "_" + timestamp + "_" + j;
+            return new Message(id, "{ \"a\": \"b\", \"timestamp\": \" " + timestamp + " \"}", "receipt");
+        }).collect(Collectors.toList());
+    }
+
+    private void flywayMigrate(DataSource dataSource) {
+        Flyway flyway = new Flyway();
+        flyway.setDataSource(dataSource);
+        flyway.setPlaceholderReplacement(false);
+        flyway.setLocations(Paths.get("db", "migration_postgres").toString());
+        try {
+            flyway.migrate();
+        } catch (FlywayException e) {
+            if (e.getMessage().contains("non-empty")) {
+                return;
+            }
+            throw e;
+        }
+    }
+
+    public void resetAllData(DataSource dataSource) {
+        // TODO
+    }
+
+}

--- a/postgres-persistence/src/test/java/com/netflix/conductor/performance/TestPostgresConfiguration.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/performance/TestPostgresConfiguration.java
@@ -1,0 +1,334 @@
+package com.netflix.conductor.performance;
+
+import com.google.inject.AbstractModule;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.execution.TestConfiguration;
+import com.netflix.conductor.postgres.PostgresConfiguration;
+import java.util.List;
+import java.util.Map;
+
+class TestPostgresConfiguration implements PostgresConfiguration {
+    private final TestConfiguration testConfiguration;
+    private final String jdbcUrl;
+    private final int connectionMax;
+    private final int connecionIdle;
+
+    public TestPostgresConfiguration(TestConfiguration testConfiguration, String jdbcUrl, int maxConns, int connecionIdle) {
+        this.jdbcUrl = jdbcUrl;
+        this.testConfiguration = testConfiguration;
+        this.connectionMax = maxConns;
+        this.connecionIdle = connecionIdle;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+    @Override
+    public String getJdbcUserName() {
+        return "postgres";
+    }
+
+    @Override
+    public String getJdbcPassword() {
+        return "postgres";
+    }
+
+
+    @Override
+    public String getTransactionIsolationLevel() {
+        return "TRANSACTION_REPEATABLE_READ";
+//            return "TRANSACTION_SERIALIZABLE";
+    }
+
+    @Override
+    public int getConnectionPoolMaxSize() {
+        return connectionMax;
+    }
+
+    @Override
+    public int getConnectionPoolMinIdle() {
+        return connecionIdle;
+    }
+
+    @Override
+    public int getSweepFrequency() {
+        return testConfiguration.getSweepFrequency();
+    }
+
+    @Override
+    public boolean disableSweep() {
+        return testConfiguration.disableSweep();
+    }
+
+    @Override
+    public boolean disableAsyncWorkers() {
+        return testConfiguration.disableAsyncWorkers();
+    }
+
+    @Override
+    public boolean isEventMessageIndexingEnabled() {
+        return testConfiguration.isEventMessageIndexingEnabled();
+    }
+
+    @Override
+    public boolean isEventExecutionIndexingEnabled() {
+        return testConfiguration.isEventExecutionIndexingEnabled();
+    }
+
+    @Override
+    public String getServerId() {
+        return testConfiguration.getServerId();
+    }
+
+    @Override
+    public String getEnvironment() {
+        return testConfiguration.getEnvironment();
+    }
+
+    @Override
+    public String getStack() {
+        return testConfiguration.getStack();
+    }
+
+    @Override
+    public String getAppId() {
+        return testConfiguration.getAppId();
+    }
+
+    @Override
+    public boolean enableAsyncIndexing() {
+        return testConfiguration.enableAsyncIndexing();
+    }
+
+    @Override
+    public String getProperty(String string, String def) {
+        return testConfiguration.getProperty(string, def);
+    }
+
+    @Override
+    public boolean getBooleanProperty(String name, boolean defaultValue) {
+        return testConfiguration.getBooleanProperty(name, defaultValue);
+    }
+
+    @Override
+    public String getAvailabilityZone() {
+        return testConfiguration.getAvailabilityZone();
+    }
+
+    @Override
+    public int getIntProperty(String string, int def) {
+        return testConfiguration.getIntProperty(string, def);
+    }
+
+    @Override
+    public String getRegion() {
+        return testConfiguration.getRegion();
+    }
+
+    @Override
+    public Long getWorkflowInputPayloadSizeThresholdKB() {
+        return testConfiguration.getWorkflowInputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getMaxWorkflowInputPayloadSizeThresholdKB() {
+        return testConfiguration.getMaxWorkflowInputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getWorkflowOutputPayloadSizeThresholdKB() {
+        return testConfiguration.getWorkflowOutputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getMaxWorkflowOutputPayloadSizeThresholdKB() {
+        return testConfiguration.getMaxWorkflowOutputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getMaxWorkflowVariablesPayloadSizeThresholdKB() {
+        return testConfiguration.getMaxWorkflowVariablesPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getTaskInputPayloadSizeThresholdKB() {
+        return testConfiguration.getTaskInputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getMaxTaskInputPayloadSizeThresholdKB() {
+        return testConfiguration.getMaxTaskInputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getTaskOutputPayloadSizeThresholdKB() {
+        return testConfiguration.getTaskOutputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Long getMaxTaskOutputPayloadSizeThresholdKB() {
+        return testConfiguration.getMaxTaskOutputPayloadSizeThresholdKB();
+    }
+
+    @Override
+    public Map<String, Object> getAll() {
+        return testConfiguration.getAll();
+    }
+
+    @Override
+    public long getLongProperty(String name, long defaultValue) {
+        return testConfiguration.getLongProperty(name, defaultValue);
+    }
+
+    @Override
+    public LOCKING_SERVER getLockingServer() {
+        return testConfiguration.getLockingServer();
+    }
+
+    @Override
+    public String getLockingServerString() {
+        return testConfiguration.getLockingServerString();
+    }
+
+    @Override
+    public boolean ignoreLockingExceptions() {
+        return testConfiguration.ignoreLockingExceptions();
+    }
+
+    @Override
+    public boolean enableWorkflowExecutionLock() {
+        return testConfiguration.enableWorkflowExecutionLock();
+    }
+
+    @Override
+    public boolean isTaskExecLogIndexingEnabled() {
+        return testConfiguration.isTaskExecLogIndexingEnabled();
+    }
+
+    @Override
+    public boolean isIndexingPersistenceEnabled() {
+        return testConfiguration.isIndexingPersistenceEnabled();
+    }
+
+    @Override
+    public int getSystemTaskWorkerThreadCount() {
+        return testConfiguration.getSystemTaskWorkerThreadCount();
+    }
+
+    @Override
+    public int getSystemTaskWorkerCallbackSeconds() {
+        return testConfiguration.getSystemTaskWorkerCallbackSeconds();
+    }
+
+    @Override
+    public int getSystemTaskWorkerPollInterval() {
+        return testConfiguration.getSystemTaskWorkerPollInterval();
+    }
+
+    @Override
+    public String getSystemTaskWorkerExecutionNamespace() {
+        return testConfiguration.getSystemTaskWorkerExecutionNamespace();
+    }
+
+    @Override
+    public int getSystemTaskWorkerIsolatedThreadCount() {
+        return testConfiguration.getSystemTaskWorkerIsolatedThreadCount();
+    }
+
+    @Override
+    public int getSystemTaskMaxPollCount() {
+        return testConfiguration.getSystemTaskMaxPollCount();
+    }
+
+    @Override
+    public boolean isOwnerEmailMandatory() {
+        return testConfiguration.isOwnerEmailMandatory();
+    }
+
+    @Override
+    public int getTaskDefRefreshTimeSecsDefaultValue() {
+        return testConfiguration.getTaskDefRefreshTimeSecsDefaultValue();
+    }
+
+    @Override
+    public int getEventHandlerRefreshTimeSecsDefaultValue() {
+        return testConfiguration.getEventHandlerRefreshTimeSecsDefaultValue();
+    }
+
+    @Override
+    public int getEventExecutionPersistenceTTL() {
+        return testConfiguration.getEventExecutionPersistenceTTL();
+    }
+
+    @Override
+    public boolean isElasticSearchAutoIndexManagementEnabled() {
+        return testConfiguration.isElasticSearchAutoIndexManagementEnabled();
+    }
+
+    @Override
+    public String getElasticSearchDocumentTypeOverride() {
+        return testConfiguration.getElasticSearchDocumentTypeOverride();
+    }
+
+    @Override
+    public int getWorkflowArchivalTTL() {
+        return testConfiguration.getWorkflowArchivalTTL();
+    }
+
+    @Override
+    public int getWorkflowArchivalDelay() {
+        return testConfiguration.getWorkflowArchivalDelay();
+    }
+
+    @Override
+    public int getWorkflowArchivalDelayQueueWorkerThreadCount() {
+        return testConfiguration.getWorkflowArchivalDelayQueueWorkerThreadCount();
+    }
+
+    @Override
+    public int getEventSchedulerPollThreadCount() {
+        return testConfiguration.getEventSchedulerPollThreadCount();
+    }
+
+    @Override
+    public boolean isWorkflowRepairServiceEnabled() {
+        return testConfiguration.isWorkflowRepairServiceEnabled();
+    }
+
+    @Override
+    public DB getDB() {
+        return testConfiguration.getDB();
+    }
+
+    @Override
+    public String getDBString() {
+        return testConfiguration.getDBString();
+    }
+
+    @Override
+    public int getAsyncUpdateShortRunningWorkflowDuration() {
+        return testConfiguration.getAsyncUpdateShortRunningWorkflowDuration();
+    }
+
+    @Override
+    public int getAsyncUpdateDelay() {
+        return testConfiguration.getAsyncUpdateDelay();
+    }
+
+    @Override
+    public boolean getJerseyEnabled() {
+        return testConfiguration.getJerseyEnabled();
+    }
+
+    @Override
+    public boolean getBoolProperty(String name, boolean defaultValue) {
+        return testConfiguration.getBoolProperty(name, defaultValue);
+    }
+
+    @Override
+    public List<AbstractModule> getAdditionalModules() {
+        return testConfiguration.getAdditionalModules();
+    }
+}


### PR DESCRIPTION
by adding proper FOR SHARE / FOR UPDATE / SKIP LOCKED locks to DB queries
where it makes sense in order to reduce conflicts/deadlocks in DB

Most important case is when workers poll for work, they are not
interested in tasks that are locked (currently being updated) so they
can leverage 'SKIP LOCKED' to prevent DB locks and tx deadlocks.

This increases the performance of postgres dao

Additional improvements:

+ move thread.sleep out of DB transaction when tasks are being polled
with timeout parameter

+ add serialization_error to the list of causes triggerring TX retry
(this is happening under heavy load)

+ fix processUnack condition: it used to do the opposite. This has been
also fixed in the meantime by u447 <rick.fishman@bcbsfl.com>

+ add a performance test. This test can be executed manually, but should
not be automated

+ add retries to containsMessage method

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>