### PR TITLE
Added missing params to Go client Ack

### DIFF
--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -203,10 +203,14 @@ func (c *ConductorHttpClient) PollForTask(taskType string, workerid string, doma
     }
 }
 
-func (c *ConductorHttpClient) AckTask(taskId string) (string, error) {
+func (c *ConductorHttpClient) AckTask(taskId, workerid, domain string) (string, error) {
     url := c.httpClient.MakeUrl("/tasks/{taskId}/ack", "{taskId}", taskId)
+    params := map[string]string{
+        "workerid": workerid,
+	"domain": domain,
+    }
     headers := map[string]string{"Accept": "application/json"}
-    outputString, err := c.httpClient.Post(url, nil, headers, "")
+    outputString, err := c.httpClient.Post(url, params, headers, "")
     if err != nil {
         return "", err
     }

--- a/client/go/conductorworker.go
+++ b/client/go/conductorworker.go
@@ -89,7 +89,7 @@ func (c *ConductorWorker) PollAndExecute(taskType string, domain string, execute
 		}
 
 		// Found a task, so we send an Ack
-		_, ackErr := c.ConductorHttpClient.AckTask(parsedTask.TaskId)
+		_, ackErr := c.ConductorHttpClient.AckTask(parsedTask.TaskId, hostname, domain)
 		if ackErr != nil {
 			log.Println("Error Acking task:", ackErr.Error())
 			continue


### PR DESCRIPTION
Go workers aren't able to correctly Ack that they've accepted a request due to missing parameters.

See #1923 