### PR TITLE
Optimize completion by removing updating all tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -677,7 +677,6 @@ public class WorkflowExecutor {
         workflow.setOutput(wf.getOutput());
         workflow.setExternalOutputPayloadStoragePath(wf.getExternalOutputPayloadStoragePath());
         executionDAOFacade.updateWorkflow(workflow);
-        executionDAOFacade.updateTasks(workflow.getTasks());
         LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
 
         if (StringUtils.isNotEmpty(workflow.getParentWorkflowId())) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -341,7 +341,7 @@ public class TestWorkflowExecutor {
         workflowExecutor.completeWorkflow(workflow);
         assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus());
         assertEquals(1, updateWorkflowCalledCounter.get());
-        assertEquals(1, updateTasksCalledCounter.get());
+        assertEquals(0, updateTasksCalledCounter.get());
         assertEquals(1, removeQueueEntryCalledCounter.get());
 
         verify(workflowStatusListener, times(0)).onWorkflowCompleted(any(Workflow.class));


### PR DESCRIPTION
Optimize completion by removing updating all tasks.
- When there are hundreds of thousands of tasks in the workflow, this update will be expensive.
- all tasks should be done before workflow is completed.