### PR TITLE
Feature: [WIP] add typing and validation for input/output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ allprojects {
         maven {
             url "https://dl.bintray.com/netflixoss/oss-candidate"
         }
+
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile "org.apache.commons:commons-lang3:${revCommonsLang3}"
     // https://mvnrepository.com/artifact/org.glassfish/javax.el
     compile group: 'org.glassfish', name: 'javax.el', version: "${revJavaElApi}"
+    compile "com.github.everit-org.json-schema:org.everit.json.schema:${revJsonSchema}"
 }
 
 import com.github.vmg.protogen.ProtoGenTask;

--- a/common/src/main/java/com/netflix/conductor/common/constraints/JsonSchemaValidityConstraint.java
+++ b/common/src/main/java/com/netflix/conductor/common/constraints/JsonSchemaValidityConstraint.java
@@ -1,0 +1,64 @@
+package com.netflix.conductor.common.constraints;
+
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+import static java.lang.annotation.ElementType.FIELD;
+
+/**
+ * This constraint checks for a given json schema definition should be valid.
+ */
+@Documented
+@Constraint(validatedBy = JsonSchemaValidityConstraint.JsonSchemaValidator.class)
+@Target({FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonSchemaValidityConstraint {
+	String message() default "";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	class JsonSchemaValidator implements ConstraintValidator<JsonSchemaValidityConstraint, Map> {
+
+		@Override
+		public void initialize(final JsonSchemaValidityConstraint constraintAnnotation) {
+		}
+
+		@Override
+		public boolean isValid(final Map json, final ConstraintValidatorContext context) {
+			try (final InputStream resource = this.getClass().getResourceAsStream("/schema_draft7.json")) {
+				final JSONObject jsonSchema = new JSONObject(json);
+				final JSONObject jsonSchemaDefinition = new JSONObject(new JSONTokener(resource));
+				final Schema schema = SchemaLoader.builder().draftV7Support()
+						.schemaJson(jsonSchemaDefinition).build().load().build();
+				schema.validate(jsonSchema);
+			} catch (final JSONException | IOException e) {
+				String message = String.format("Invalid json schema definition: %s", e.getMessage());
+				context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+				return false;
+			} catch (final ValidationException e) {
+                e.getAllMessages().forEach(message ->
+                        context.buildConstraintViolationWithTemplate(message).addConstraintViolation());
+                return false;
+            }
+			return true;
+		}
+	}
+}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -19,6 +19,7 @@ package com.netflix.conductor.common.metadata.tasks;
 import com.github.vmg.protogen.annotations.ProtoEnum;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
+import com.netflix.conductor.common.constraints.JsonSchemaValidityConstraint;
 import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.constraints.TaskTimeoutConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
@@ -68,9 +69,11 @@ public class TaskDef extends Auditable {
 	@NotNull
 	private long timeoutSeconds;
 
+	@Deprecated
 	@ProtoField(id = 5)
 	private List<String> inputKeys = new ArrayList<String>();
 
+	@Deprecated
 	@ProtoField(id = 6)
 	private List<String> outputKeys = new ArrayList<String>();
 
@@ -117,6 +120,14 @@ public class TaskDef extends Auditable {
 	@ProtoField(id = 19)
 	@Min(value = 0, message = "TaskDef pollTimeoutSeconds: {value} must be >= 0")
 	private Integer pollTimeoutSeconds;
+
+	@ProtoField(id = 20)
+	@JsonSchemaValidityConstraint
+	private Map<String, Object> inputDefinition = new HashMap<>();;
+
+	@ProtoField(id = 21)
+	@JsonSchemaValidityConstraint
+	private Map<String, Object> outputDefinition = new HashMap<>();;
 
 	public TaskDef() {
 	}
@@ -207,6 +218,7 @@ public class TaskDef extends Auditable {
 	 *
 	 * @return Returns the input keys
 	 */
+	@Deprecated
 	public List<String> getInputKeys() {
 		return inputKeys;
 	}
@@ -214,6 +226,7 @@ public class TaskDef extends Auditable {
 	/**
 	 * @param inputKeys Set of keys that the task accepts in the input map
 	 */
+	@Deprecated
 	public void setInputKeys(List<String> inputKeys) {
 		this.inputKeys = inputKeys;
 	}
@@ -221,6 +234,7 @@ public class TaskDef extends Auditable {
 	/**
 	 * @return Returns the output keys for the task when executed
 	 */
+	@Deprecated
 	public List<String> getOutputKeys() {
 		return outputKeys;
 	}
@@ -228,6 +242,7 @@ public class TaskDef extends Auditable {
 	/**
 	 * @param outputKeys Sets the output keys
 	 */
+	@Deprecated
 	public void setOutputKeys(List<String> outputKeys) {
 		this.outputKeys = outputKeys;
 	}
@@ -405,6 +420,22 @@ public class TaskDef extends Auditable {
 	 */
 	public Integer getPollTimeoutSeconds() {
 		return pollTimeoutSeconds;
+	}
+
+	public Map<String, Object> getInputDefinition() {
+		return inputDefinition;
+	}
+
+	public void setInputDefinition(final Map<String, Object> inputDefinition) {
+		this.inputDefinition = inputDefinition;
+	}
+
+	public Map<String, Object> getOutputDefinition() {
+		return outputDefinition;
+	}
+
+	public void setOutputDefinition(final Map<String, Object> outputDefinition) {
+		this.outputDefinition = outputDefinition;
 	}
 
 	@Override

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -18,6 +18,7 @@ package com.netflix.conductor.common.metadata.workflow;
 import com.github.vmg.protogen.annotations.ProtoEnum;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
+import com.netflix.conductor.common.constraints.JsonSchemaValidityConstraint;
 import com.netflix.conductor.common.constraints.NoSemiColonConstraint;
 import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.constraints.TaskReferenceNameUniqueConstraint;
@@ -64,9 +65,11 @@ public class WorkflowDef extends Auditable {
 	private List<@Valid WorkflowTask> tasks = new LinkedList<>();
 
 	@ProtoField(id = 5)
+	@Deprecated
 	private List<String> inputParameters = new LinkedList<>();
 
 	@ProtoField(id = 6)
+	@Deprecated
 	private Map<String, Object> outputParameters = new HashMap<>();
 
 	@ProtoField(id = 7)
@@ -98,6 +101,14 @@ public class WorkflowDef extends Auditable {
 
 	@ProtoField(id = 14)
 	private Map<String, Object> variables = new HashMap<>();
+
+	@ProtoField(id = 15)
+	@JsonSchemaValidityConstraint
+	private Map<String, Object> inputDefinition = new HashMap<>();
+
+	@ProtoField(id = 16)
+	@JsonSchemaValidityConstraint
+	private Map<String, Object> outputDefinition = new HashMap<>();
 
 	/**
 	 * @return the name
@@ -144,6 +155,7 @@ public class WorkflowDef extends Auditable {
 	/**
 	 * @return the inputParameters
 	 */
+	@Deprecated
 	public List<String> getInputParameters() {
 		return inputParameters;
 	}
@@ -151,6 +163,7 @@ public class WorkflowDef extends Auditable {
 	/**
 	 * @param inputParameters the inputParameters to set
 	 */
+	@Deprecated
 	public void setInputParameters(List<String> inputParameters) {
 		this.inputParameters = inputParameters;
 	}
@@ -171,6 +184,7 @@ public class WorkflowDef extends Auditable {
 	/**
 	 * @return the outputParameters
 	 */
+	@Deprecated
 	public Map<String, Object> getOutputParameters() {
 		return outputParameters;
 	}
@@ -178,6 +192,7 @@ public class WorkflowDef extends Auditable {
 	/**
 	 * @param outputParameters the outputParameters to set
 	 */
+	@Deprecated
 	public void setOutputParameters(Map<String, Object> outputParameters) {
 		this.outputParameters = outputParameters;
 	}
@@ -349,6 +364,22 @@ public class WorkflowDef extends Auditable {
 			tasks.addAll(workflowTask.collectTasks());
 		}
 		return tasks;
+	}
+
+	public Map<String, Object> getInputDefinition() {
+		return inputDefinition;
+	}
+
+	public void setInputDefinition(final Map<String, Object> inputDefinition) {
+		this.inputDefinition = inputDefinition;
+	}
+
+	public Map<String, Object> getOutputDefinition() {
+		return outputDefinition;
+	}
+
+	public void setOutputDefinition(final Map<String, Object> outputDefinition) {
+		this.outputDefinition = outputDefinition;
 	}
 
 	@Override

--- a/common/src/main/java/com/netflix/conductor/common/validation/ValidationError.java
+++ b/common/src/main/java/com/netflix/conductor/common/validation/ValidationError.java
@@ -1,6 +1,5 @@
 package com.netflix.conductor.common.validation;
 
-import com.netflix.conductor.common.validation.ErrorResponse;
 import java.util.StringJoiner;
 
 /**

--- a/common/src/main/resources/schema_draft7.json
+++ b/common/src/main/resources/schema_draft7.json
@@ -1,0 +1,172 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": { "$ref": "#" },
+        "then": { "$ref": "#" },
+        "else": { "$ref": "#" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/common/src/test/java/com/netflix/conductor/common/tasks/TaskDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/tasks/TaskDefTest.java
@@ -27,7 +27,10 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -124,5 +127,49 @@ public class TaskDefTest {
 
         Set<ConstraintViolation<Object>> result = validator.validate(taskDef);
         assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testTaskDefValidInputOutput() {
+        final Map<String, Object> name = new HashMap<>();
+		name.put("type", "string");
+		name.put("minLength", 1);
+		final Map<String, Object> properties = Collections.singletonMap("name", name);
+		final Map<String, Object> definition = Collections.singletonMap("properties", properties);
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("test-task");
+        taskDef.setRetryCount(1);
+        taskDef.setTimeoutSeconds(1000);
+        taskDef.setResponseTimeoutSeconds(1);
+        taskDef.setOwnerEmail("owner@test.com");
+		taskDef.setInputDefinition(definition);
+		taskDef.setOutputDefinition(definition);
+
+        Set<ConstraintViolation<Object>> result = validator.validate(taskDef);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testTaskDefInvalidInputOutput() {
+        final Map<String, Object> definition = new HashMap<>();
+		definition.put("title", "invalid");
+		definition.put("type", "unknown type");
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("test-task");
+        taskDef.setRetryCount(1);
+        taskDef.setTimeoutSeconds(1000);
+        taskDef.setResponseTimeoutSeconds(1);
+        taskDef.setOwnerEmail("owner@test.com");
+		taskDef.setInputDefinition(definition);
+		taskDef.setOutputDefinition(definition);
+
+        Set<ConstraintViolation<Object>> result = validator.validate(taskDef);
+        assertEquals(6, result.size());
+
+        final List<String> validationErrors = new ArrayList<>();
+        result.forEach(e -> validationErrors.add(e.getMessage()));
+        assertTrue(validationErrors.contains("#: expected type: Boolean, found: JSONObject"));
+        assertTrue(validationErrors.contains("#/type: unknown type is not a valid enum value"));
+        assertTrue(validationErrors.contains("#/type: expected type: JSONArray, found: String"));
     }
 }

--- a/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
@@ -85,8 +85,10 @@ public class SubWorkflowParamsTest {
             "  \"name\" : \"test_workflow\",\n" +
             "  \"version\" : 1,\n" +
             "  \"workflowDefinition\" : {\n" +
+            "    \"inputDefinition\" : { },\n" +
             "    \"inputParameters\" : [ ],\n" +
             "    \"name\" : \"test_workflow\",\n" +
+            "    \"outputDefinition\" : { },\n" +
             "    \"outputParameters\" : { },\n" +
             "    \"restartable\" : true,\n" +
             "    \"schemaVersion\" : 2,\n" +

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile "javax.validation:validation-api:${revValidationApi}"
     // https://mvnrepository.com/artifact/org.glassfish/javax.el
     compile group: 'org.glassfish', name: 'javax.el', version: "${revJavaElApi}"
-    
+    compile "com.github.everit-org.json-schema:org.everit.json.schema:${revJsonSchema}"
+
     testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -491,6 +491,34 @@ public interface Configuration {
 	 */
 	Long getMaxTaskOutputPayloadSizeThresholdKB();
 
+    /**
+     * @return when set to true, task inputs are validated before any scheduling. If failed, the workflow will be terminated
+     */
+    default boolean isInputTaskValidationEnabled() {
+        return getBooleanProperty("conductor.validator.input.task", false);
+    }
+
+    /**
+     * @return when set to true, workflow inputs are validated before to start it. If failed, the workflow will not be created
+     */
+    default boolean isInputWorkflowValidationEnabled() {
+        return getBooleanProperty("conductor.validator.input.workflow", false);
+    }
+
+    /**
+     * @return when set to true, task outputs are validated before any task update. If failed, the received task is refused and ignored
+     */
+    default boolean isOutputTaskValidationEnabled() {
+        return getBooleanProperty("conductor.validator.output.task", false);
+    }
+
+    /**
+     * @return when set to true, workflow outputs are validated at workflow completion. If failed, the workflow will be mark as failed
+     */
+    default boolean isOutputWorkflowValidationEnabled() {
+        return getBooleanProperty("conductor.validator.output.workflow", false);
+    }
+
     enum DB {
         REDIS, DYNOMITE, MEMORY, REDIS_CLUSTER, MYSQL, POSTGRES, CASSANDRA, REDIS_SENTINEL
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/ValidationException.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/ValidationException.java
@@ -1,0 +1,22 @@
+package com.netflix.conductor.core.execution;
+
+import java.util.List;
+
+public class ValidationException extends ApplicationException {
+	private final int violationCount;
+	private final List<String> errors;
+
+	public ValidationException(final String message, int violationCount, List<String> errors) {
+		super(Code.INVALID_INPUT, message);
+		this.violationCount = violationCount;
+		this.errors = errors;
+	}
+
+	public int getViolationCount() {
+		return violationCount;
+	}
+
+	public List<String> getErrors() {
+		return errors;
+	}
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
@@ -13,6 +13,8 @@ import com.netflix.conductor.service.WorkflowBulkService;
 import com.netflix.conductor.service.WorkflowBulkServiceImpl;
 import com.netflix.conductor.service.WorkflowService;
 import com.netflix.conductor.service.WorkflowServiceImpl;
+import com.netflix.conductor.service.WorkflowValidator;
+import com.netflix.conductor.service.WorkflowValidatorImpl;
 
 /**
  * Default implementation for the workflow status listener
@@ -30,5 +32,6 @@ public class WorkflowExecutorModule extends AbstractModule {
         bind(TaskService.class).to(TaskServiceImpl.class);
         bind(EventService.class).to(EventServiceImpl.class);
         bind(MetadataService.class).to(MetadataServiceImpl.class);
+        bind(WorkflowValidator.class).to(WorkflowValidatorImpl.class);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowValidator.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowValidator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.service;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.Workflow;
+
+import java.util.Map;
+
+public interface WorkflowValidator {
+	void validate(final WorkflowDef workflowDef, final Workflow workflowInput);
+}

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowValidatorImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowValidatorImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.conductor.service;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.ValidationException;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+
+import java.util.List;
+
+
+public class WorkflowValidatorImpl implements WorkflowValidator {
+	@Override
+	public void validate(WorkflowDef workflowDef, Workflow workflow) {
+		if (workflowDef.getInputDefinition().isEmpty()) {
+			return;
+		}
+		final JSONObject jsonSchema = new JSONObject(workflow.getInput());
+		final JSONObject jsonSchemaDefinition = new JSONObject(workflowDef.getInputDefinition());
+		final Schema schema = SchemaLoader.builder().draftV7Support()
+				.schemaJson(jsonSchemaDefinition).build().load().build();
+		try {
+			schema.validate(jsonSchema);
+		} catch (final org.everit.json.schema.ValidationException e) {
+			final int violationCount = e.getViolationCount();
+			final String errorMessage = e.getErrorMessage();
+			final List<String> errors = e.getAllMessages();
+			throw new ValidationException(errorMessage, violationCount, errors);
+		}
+	}
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestConfiguration.java
@@ -154,4 +154,9 @@ public class TestConfiguration implements Configuration {
 	public long getLongProperty(String name, long defaultValue) {
 		return 1000000L;
 	}
+
+	@Override
+	public boolean isInputWorkflowValidationEnabled() {
+		return true;
+	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -50,8 +50,11 @@ import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.WorkflowValidator;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
@@ -104,6 +107,10 @@ public class TestWorkflowExecutor {
     private QueueDAO queueDAO;
     private WorkflowStatusListener workflowStatusListener;
     private ExecutionLockService executionLockService;
+    private WorkflowValidator workflowValidator;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void init() {
@@ -114,6 +121,7 @@ public class TestWorkflowExecutor {
         workflowStatusListener = mock(WorkflowStatusListener.class);
         ExternalPayloadStorageUtils externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         executionLockService = mock(ExecutionLockService.class);
+        workflowValidator = mock(WorkflowValidator.class);
         ObjectMapper objectMapper = new JsonMapperProvider().get();
         ParametersUtils parametersUtils = new ParametersUtils();
         Map<String, TaskMapper> taskMappers = new HashMap<>();
@@ -136,7 +144,7 @@ public class TestWorkflowExecutor {
         DeciderService deciderService = new DeciderService(parametersUtils, metadataDAO, externalPayloadStorageUtils, taskMappers, config);
         MetadataMapperService metadataMapperService = new MetadataMapperService(metadataDAO);
         workflowExecutor = new WorkflowExecutor(deciderService, metadataDAO, queueDAO, metadataMapperService,
-            workflowStatusListener, executionDAOFacade, config, executionLockService, parametersUtils);
+            workflowStatusListener, executionDAOFacade, config, executionLockService, parametersUtils, workflowValidator);
     }
 
     @Test
@@ -1472,6 +1480,35 @@ public class TestWorkflowExecutor {
                 taskToDomain);
 
         verify(executionDAOFacade, times(1)).createWorkflow(any(Workflow.class));
+    }
+
+    @Test
+    public void testInputDefinitionValidation() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("test");
+        def.setInputDefinition(new HashMap<>());
+
+        Map<String, Object> workflowInput = new HashMap<>();
+        String externalInputPayloadStoragePath = null;
+        String correlationId = null;
+        Integer priority = null;
+        String parentWorkflowId = null;
+        String parentWorkflowTaskId = null;
+        String event = null;
+        Map<String, String> taskToDomain = null;
+
+        doThrow(new ApplicationException(ApplicationException.Code.INVALID_INPUT, "Invalid Input")).when(workflowValidator).validate(eq(def), any());
+        expectedException.expect(ApplicationException.class);
+        expectedException.expectMessage("Invalid Input");
+        workflowExecutor.startWorkflow(def,
+            workflowInput,
+            externalInputPayloadStoragePath,
+            correlationId,
+            priority,
+            parentWorkflowId,
+            parentWorkflowTaskId,
+            event,
+            taskToDomain);
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowValidator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowValidator.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.utils.JsonMapperProvider;
+import com.netflix.conductor.service.WorkflowValidator;
+import com.netflix.conductor.service.WorkflowValidatorImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Viren
+ */
+public class TestWorkflowValidator {
+	private WorkflowValidator workflowValidator;
+
+	@Before
+	public void init() {
+		workflowValidator = new WorkflowValidatorImpl();
+	}
+
+	@Test
+	public void testEmptyInput() throws JsonProcessingException {
+		final WorkflowDef def = new WorkflowDef();
+		def.setInputDefinition(generateInputDefinition());
+		final Map<String, Object> inputs = new HashMap<>();
+		final Workflow workflow = new Workflow();
+		workflow.setInput(inputs);
+		workflowValidator.validate(def, workflow);
+	}
+
+	@Test
+	public void testSingleInvalidInput() throws JsonProcessingException {
+		final WorkflowDef def = new WorkflowDef();
+		def.setInputDefinition(generateInputDefinition());
+		final Map<String, Object> inputs = new HashMap<>();
+		inputs.put("person", Collections.emptyMap());
+		final Workflow workflow = new Workflow();
+		workflow.setInput(inputs);
+
+		try {
+			workflowValidator.validate(def, workflow);
+		} catch (final ValidationException e) {
+			Assert.assertEquals(1, e.getViolationCount());
+			Assert.assertEquals(1, e.getErrors().size());
+			Assert.assertEquals("#/person: required key [name] not found", e.getErrors().get(0));
+		}
+	}
+
+	@Test
+	public void testMultipleInvalidInputs() throws JsonProcessingException {
+		final WorkflowDef def = new WorkflowDef();
+		def.setInputDefinition(generateInputDefinition());
+		final Map<String, Object> inputs = new HashMap<>();
+		inputs.put("person", Collections.singletonMap("age", 11));
+		final Workflow workflow = new Workflow();
+		workflow.setInput(inputs);
+
+		try {
+			workflowValidator.validate(def, workflow);
+		} catch (final ValidationException e) {
+			Assert.assertEquals(2, e.getViolationCount());
+			Assert.assertEquals(2, e.getErrors().size());
+			Assert.assertEquals("#/person: required key [name] not found", e.getErrors().get(0));
+			Assert.assertEquals("#/person/age: 11 is not greater or equal to 18", e.getErrors().get(1));
+		}
+	}
+
+	@Test
+	public void testValidInput() throws JsonProcessingException {
+		final WorkflowDef def = new WorkflowDef();
+		def.setInputDefinition(generateInputDefinition());
+		final Map<String, Object> person = new HashMap<>();
+		person.put("name", "John");
+		person.put("age", 24);
+		final Map<String, Object> inputs = Collections.singletonMap("person", person);
+		final Workflow workflow = new Workflow();
+		workflow.setInput(inputs);
+		workflowValidator.validate(def, workflow);
+
+	}
+
+	private Map<String, Object> generateInputDefinition() throws JsonProcessingException {
+		final String inputDefinition = "{"
+			+ "\"type\": \"object\","
+		    + "\"properties\": {"
+				+ "\"person\": {"
+					+ "\"type\": \"object\","
+					+ "\"description\": \"Testing nested properties\","
+					+ "\"required\": [\"name\"],"
+					+ "\"properties\": {"
+						+ "\"name\": {"
+							+ "\"type\": \"string\""
+						+ "},"
+						+ "\"age\": {"
+							+ "\"type\": \"integer\","
+							+ "\"minimum\": 18,"
+							+ "\"maximum\": 99"
+						+ "}"
+					+ "}"
+				+ "}"
+			+ "}"
+		+ "}";
+		final ObjectMapper objectMapper = new JsonMapperProvider().get();
+		return objectMapper.readValue(inputDefinition, Map.class);
+	}
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/DoWhileTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.WorkflowValidator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,6 +63,7 @@ public class DoWhileTest {
     WorkflowStatusListener workflowStatusListener ;
     ExecutionDAOFacade executionDAOFacade;
     ExecutionLockService executionLockService;
+    WorkflowValidator workflowValidator;
     Configuration config;
     ParametersUtils parametersUtils;
 
@@ -77,9 +79,10 @@ public class DoWhileTest {
         workflowStatusListener = Mockito.mock(WorkflowStatusListener.class);
         executionDAOFacade = Mockito.mock(ExecutionDAOFacade.class);
         executionLockService = Mockito.mock(ExecutionLockService.class);
+        workflowValidator = Mockito.mock(WorkflowValidator.class);
         config = Mockito.mock(Configuration.class);
         provider = spy(new WorkflowExecutor(deciderService, metadataDAO, queueDAO, metadataMapperService,
-                workflowStatusListener, executionDAOFacade, config, executionLockService, parametersUtils));
+                workflowStatusListener, executionDAOFacade, config, executionLockService, parametersUtils, workflowValidator));
         loopWorkflowTask1 = new WorkflowTask();
         loopWorkflowTask1.setTaskReferenceName("task1");
         loopWorkflowTask1.setName("task1");

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -24,6 +24,7 @@ ext {
     revHealth = '1.1.+'
     revHikariCP = '3.2.0'
     revJsonPath = '2.2.0'
+    revJsonSchema = '1.12.1'
     revJaxrsJackson = '2.10.0'
     revJavaElApi = '3.0.0'
     revBval = '2.0.3'


### PR DESCRIPTION
Hello, based on this discussion #1164, I would like to contribute by providing a way to define a better structure for task and workflow input/output, adding the possibility to validate them. I decided to opt for json schema to define the structure, as it is meant exactly for validation. For the implementation in Java, I decided to use [everit-org](https://github.com/everit-org/json-schema).
I decided to create this PR in order to collect feedback.

Here the list of steps that I want to follow:
1. Adding new field for input/output for task and workflow, and marking old one as deprecated - DONE
2. Adding configuration to enable/disable validation - DONE
3. Performing a validation on the Json Schema provided by the user inside the WorkflowDef/MetadataTask - DONE
4. Validate workflow input at creation time, preventing its creation in case of failure - DONE
5. Validate task input at scheduling time, failing the entire workflow in case of failure - ONGOING
6. Validate task output at updating time, rejecting the task if it is not compliant - ONGOING
7. Validate workflow output once the last task is completed, failing the workflow if the output is not valid - ONGOING
8. Add support for custom validators (cf. https://github.com/everit-org/json-schema#example) 

Please do not hesitate to provide feedback