### PR TITLE
Updated go client to only include domain param when given

### DIFF
--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -195,10 +195,7 @@ func (c *ConductorHttpClient) PollForTask(taskType string, workerid string, doma
     }
     // only add the domain if requested, otherwise conductor will silently fail (https://github.com/Netflix/conductor/issues/1952)
     if domain != "" {
-        log.Println("Polling for task with domain: ", domain, "taskType: ", taskType)
         params["domain"] = domain
-    } else {
-        log.Println("Polling for task without domain, taskType: ", taskType)
     }
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {
@@ -216,10 +213,7 @@ func (c *ConductorHttpClient) AckTask(taskId, workerid, domain string) (string, 
     }
     // only add the domain if requested, otherwise conductor will silently fail (https://github.com/Netflix/conductor/issues/1952)
     if domain != "" {
-        log.Println("Acking task with domain: ", domain, "taskid: ", taskId)
         params["domain"] = domain
-    } else {
-        log.Println("Acking task without domain, taskid: ", taskId)
     }
     headers := map[string]string{"Accept": "application/json"}
     outputString, err := c.httpClient.Post(url, params, headers, "")

--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -193,11 +193,12 @@ func (c *ConductorHttpClient) PollForTask(taskType string, workerid string, doma
     params := map[string]string{
         "workerid": workerid,
     }
+    // only add the domain if requested, otherwise conductor will silently fail (https://github.com/Netflix/conductor/issues/1952)
     if domain != "" {
-        log.Println("Acking task with domain: ", domain, "taskType: ", taskType)
+        log.Println("Polling for task with domain: ", domain, "taskType: ", taskType)
         params["domain"] = domain
     } else {
-        log.Println("Acking task without domain, taskType: ", taskType)
+        log.Println("Polling for task without domain, taskType: ", taskType)
     }
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {

--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -207,7 +207,13 @@ func (c *ConductorHttpClient) AckTask(taskId, workerid, domain string) (string, 
     url := c.httpClient.MakeUrl("/tasks/{taskId}/ack", "{taskId}", taskId)
     params := map[string]string{
         "workerid": workerid,
-	"domain": domain,
+    }
+    // only add the domain if requested, otherwise conductor will silently fail (https://github.com/Netflix/conductor/issues/1952)
+    if domain != "" {
+        log.Println("Acking task with domain: ", domain, "taskid: ", taskId)
+        params["domain"] = domain
+    } else {
+        log.Println("Acking task without domain, taskid: ", taskId)
     }
     headers := map[string]string{"Accept": "application/json"}
     outputString, err := c.httpClient.Post(url, params, headers, "")

--- a/client/go/conductorhttpclient.go
+++ b/client/go/conductorhttpclient.go
@@ -192,7 +192,12 @@ func (c *ConductorHttpClient) PollForTask(taskType string, workerid string, doma
     url := c.httpClient.MakeUrl("/tasks/poll/{taskType}", "{taskType}", taskType)
     params := map[string]string{
         "workerid": workerid,
-        "domain":   domain,
+    }
+    if domain != "" {
+        log.Println("Acking task with domain: ", domain, "taskType: ", taskType)
+        params["domain"] = domain
+    } else {
+        log.Println("Acking task without domain, taskType: ", taskType)
     }
     outputString, err := c.httpClient.Get(url, params, nil)
     if err != nil {


### PR DESCRIPTION
Configured the Ack and PollForTask methods to only include the "domain" parameter if explicitly requested. 

See #1952 