### PR TITLE
add asyncComplete support to Kafka publish task

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -92,7 +92,11 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 			Future<RecordMetadata> recordMetaDataFuture = kafkaPublish(input);
 			try {
 				recordMetaDataFuture.get();
-				task.setStatus(Task.Status.COMPLETED);
+				if (isAsyncComplete(task)) {
+					task.setStatus(Task.Status.IN_PROGRESS);
+				} else {
+					task.setStatus(Task.Status.COMPLETED);
+				}
 				long timeTakenToCompleteTask = Instant.now().toEpochMilli() - taskStartMillis;
 				logger.debug("Published message {}, Time taken {}", input, timeTakenToCompleteTask);
 

--- a/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaPublishTask.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/kafka/TestKafkaPublishTask.java
@@ -128,6 +128,24 @@ public class TestKafkaPublishTask {
 		Assert.assertEquals(Task.Status.COMPLETED, task.getStatus());
 	}
 
+	@Test
+	public void kafkaPublishSuccess_AsyncComplete() {
+
+		Task task = getTask();
+		task.getInputData().put("asyncComplete", true);
+
+		KafkaProducerManager producerManager = Mockito.mock(KafkaProducerManager.class);
+		KafkaPublishTask kPublishTask = new KafkaPublishTask(new SystemPropertiesConfiguration(), producerManager, objectMapper);
+
+		Producer producer = Mockito.mock(Producer.class);
+
+		Mockito.when(producerManager.getProducer(Mockito.any())).thenReturn(producer);
+		Mockito.when(producer.send(Mockito.any())).thenReturn(Mockito.mock(Future.class));
+
+		kPublishTask.start(Mockito.mock(Workflow.class), task, Mockito.mock(WorkflowExecutor.class));
+		Assert.assertEquals(Task.Status.IN_PROGRESS, task.getStatus());
+	}
+
 	private Task getTask() {
 		Task task = new Task();
 		KafkaPublishTask.Input input = new KafkaPublishTask.Input();

--- a/docs/docs/apispec.md
+++ b/docs/docs/apispec.md
@@ -33,7 +33,7 @@ JSON for start workflow request
 {
   "name": "myWorkflow", // Name of the workflow
   "version": 1, // Version
-  “correlationId”: “corr1”, // correlation Id
+  "correlationId": "corr1", // correlation Id
   "priority": 1, // Priority
   "input": {
 	// Input map. 

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -582,11 +582,16 @@ For example, if you have a decision where the first condition is met, you want t
 
 ## Kafka Publish Task
 
-A kafka Publish task is used to push messages to another microservice via kafka
+A kafka Publish task is used to push messages to another microservice via kafka.
 
 **Parameters:**
 
-The task expects an input parameter named ```kafka_request``` as part of the task's input with the following details:
+|name|type|description|
+|---|---|---|
+| kafka_request | kafkaRequest | JSON object (see below) |
+| asyncComplete | Boolean | ```false``` to mark status COMPLETED upon execution ; ```true``` to keep it IN_PROGRESS, wait for an external event (via Conductor or SQS or EventHandler) to complete it. |
+
+```kafkaRequest``` JSON object:
 
 |name|description|
 |---|---|
@@ -601,10 +606,6 @@ The task expects an input parameter named ```kafka_request``` as part of the tas
 
 The producer created in the kafka task is cached. By default the cache size is 10 and expiry time is 120000 ms. To change the defaults following can be modified kafka.publish.producer.cache.size,kafka.publish.producer.cache.time.ms respectively.  
 
-**Kafka Task Output**
-
-Task status transitions to COMPLETED
-
 **Example**
 
 Task sample
@@ -614,6 +615,7 @@ Task sample
   "name": "call_kafka",
   "taskReferenceName": "call_kafka",
   "inputParameters": {
+    "asyncComplete": false,
     "kafka_request": {
       "topic": "userTopic",
       "value": "Message to publish",


### PR DESCRIPTION
Added asyncComplete  support to kafka publish task (like in the http task).
If the asyncComplete parameter is set to true, the task remain in IN_PROGRESS state and wait for an external event to complete.