### PR TITLE
Python Client: Error print statement now also prints exec_function name.

### DIFF
--- a/client/python/conductor/ConductorWorker.py
+++ b/client/python/conductor/ConductorWorker.py
@@ -78,7 +78,7 @@ class ConductorWorker:
                 task['reasonForIncompletion'] = resp['reasonForIncompletion']
             self.taskClient.updateTask(task)
         except Exception as err:
-            print('Error executing task: ' + str(err))
+            print(f'Error executing task: {exec_function.__name__} with error: {str(err)}')
             task['status'] = 'FAILED'
             self.taskClient.updateTask(task)
 


### PR DESCRIPTION
Detecting errors happening when a workflow is running is somewhat difficult. When the workers log the problematic exec_function's name, it is much easier to detect the issue without having to view the Conductor UI.