### PR TITLE
Fix for bug #1968 - handle response code in upload PayloadStorage

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     compile "commons-io:commons-io:${revApacheCommons}"
 
     testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"
+    testCompile "org.powermock:powermock-module-junit4:${revPowerMock}"
+    testCompile "org.powermock:powermock-api-mockito2:${revPowerMock}"
 }
 
 tasks.withType(FindBugs) {

--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -614,6 +614,14 @@
             "locked": "3.1.0",
             "requested": "3.1.0"
         },
+        "org.powermock:powermock-api-mockito2": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
+        "org.powermock:powermock-module-junit4": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
@@ -724,6 +732,14 @@
         "org.mockito:mockito-core": {
             "locked": "3.1.0",
             "requested": "3.1.0"
+        },
+        "org.powermock:powermock-api-mockito2": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
+        "org.powermock:powermock-module-junit4": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -836,6 +852,14 @@
             "locked": "3.1.0",
             "requested": "3.1.0"
         },
+        "org.powermock:powermock-api-mockito2": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
+        "org.powermock:powermock-module-junit4": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
@@ -946,6 +970,14 @@
         "org.mockito:mockito-core": {
             "locked": "3.1.0",
             "requested": "3.1.0"
+        },
+        "org.powermock:powermock-api-mockito2": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
+        },
+        "org.powermock:powermock-module-junit4": {
+            "locked": "2.0.9",
+            "requested": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/client/src/test/java/com/netflix/conductor/client/http/PayloadStorageTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/PayloadStorageTest.java
@@ -1,0 +1,126 @@
+package com.netflix.conductor.client.http;
+
+
+import com.netflix.conductor.client.exceptions.ConductorClientException;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PayloadStorage.class})
+public class PayloadStorageTest {
+
+    @InjectMocks
+    PayloadStorage payloadStorage;
+
+    @Mock
+    ClientBase clientBase;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+
+    @Test
+    public void testUploadSuccessfully2xx() throws Exception {
+
+        URI uriMock = PowerMockito.mock(URI.class);
+        URL urlMock = PowerMockito.mock(URL.class);
+        HttpURLConnection httpURLConnection = PowerMockito.mock(HttpURLConnection.class);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        whenNew(URI.class).withAnyArguments().thenReturn(uriMock);
+        when(uriMock.toURL()).thenReturn(urlMock);
+        when(urlMock.openConnection()).thenReturn(httpURLConnection);
+        when(httpURLConnection.getResponseCode()).thenReturn(200);
+        when(httpURLConnection.getOutputStream()).thenReturn(outputStream);
+
+        String payload = "my payload my payload my payload my payload";
+        InputStream payloadInputStream = IOUtils.toInputStream(payload, Charset.defaultCharset());
+
+        payloadStorage.upload("http://url", payloadInputStream, payload.length());
+
+        assertArrayEquals(payload.getBytes(Charset.defaultCharset()), outputStream.toByteArray());
+        Mockito.verify(httpURLConnection).disconnect();
+
+    }
+
+
+    @Test
+    public void testUploadFailure4xx() throws Exception {
+
+        // set expected exception
+        expectedException.expect(ConductorClientException.class);
+        expectedException.expectMessage("Unable to upload. Response code: 400");
+
+        URI uriMock = PowerMockito.mock(URI.class);
+        URL urlMock = PowerMockito.mock(URL.class);
+        HttpURLConnection httpURLConnection = PowerMockito.mock(HttpURLConnection.class);
+        OutputStream outputStream = new ByteArrayOutputStream();
+
+        whenNew(URI.class).withAnyArguments().thenReturn(uriMock);
+        when(uriMock.toURL()).thenReturn(urlMock);
+        when(urlMock.openConnection()).thenReturn(httpURLConnection);
+        when(httpURLConnection.getResponseCode()).thenReturn(400);
+        when(httpURLConnection.getOutputStream()).thenReturn(outputStream);
+
+        String payload = "my payload my payload my payload my payload";
+        InputStream payloadInputStream = IOUtils.toInputStream(payload, Charset.defaultCharset());
+
+        payloadStorage.upload("http://url", payloadInputStream, payload.length());
+
+        Mockito.verify(httpURLConnection).disconnect();
+    }
+
+
+    @Test
+    public void testUploadInvalidUrl() {
+
+        // set expected exception
+        expectedException.expect(ConductorClientException.class);
+        expectedException.expectMessage("Invalid path specified: http://invalidUrl/^");
+
+        payloadStorage.upload("http://invalidUrl/^", null, 0);
+    }
+
+
+    @Test
+    public void testUploadIOException() throws Exception {
+
+        // set expected exception
+        expectedException.expect(ConductorClientException.class);
+        expectedException.expectMessage("Error uploading to path: http://url");
+
+        URI uriMock = PowerMockito.mock(URI.class);
+        URL urlMock = PowerMockito.mock(URL.class);
+
+        whenNew(URI.class).withAnyArguments().thenReturn(uriMock);
+        when(uriMock.toURL()).thenReturn(urlMock);
+        when(urlMock.openConnection()).thenThrow(new IOException("my exception"));
+
+        payloadStorage.upload("http://url", null, 0);
+    }
+
+
+}

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -43,6 +43,7 @@ ext {
     revLog4jApi = '2.9.1'
     revLog4jCore = '2.9.1'
     revMockito = '3.1.0'
+    revPowerMock = '2.0.9'
     revMySqlConnector = '8.0.11'
     revNatsStreaming = '0.5.0'
     revOauthClient = '1.19.4'


### PR DESCRIPTION
Fix for bug #1968. Throw exception if response code isn't 2xx.