### PR TITLE
avoid deep recursive WorkflowExecutor.decide calls, which may cause oom.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/eventbus/DecideAsyncEventBus.java
+++ b/core/src/main/java/com/netflix/conductor/core/eventbus/DecideAsyncEventBus.java
@@ -1,0 +1,33 @@
+package com.netflix.conductor.core.eventbus;
+
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.EventBus;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DecideAsyncEventBus {
+
+    private static ExecutorService executorService =
+            new ThreadPoolExecutor(5, 10, 60L, TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(1000));
+
+    public static class EventBusHolder {
+
+        private static EventBus BUS = new AsyncEventBus(executorService);
+    }
+
+    public static void postEvent(Object event) {
+        EventBusHolder.BUS.post(event);
+    }
+
+    public static void register(Object listener) {
+        EventBusHolder.BUS.register(listener);
+    }
+
+    public static void unregister(Object listener) {
+        EventBusHolder.BUS.unregister(listener);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/eventbus/DecideEvent.java
+++ b/core/src/main/java/com/netflix/conductor/core/eventbus/DecideEvent.java
@@ -1,0 +1,18 @@
+package com.netflix.conductor.core.eventbus;
+
+public class DecideEvent {
+
+    private String workflowId;
+
+    public DecideEvent(String workflowId) {
+        this.workflowId = workflowId;
+    }
+
+    public String getWorkflowId() {
+        return workflowId;
+    }
+
+    public void setWorkflowId(String workflowId) {
+        this.workflowId = workflowId;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/eventbus/DecideEventListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/eventbus/DecideEventListener.java
@@ -1,0 +1,19 @@
+package com.netflix.conductor.core.eventbus;
+
+import com.google.common.eventbus.AllowConcurrentEvents;
+import com.google.common.eventbus.Subscribe;
+
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import javax.inject.Inject;
+
+public class DecideEventListener {
+
+    @Inject
+    private WorkflowExecutor workflowExecutor;
+
+    @Subscribe
+    @AllowConcurrentEvents
+    public void onDecideEvent(DecideEvent decideEvent) {
+        workflowExecutor.decide(decideEvent.getWorkflowId());
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -44,6 +44,8 @@ import com.netflix.conductor.common.utils.RetryUtil;
 import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.WorkflowContext;
 import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.eventbus.DecideAsyncEventBus;
+import com.netflix.conductor.core.eventbus.DecideEvent;
 import com.netflix.conductor.core.execution.ApplicationException.Code;
 import com.netflix.conductor.core.execution.tasks.SubWorkflow;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
@@ -1061,7 +1063,8 @@ public class WorkflowExecutor {
             stateChanged = scheduleTask(workflow, tasksToBeScheduled) || stateChanged;
 
             if (stateChanged) {
-                decide(workflowId);
+                // async process
+                DecideAsyncEventBus.postEvent(new DecideEvent(workflowId));
             }
 
         } catch (TerminateWorkflowException twe) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorModule.java
@@ -1,6 +1,8 @@
 package com.netflix.conductor.core.execution;
 
 import com.google.inject.AbstractModule;
+import com.netflix.conductor.core.eventbus.DecideAsyncEventBus;
+import com.netflix.conductor.core.eventbus.DecideEventListener;
 import com.netflix.conductor.service.AdminService;
 import com.netflix.conductor.service.AdminServiceImpl;
 import com.netflix.conductor.service.EventService;
@@ -30,5 +32,14 @@ public class WorkflowExecutorModule extends AbstractModule {
         bind(TaskService.class).to(TaskServiceImpl.class);
         bind(EventService.class).to(EventServiceImpl.class);
         bind(MetadataService.class).to(MetadataServiceImpl.class);
+
+        // events
+        bindEvents();
+    }
+
+    private void bindEvents(){
+        DecideEventListener decideEventListener = new DecideEventListener();
+        requestInjection(decideEventListener);
+        DecideAsyncEventBus.register(decideEventListener);
     }
 }


### PR DESCRIPTION
fix [issues#2007 ](https://github.com/Netflix/conductor/issues/2007)