### PR TITLE
modify primary key on queue_message table

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
@@ -1,0 +1,24 @@
+# no longer need separate index if pk is queue_name, message_id
+SET @idx_exists := (SELECT COUNT(INDEX_NAME)
+                    FROM information_schema.STATISTICS
+                    WHERE `TABLE_NAME` = 'queue_message'
+                      AND `INDEX_NAME` = 'unique_queue_name_message_id'
+                      AND TABLE_SCHEMA = database());
+SET @idxstmt := IF(@idx_exists > 0, 'ALTER TABLE `queue_message` DROP INDEX `unique_queue_name_message_id`',
+                                    'SELECT ''INFO: Index unique_queue_name_message_id does not exist.''');
+PREPARE stmt1 FROM @idxstmt;
+EXECUTE stmt1;
+
+# remove id column
+set @col_exists := (SELECT COUNT(*)
+                    FROM information_schema.COLUMNS
+                    WHERE `TABLE_NAME`  = 'queue_message'
+                      AND `COLUMN_NAME` = 'id'
+                      AND TABLE_SCHEMA  = database());
+SET @colstmt := IF(@col_exists > 0, 'ALTER TABLE `queue_message` DROP COLUMN `id`',
+                                    'SELECT ''INFO: Column id does not exist.''') ;
+PREPARE stmt2 from @colstmt;
+EXECUTE stmt2;
+
+# set primary key to queue_name, message_id
+ALTER TABLE queue_message ADD PRIMARY KEY (queue_name, message_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
@@ -1,0 +1,11 @@
+-- no longer need separate index if pk is queue_name, message_id
+DROP INDEX IF EXISTS unique_queue_name_message_id;
+
+-- remove id primary key
+ALTER TABLE queue_message DROP CONSTRAINT IF EXISTS queue_message_pkey;
+
+-- remove id column
+ALTER TABLE queue_message DROP COLUMN IF EXISTS id;
+
+-- set primary key to queue_name, message_id
+ALTER TABLE queue_message ADD PRIMARY KEY (queue_name, message_id);


### PR DESCRIPTION
This PR modifies the primary key on the queue_message table to be queue_name, message_id columns for postgres and mysql. 

Currently, on the queue_message table, there is a primary key of 'id' (SERIAL) and a unique index of 'queue_name' and 'message_id' columns. (both columns non-null) Since, AFAICT, the id column is unused, the index should replace id as the primary key. 

The motivation behind this PR is to enable support for sharding the queue_message table using Citus. (see #1997) In order to shard, the queue_message table cannot have a unique constraint or primary key that does not include the partition (shard) column. By removing the id pk/column and replacing the pk with the existing unique index, the queue_message table can be sharded in Citus. (by queue_name or message_id)

While Citus is postgres only, these changes seem appropriate for mysql as well.

@kishorebanala @raghavendra-bhat
