### PR TITLE
Issue #2026: Fixed the retry mechanism for subworkflows so that retry starts from the last failed task.

### DIFF
--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.core.execution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -895,6 +896,89 @@ public class TestWorkflowExecutor {
         assertEquals(6, workflow.getTasks().size());
         assertEquals(Workflow.WorkflowStatus.RUNNING, workflow.getStatus());
     }
+
+
+    @Test
+    public void testRetryFromLastFailedSubWorkflowTaskThenStartWithLastFailedTask() {
+
+        //given
+        String id = IDGenerator.generate();
+        String workflowInstanceId = IDGenerator.generate();
+        Task task = new Task();
+        task.setTaskType(TaskType.SIMPLE.name());
+        task.setTaskDefName("task");
+        task.setReferenceTaskName("task_ref");
+        task.setWorkflowInstanceId(workflowInstanceId);
+        task.setScheduledTime(System.currentTimeMillis());
+        task.setTaskId(IDGenerator.generate());
+        task.setStatus(Status.COMPLETED);
+        task.setRetryCount(0);
+        task.setWorkflowTask(new WorkflowTask());
+        task.setOutputData(new HashMap<>());
+        task.setSubWorkflowId(id);
+        task.setSeq(1);
+
+        Task task1 = new Task();
+        task1.setTaskType(TaskType.SIMPLE.name());
+        task1.setTaskDefName("task1");
+        task1.setReferenceTaskName("task1_ref");
+        task1.setWorkflowInstanceId(workflowInstanceId);
+        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setTaskId(IDGenerator.generate());
+        task1.setStatus(Status.FAILED);
+        task1.setRetryCount(0);
+        task1.setWorkflowTask(new WorkflowTask());
+        task1.setOutputData(new HashMap<>());
+        task1.setSubWorkflowId(id);
+        task1.setSeq(2);
+
+        Workflow subWorkflow = new Workflow();
+        subWorkflow.setWorkflowId(id);
+        subWorkflow.setStatus(Workflow.WorkflowStatus.FAILED);
+        subWorkflow.setTasks(Lists.newArrayList(task,task1));
+        subWorkflow.setParentWorkflowId("testRunWorkflowId");
+
+        Task task2 = new Task();
+        task2.setWorkflowInstanceId(subWorkflow.getWorkflowId());
+        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setTaskId(IDGenerator.generate());
+        task2.setStatus(Status.FAILED);
+        task2.setRetryCount(0);
+        task2.setOutputData(new HashMap<>());
+        task2.setSubWorkflowId(id);
+        task2.setTaskType(TaskType.SUB_WORKFLOW.name());
+
+
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowId("testRunWorkflowId");
+        workflow.setStatus(Workflow.WorkflowStatus.FAILED);
+        workflow.setTasks(Collections.singletonList(task2));
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("first_workflow");
+        workflow.setWorkflowDefinition(workflowDef);
+
+
+
+        //when
+        when(executionDAOFacade.getWorkflowById(workflow.getWorkflowId(), true)).thenReturn(workflow);
+        when(executionDAOFacade.getWorkflowById(task.getSubWorkflowId(), true)).thenReturn(subWorkflow);
+        when(metadataDAO.getWorkflowDef(anyString(), anyInt())).thenReturn(Optional.of(workflowDef));
+        when(executionDAOFacade.getTaskById(subWorkflow.getParentWorkflowTaskId())).thenReturn(task1);
+        when(executionDAOFacade.getWorkflowById(subWorkflow.getParentWorkflowId(), false)).thenReturn(workflow);
+
+        workflowExecutor.retry(workflow.getWorkflowId());
+
+        //then
+        assertEquals(task.getStatus(), Status.COMPLETED);
+        assertEquals(task1.getStatus(),Status.IN_PROGRESS);
+        assertEquals(workflow.getStatus(),WorkflowStatus.RUNNING);
+        assertEquals(subWorkflow.getStatus(),WorkflowStatus.RUNNING);
+
+    }
+
+
+
+
 
     @Test
     public void testRerunWorkflow() {


### PR DESCRIPTION
Issue #2012: Fixed the retry mechanism for subworkflows so that retry starts from the last failed task.

Co-authors: @grkn @azb96