### PR TITLE
increase the reason for incompletion limit

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -546,7 +546,7 @@ public class Task {
      * @param reasonForIncompletion the reasonForIncompletion to set
      */
     public void setReasonForIncompletion(String reasonForIncompletion) {
-        this.reasonForIncompletion = StringUtils.substring(reasonForIncompletion, 0, 500);
+        this.reasonForIncompletion = StringUtils.substring(reasonForIncompletion, 0, 1000);
     }
 
     /**


### PR DESCRIPTION
This causes some clipping in some cases, so doubling the limit to fix that.