### PR TITLE
doc: Update apispec sort format from <direction>:<fieldname> to <fieldname>:<direction>

### DIFF
--- a/docs/docs/apispec.md
+++ b/docs/docs/apispec.md
@@ -66,7 +66,7 @@ Conductor uses Elasticsearch for indexing workflow execution and is used by sear
 |---|---|
 |start|Page number.  Defaults to 0|
 |size|Number of results to return|
-|sort|Sorting.  Format is: `ASC:<fieldname>` or `DESC:<fieldname>` to sort in ascending or descending order by a field|
+|sort|Sorting.  Format is: `<fieldname>:ASC` or `<fieldname>:DESC` to sort in ascending or descending order by a field|
 |freeText|Elasticsearch supported query. e.g. workflowType:"name_of_workflow"|
 |query|SQL like where clause.  e.g. workflowType = 'name_of_workflow'.  Optional if freeText is provided.|
 


### PR DESCRIPTION
### What
doc: Update apispec sort format from `<direction>:<fieldname>` to `<fieldname>:<direction>`.

### Why
The implementation uses the reversed format, than what is in the docs. Implementation is here:
https://github.com/Netflix/conductor/blob/be9e74ebd8ee784abb2b5d0eeb9d4c3786fe108f/jersey/src/main/java/com/netflix/conductor/server/resources/WorkflowResource.java#L214

Note: Swagger UI already matches the implementation, so no change needed there.
![SwaggerUI](https://user-images.githubusercontent.com/2981255/104057581-654c4500-51c0-11eb-9ad0-0c7fad384368.png)

