### PR TITLE
Fix case where decision task is followed by a terminate task

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -20,19 +20,19 @@ import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.constraints.TaskReferenceNameUniqueConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @ProtoMessage
 @TaskReferenceNameUniqueConstraint
@@ -304,6 +304,11 @@ public class WorkflowDef extends Auditable {
     }
 
     public WorkflowTask getNextTask(String taskReferenceName) {
+        WorkflowTask workflowTask = getTaskByRefName(taskReferenceName);
+        if (workflowTask != null && TaskType.TERMINATE.name().equals(workflowTask.getType())) {
+            return null;
+        }
+
         Iterator<WorkflowTask> iterator = tasks.iterator();
         while (iterator.hasNext()) {
             WorkflowTask task = iterator.next();

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -620,6 +620,7 @@ public class WorkflowTask {
                 }
                 break;
             case DYNAMIC:
+            case TERMINATE:
             case SIMPLE:
                 return null;
             default:

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -20,13 +20,12 @@ import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component(SubWorkflow.NAME)
 public class SubWorkflow extends WorkflowSystemTask {
@@ -138,9 +137,10 @@ public class SubWorkflow extends WorkflowSystemTask {
         }
         Workflow subWorkflow = provider.getWorkflow(workflowId, true);
         subWorkflow.setStatus(WorkflowStatus.TERMINATED);
-        provider
-            .terminateWorkflow(subWorkflow, "Parent workflow has been terminated with status " + workflow.getStatus(),
-                null);
+        String reason = StringUtils.isEmpty(workflow.getReasonForIncompletion())
+            ? "Parent workflow has been terminated with status " + workflow.getStatus()
+            : "Parent workflow has been terminated with reason: " + workflow.getReasonForIncompletion();
+        provider.terminateWorkflow(subWorkflow, reason, null);
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Terminate.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Terminate.java
@@ -12,19 +12,16 @@
  */
 package com.netflix.conductor.core.execution.tasks;
 
+import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.COMPLETED;
+import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.FAILED;
+
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.COMPLETED;
-import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.FAILED;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Task that can terminate a workflow with a given status and modify the workflow's output with a given parameter, it
@@ -56,7 +53,6 @@ import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.FAILED;
 @Component(Terminate.NAME)
 public class Terminate extends WorkflowSystemTask {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Terminate.class);
     private static final String TERMINATION_STATUS_PARAMETER = "terminationStatus";
     private static final String TERMINATION_WORKFLOW_OUTPUT = "workflowOutput";
     public static final String NAME = "TERMINATE";
@@ -71,9 +67,7 @@ public class Terminate extends WorkflowSystemTask {
         String returnStatus = (String) task.getInputData().get(TERMINATION_STATUS_PARAMETER);
 
         if (validateInputStatus(returnStatus)) {
-            workflow.setStatus(Workflow.WorkflowStatus.valueOf(returnStatus));
             task.setOutputData(getInputFromParam(task.getInputData()));
-            setWorkflowOutput(task.getOutputData(), workflow);
             task.setStatus(Task.Status.COMPLETED);
             return true;
         }
@@ -92,12 +86,6 @@ public class Terminate extends WorkflowSystemTask {
 
     public static Boolean validateInputStatus(String status) {
         return COMPLETED.name().equals(status) || FAILED.name().equals(status);
-    }
-
-    private void setWorkflowOutput(Map<String, Object> taskOutput, Workflow workflow) {
-        if (!taskOutput.isEmpty()) {
-            workflow.setOutput(taskOutput);
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1075,6 +1075,56 @@ public class TestDeciderService {
         }
     }
 
+    @Test
+    public void testCheckForWorkflowCompletion() {
+        WorkflowDef conditionalWorkflowDef = createConditionalWF();
+        WorkflowTask terminateWT = new WorkflowTask();
+        terminateWT.setType(TaskType.TERMINATE.name());
+        terminateWT.setTaskReferenceName("terminate");
+        terminateWT.setName("terminate");
+        terminateWT.getInputParameters().put("terminationStatus", "COMPLETED");
+        conditionalWorkflowDef.getTasks().add(terminateWT);
+
+        // when workflow has no tasks
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowDefinition(conditionalWorkflowDef);
+
+        // then workflow completion check returns false
+        assertFalse(deciderService.checkForWorkflowCompletion(workflow));
+
+        // when only part of the tasks are completed
+        Task decTask = new Task();
+        decTask.setTaskType(TaskType.DECISION.name());
+        decTask.setReferenceTaskName("conditional2");
+        decTask.setStatus(Status.COMPLETED);
+
+        Task task1 = new Task();
+        decTask.setTaskType(TaskType.SIMPLE.name());
+        task1.setReferenceTaskName("t1");
+        task1.setStatus(Status.COMPLETED);
+
+        workflow.getTasks().addAll(Arrays.asList(decTask, task1));
+
+        // then workflow completion check returns false
+        assertFalse(deciderService.checkForWorkflowCompletion(workflow));
+
+        // when the terminate task is COMPLETED
+        Task task2 = new Task();
+        decTask.setTaskType(TaskType.SIMPLE.name());
+        task2.setReferenceTaskName("t2");
+        task2.setStatus(Status.SCHEDULED);
+
+        Task terminateTask = new Task();
+        decTask.setTaskType(TaskType.TERMINATE.name());
+        terminateTask.setReferenceTaskName("terminate");
+        terminateTask.setStatus(Status.COMPLETED);
+
+        workflow.getTasks().addAll(Arrays.asList(task2, terminateTask));
+
+        // then the workflow completion check returns true
+        assertTrue(deciderService.checkForWorkflowCompletion(workflow));
+    }
+
     private WorkflowDef createConditionalWF() {
 
         WorkflowTask workflowTask1 = new WorkflowTask();

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestTerminate.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestTerminate.java
@@ -12,20 +12,19 @@
  */
 package com.netflix.conductor.core.execution.tasks;
 
-import com.netflix.conductor.common.metadata.tasks.Task;
-import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.core.execution.WorkflowExecutor;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.netflix.conductor.core.execution.tasks.Terminate.getTerminationStatusParameter;
 import static com.netflix.conductor.core.execution.tasks.Terminate.getTerminationWorkflowOutputParameter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
 
 public class TestTerminate {
 
@@ -43,7 +42,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.FAILED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.RUNNING, workflow.getStatus());
     }
 
     @Test
@@ -58,7 +56,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.FAILED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.RUNNING, workflow.getStatus());
     }
 
     @Test
@@ -73,7 +70,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.FAILED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.RUNNING, workflow.getStatus());
     }
 
     @Test
@@ -94,8 +90,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.COMPLETED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus());
-        assertEquals(expectedOutput, workflow.getOutput());
         assertEquals(expectedOutput, task.getOutputData());
     }
 
@@ -117,8 +111,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.COMPLETED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.FAILED, workflow.getStatus());
-        assertEquals(expectedOutput, workflow.getOutput());
         assertEquals(expectedOutput, task.getOutputData());
     }
 
@@ -134,8 +126,6 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.COMPLETED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.FAILED, workflow.getStatus());
-        assertTrue(workflow.getOutput().isEmpty());
         assertTrue(task.getOutputData().isEmpty());
     }
 
@@ -156,7 +146,5 @@ public class TestTerminate {
         task.getInputData().putAll(input);
         terminateTask.execute(workflow, task, executor);
         assertEquals(Task.Status.COMPLETED, task.getStatus());
-        assertEquals(Workflow.WorkflowStatus.FAILED, workflow.getStatus());
-        assertEquals(expectedOutput, workflow.getOutput());
     }
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DecisionTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DecisionTaskSpec.groovy
@@ -70,6 +70,8 @@ class DecisionTaskSpec extends AbstractSpecification {
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 3
+            tasks[0].taskType == 'DECISION'
+            tasks[0].status == Task.Status.COMPLETED
             tasks[1].taskType == 'integration_task_1'
             tasks[1].status == Task.Status.COMPLETED
             tasks[2].taskType == 'integration_task_2'

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LambdaAndTerminateTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LambdaAndTerminateTaskSpec.groovy
@@ -15,8 +15,12 @@ package com.netflix.conductor.test.integration
 import com.netflix.conductor.common.metadata.tasks.Task
 import com.netflix.conductor.common.metadata.tasks.TaskResult
 import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.SubWorkflow
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask
 import com.netflix.conductor.test.base.AbstractSpecification
 import spock.lang.Shared
+
+import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
 
 class LambdaAndTerminateTaskSpec extends AbstractSpecification {
 
@@ -32,6 +36,9 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
     @Shared
     def PARENT_WORKFLOW_WITH_TERMINATE_TASK = 'test_terminate_task_parent_wf'
 
+    @Shared
+    def WORKFLOW_WITH_DECISION_AND_TERMINATE = "ConditionalTerminateWorkflow"
+
     def setup() {
         workflowTestUtil.registerWorkflows(
                 'failure_workflow_for_terminate_task_workflow.json',
@@ -39,7 +46,8 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
                 'terminate_task_failed_workflow_integration.json',
                 'simple_lambda_workflow_integration_test.json',
                 'terminate_task_parent_workflow.json',
-                'terminate_task_sub_workflow.json'
+                'terminate_task_sub_workflow.json',
+                "decision_and_terminate_integration_test.json"
         )
     }
 
@@ -56,10 +64,13 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.COMPLETED
             tasks.size() == 2
+            reasonForIncompletion.contains('Workflow is COMPLETED by TERMINATE task')
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'LAMBDA'
+            tasks[0].seq == 1
             tasks[1].status == Task.Status.COMPLETED
             tasks[1].taskType == 'TERMINATE'
+            tasks[1].seq == 2
             output.size() == 1
             output as String == "[result:[testvalue:true]]"
         }
@@ -78,10 +89,13 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.FAILED
             tasks.size() == 2
+            reasonForIncompletion.contains('Workflow is FAILED by TERMINATE task')
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'LAMBDA'
+            tasks[0].seq == 1
             tasks[1].status == Task.Status.COMPLETED
             tasks[1].taskType == 'TERMINATE'
+            tasks[1].seq == 2
             output
             def failedWorkflowId = output['conductor.failure_workflow'] as String
             with(workflowExecutionService.getExecutionStatus(failedWorkflowId, true)) {
@@ -108,18 +122,39 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
             tasks.size() == 6
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'FORK'
+            tasks[0].seq == 1
             tasks[1].status == Task.Status.COMPLETED
             tasks[1].taskType == 'LAMBDA'
             tasks[1].referenceTaskName == 'lambdaTask1'
+            tasks[1].seq == 2
             tasks[2].status == Task.Status.COMPLETED
             tasks[2].taskType == 'LAMBDA'
             tasks[2].referenceTaskName == 'lambdaTask2'
+            tasks[2].seq == 3
             tasks[3].status == Task.Status.IN_PROGRESS
             tasks[3].taskType == 'JOIN'
-            tasks[4].status == Task.Status.SCHEDULED || tasks[4].status == Task.Status.IN_PROGRESS
+            tasks[3].seq == 4
+            tasks[4].status == Task.Status.SCHEDULED
             tasks[4].taskType == 'SUB_WORKFLOW'
+            tasks[4].seq == 5
             tasks[5].status == Task.Status.IN_PROGRESS
             tasks[5].taskType == 'WAIT'
+            tasks[5].seq == 6
+        }
+
+        when: "subworkflow is retrieved"
+        def workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
+        def subWorkflowTaskId = workflow.getTaskByRefName("test_terminate_subworkflow").getTaskId()
+        workflowExecutor.executeSystemTask(WorkflowSystemTask.get(SubWorkflow.NAME), subWorkflowTaskId, 1)
+        workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
+        def subWorkflowId = workflow.getTaskByRefName("test_terminate_subworkflow").subWorkflowId
+
+        then: "verify that the sub workflow is RUNNING, and the task within is in SCHEDULED state"
+        with(workflowExecutionService.getExecutionStatus(subWorkflowId, true)) {
+            status == Workflow.WorkflowStatus.RUNNING
+            tasks.size() == 1
+            tasks[0].taskType == 'integration_task_3'
+            tasks[0].status == Task.Status.SCHEDULED
         }
 
         when: "Complete the WAIT task that should cause the TERMINATE task to execute"
@@ -131,22 +166,86 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.COMPLETED
             tasks.size() == 7
+            reasonForIncompletion.contains('Workflow is COMPLETED by TERMINATE task')
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'FORK'
+            tasks[0].seq == 1
             tasks[1].status == Task.Status.COMPLETED
             tasks[1].taskType == 'LAMBDA'
             tasks[1].referenceTaskName == 'lambdaTask1'
+            tasks[1].seq == 2
             tasks[2].status == Task.Status.COMPLETED
             tasks[2].taskType == 'LAMBDA'
             tasks[2].referenceTaskName == 'lambdaTask2'
-            tasks[3].status == Task.Status.SKIPPED
+            tasks[2].seq == 3
+            tasks[3].status == Task.Status.CANCELED
             tasks[3].taskType == 'JOIN'
-            tasks[4].status == Task.Status.SKIPPED
+            tasks[3].seq == 4
+            tasks[4].status == Task.Status.CANCELED
             tasks[4].taskType == 'SUB_WORKFLOW'
+            tasks[4].seq == 5
             tasks[5].status == Task.Status.COMPLETED
             tasks[5].taskType == 'WAIT'
+            tasks[5].seq == 6
             tasks[6].status == Task.Status.COMPLETED
             tasks[6].taskType == 'TERMINATE'
+            tasks[6].seq == 7
+        }
+
+        and: "ensure that the subworkflow is terminated"
+        with(workflowExecutionService.getExecutionStatus(subWorkflowId, true)) {
+            status == Workflow.WorkflowStatus.TERMINATED
+            tasks.size() == 1
+            reasonForIncompletion.contains('Parent workflow has been terminated with reason: Workflow is COMPLETED by' +
+                    ' TERMINATE task')
+            tasks[0].taskType == 'integration_task_3'
+            tasks[0].status == Task.Status.CANCELED
+        }
+    }
+
+    def "Test workflow with a terminate task within a decision branch"() {
+        given: "workflow input"
+        Map workflowInput = new HashMap<String, Object>()
+        workflowInput['param1'] = 'p1'
+        workflowInput['param2'] = 'p2'
+        workflowInput['case'] = 'fail'
+
+        when: "The workflow is started"
+        def workflowInstanceId = workflowExecutor.startWorkflow(WORKFLOW_WITH_DECISION_AND_TERMINATE, 1, '',
+                workflowInput, null, null, null)
+
+        then: "verify that the workflow is in RUNNING state"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.RUNNING
+            tasks.size() == 1
+            tasks[0].taskType == 'integration_task_1'
+            tasks[0].status == Task.Status.SCHEDULED
+            tasks[0].seq == 1
+        }
+
+        when: "the task 'integration_task_1' is polled and completed"
+        def polledAndCompletedTask1Try1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker', ['op':'task1 completed'])
+
+        then: "verify that the task is completed and acknowledged"
+        verifyPolledAndAcknowledgedTask(polledAndCompletedTask1Try1)
+
+        and: "verify that the 'integration_task_1' is COMPLETED and the workflow has FAILED due to terminate task"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 3
+            output.size() == 1
+            output as String == "[output:task1 completed]"
+            reasonForIncompletion.contains('Workflow is FAILED by TERMINATE task')
+            tasks[0].taskType == 'integration_task_1'
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].outputData['op'] == 'task1 completed'
+            tasks[0].seq == 1
+            tasks[1].taskType == 'DECISION'
+            tasks[1].status == Task.Status.COMPLETED
+            tasks[1].seq == 2
+            tasks[2].taskType == 'TERMINATE'
+            tasks[2].status == Task.Status.COMPLETED
+            tasks[2].seq == 3
         }
     }
 
@@ -166,6 +265,7 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'LAMBDA'
             tasks[0].outputData as String == "[result:[testvalue:true]]"
+            tasks[0].seq == 1
         }
     }
 }

--- a/test-harness/src/test/resources/decision_and_terminate_integration_test.json
+++ b/test-harness/src/test/resources/decision_and_terminate_integration_test.json
@@ -1,0 +1,113 @@
+{
+  "name": "ConditionalTerminateWorkflow",
+  "description": "ConditionalTerminateWorkflow",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "integration_task_1",
+      "taskReferenceName": "t1",
+      "inputParameters": {
+        "tp11": "${workflow.input.param1}",
+        "tp12": "${workflow.input.param2}"
+      },
+      "type": "SIMPLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    },
+    {
+      "name": "decision",
+      "taskReferenceName": "decision",
+      "inputParameters": {
+        "case": "${workflow.input.case}"
+      },
+      "type": "DECISION",
+      "caseValueParam": "case",
+      "decisionCases": {
+        "pass": [
+          {
+            "name": "integration_task_2",
+            "taskReferenceName": "t2",
+            "inputParameters": {
+              "tp21": "${workflow.input.param1}"
+            },
+            "type": "SIMPLE",
+            "decisionCases": {},
+            "defaultCase": [],
+            "forkTasks": [],
+            "startDelay": 0,
+            "joinOn": [],
+            "optional": false,
+            "defaultExclusiveJoinTask": [],
+            "asyncComplete": false,
+            "loopOver": []
+          }
+        ],
+        "fail": [
+          {
+            "name": "terminate",
+            "taskReferenceName": "terminate0",
+            "inputParameters": {
+              "terminationStatus": "FAILED",
+              "workflowOutput": "${t1.output.op}"
+            },
+            "type": "TERMINATE",
+            "decisionCases": {},
+            "defaultCase": [],
+            "forkTasks": [],
+            "startDelay": 0,
+            "joinOn": [],
+            "optional": false,
+            "defaultExclusiveJoinTask": [],
+            "asyncComplete": false,
+            "loopOver": []
+          }
+        ]
+      },
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    },
+    {
+      "name": "integration_task_3",
+      "taskReferenceName": "t3",
+      "inputParameters": {
+        "tp31": "${workflow.input.param2}"
+      },
+      "type": "SIMPLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [
+    "param1",
+    "param2"
+  ],
+  "outputParameters": {
+    "o2": "${t3.output.op}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}

--- a/test-harness/src/test/resources/terminate_task_sub_workflow.json
+++ b/test-harness/src/test/resources/terminate_task_sub_workflow.json
@@ -3,9 +3,9 @@
   "version": 1,
   "tasks": [
     {
-      "name": "test_third_wait_task",
-      "taskReferenceName": "basicJavaC",
-      "type": "WAIT"
+      "name": "integration_task_3",
+      "taskReferenceName": "t3",
+      "type": "SIMPLE"
     }
   ],
   "schemaVersion": 2,


### PR DESCRIPTION
### OLD STATE
The execution of the `TERMINATE` task deviated from that of other tasks such that -

1. The task execution would modify the enclosing workflow but expect the orchestrator/state machine to persist the workflow changes
2. In order to accomodate this behavior, the state machine evaluation had to be hacked for detection and early termination of the workflow, leading to incomplete workflow evalutions. (The most obvious side-effect of this being the TERMINATE task would be added to the workflow with a seq of 0).
3. The incomplete state evaluation further led to the corner case such that when a DECISION task is followed by a TERMINATE task in one of its branches, the DECISION task would not be persisted by the state machine as part of the workflow data.

### NEW STATE
This PR aims to resolve the above discrepancies by

1. Making the TERMINATE task execution consistent with that of other tasks and relying on state machine to modify and update any workflow level changes.
2. Fixing the DAG evaluation in the state machine such that it exits early when a TERMINATE task node is met in the graph.
3. Removing the hacks during task execution and replacing it with DAG evaluation combined with workflow evaluation for early termination of workflows using the TERMINATE task.

#### Behavioral Impact
A behavior change for the TERMINATE task that has been introduced in this PR is that other non-terminal tasks will be marked as CANCELED keeping it consistent to the behavior if the workflow were to be TERMINATED manually (or using the API). The old behavior here was to mark such tasks as SKIPPED.