### PR TITLE
fix npe

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1814,6 +1814,10 @@ public class WorkflowExecutor {
     }
 
     private void executeSubworkflowTaskAndSyncData(Workflow subWorkflow, Task subWorkflowTask) {
+        if(null == subWorkflow || null == subWorkflowTask){
+            return;
+        }
+
         WorkflowSystemTask subWorkflowSystemTask = WorkflowSystemTask.get(SubWorkflow.NAME);
         subWorkflowSystemTask.execute(subWorkflow, subWorkflowTask, this);
         // Keep Subworkflow task's data consistent with Subworkflow's.

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -110,6 +110,10 @@ public class SubWorkflow extends WorkflowSystemTask {
 
     @Override
     public boolean execute(Workflow workflow, Task task, WorkflowExecutor provider) {
+        if(null == task){
+            return false;
+        }
+
         String workflowId = task.getSubWorkflowId();
         if (StringUtils.isEmpty(workflowId)) {
             return false;


### PR DESCRIPTION
![企业咚咚20210122212003](https://user-images.githubusercontent.com/11346379/105495936-c105ea80-5cf7-11eb-84a7-c4714a01cdaa.jpg)
fix the npe when subworkflow task is null.