### PR TITLE
add task failed hook method for WorkflowStatusListener

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWithTTLWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWithTTLWorkflowStatusListener.java
@@ -90,6 +90,11 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
         }
     }
 
+    @Override
+    public void onWorkflowFailed(Workflow workflow) {
+
+    }
+
     private class DelayArchiveWorkflow implements Runnable {
 
         private final String workflowId;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWorkflowStatusListener.java
@@ -46,5 +46,10 @@ public class ArchivingWorkflowStatusListener implements WorkflowStatusListener {
         this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true);
         Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
     }
+
+    @Override
+    public void onWorkflowFailed(Workflow workflow) {
+
+    }
 }
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisher.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisher.java
@@ -56,6 +56,11 @@ public class ConductorQueueStatusPublisher implements WorkflowStatusListener {
         queueDAO.push(failureStatusQueue, Collections.singletonList(workflowToMessage(workflow)));
     }
 
+    @Override
+    public void onWorkflowFailed(Workflow workflow) {
+
+    }
+
     private Message workflowToMessage(Workflow workflow) {
         String jsonWfSummary;
         WorkflowSummary summary = new WorkflowSummary(workflow);

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -842,6 +842,13 @@ public class WorkflowExecutor {
             return;
         }
 
+        //if task is failed in a workflow, trigger the onWorkflowFailed from listener
+        if(!isSystemTask.test(task) && taskResult.getStatus() == Status.FAILED){
+            if (workflowInstance.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+                workflowStatusListener.onWorkflowFailed(workflowInstance);
+            }
+        }
+
         if (workflowInstance.getStatus().isTerminal()) {
             // Workflow is in terminal state
             queueDAO.remove(taskQueueName, taskResult.getTaskId());

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
@@ -22,4 +22,6 @@ public interface WorkflowStatusListener {
     void onWorkflowCompleted(Workflow workflow);
 
     void onWorkflowTerminated(Workflow workflow);
+
+    void onWorkflowFailed(Workflow workflow);
 }

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListenerStub.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListenerStub.java
@@ -32,4 +32,9 @@ public class WorkflowStatusListenerStub implements WorkflowStatusListener {
     public void onWorkflowTerminated(Workflow workflow) {
         LOGGER.debug("Workflow {} is terminated", workflow.getWorkflowId());
     }
+
+    @Override
+    public void onWorkflowFailed(Workflow workflow) {
+        LOGGER.debug("Workflow {} is failed in a task", workflow.getWorkflowId());
+    }
 }


### PR DESCRIPTION
We extended WorkflowStatusListener in our production environment and added onWorkflowFailed method for task fails. This feature was added because of it is not enough for terminate and complete status trigger and sometimes we need hook mechanism when one of the tasks fails when the workflow is not terminated. Pls evaluate this feature.