### PR TITLE
update flyway version

### DIFF
--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -130,8 +130,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -278,8 +278,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -426,8 +426,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -584,8 +584,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -732,8 +732,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -884,8 +884,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1048,8 +1048,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1212,8 +1212,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1376,8 +1376,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLConfiguration.java
@@ -2,7 +2,7 @@ package com.netflix.conductor.mysql;
 
 import com.netflix.conductor.core.config.Configuration;
 
-import java.util.Optional;
+
 import java.util.concurrent.TimeUnit;
 
 public interface MySQLConfiguration extends Configuration {
@@ -20,7 +20,7 @@ public interface MySQLConfiguration extends Configuration {
     boolean FLYWAY_ENABLED_DEFAULT_VALUE = true;
 
     String FLYWAY_TABLE_PROPERTY_NAME = "flyway.table";
-    Optional<String> FLYWAY_TABLE_DEFAULT_VALUE = Optional.empty();
+    String FLYWAY_TABLE_DEFAULT_VALUE = "schema_version";
 
     // The defaults are currently in line with the HikariConfig defaults, which are unfortunately private.
     String CONNECTION_POOL_MAX_SIZE_PROPERTY_NAME = "conductor.mysql.connection.pool.size.max";
@@ -61,8 +61,8 @@ public interface MySQLConfiguration extends Configuration {
         return getBoolProperty(FLYWAY_ENABLED_PROPERTY_NAME, FLYWAY_ENABLED_DEFAULT_VALUE);
     }
 
-    default Optional<String> getFlywayTable() {
-        return Optional.ofNullable(getProperty(FLYWAY_TABLE_PROPERTY_NAME, null));
+    default String getFlywayTable() {
+        return getProperty(FLYWAY_TABLE_PROPERTY_NAME, FLYWAY_TABLE_DEFAULT_VALUE);
     }
 
     default int getConnectionPoolMaxSize() {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
@@ -68,16 +68,13 @@ public class MySQLDataSourceProvider implements Provider<DataSource> {
             logger.debug("Flyway migrations are disabled");
             return;
         }
-
+        String flywayTable = configuration.getFlywayTable();
+        logger.debug("Using Flyway migration table '{}'", flywayTable);
 
         FluentConfiguration flywayConfiguration = Flyway.configure()
+                .table(flywayTable)
                 .dataSource(dataSource)
                 .placeholderReplacement(false);
-
-        configuration.getFlywayTable().ifPresent(tableName -> {
-            logger.debug("Using Flyway migration table '{}'", tableName);
-            flywayConfiguration.table(tableName);
-        });
 
         Flyway flyway = flywayConfiguration.load();
         flyway.migrate();

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/MySQLDataSourceProvider.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,14 +70,16 @@ public class MySQLDataSourceProvider implements Provider<DataSource> {
         }
 
 
-        Flyway flyway = new Flyway();
+        FluentConfiguration flywayConfiguration = Flyway.configure()
+                .dataSource(dataSource)
+                .placeholderReplacement(false);
+
         configuration.getFlywayTable().ifPresent(tableName -> {
             logger.debug("Using Flyway migration table '{}'", tableName);
-            flyway.setTable(tableName);
+            flywayConfiguration.table(tableName);
         });
 
-        flyway.setDataSource(dataSource);
-        flyway.setPlaceholderReplacement(false);
+        Flyway flyway = flywayConfiguration.load();
         flyway.migrate();
     }
 }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLDAOTestUtil.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLDAOTestUtil.java
@@ -74,6 +74,7 @@ public class MySQLDAOTestUtil {
 
         Flyway flyway = Flyway.configure()
                 .dataSource(dataSource)
+                .table("schema_version")
                 .placeholderReplacement(false)
                 .load();
 

--- a/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLDAOTestUtil.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/dao/mysql/MySQLDAOTestUtil.java
@@ -72,9 +72,11 @@ public class MySQLDAOTestUtil {
 
     private void flywayMigrate(DataSource dataSource) {
 
-        Flyway flyway = new Flyway();
-        flyway.setDataSource(dataSource);
-        flyway.setPlaceholderReplacement(false);
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .placeholderReplacement(false)
+                .load();
+
         flyway.migrate();
     }
 

--- a/postgres-persistence/dependencies.lock
+++ b/postgres-persistence/dependencies.lock
@@ -126,8 +126,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -274,8 +274,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -422,8 +422,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -580,8 +580,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -728,8 +728,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -880,8 +880,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1044,8 +1044,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1208,8 +1208,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1372,8 +1372,8 @@
             "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
-            "requested": "4.0.3"
+            "locked": "7.5.2",
+            "requested": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresConfiguration.java
@@ -14,7 +14,6 @@ package com.netflix.conductor.postgres;
 
 import com.netflix.conductor.core.config.Configuration;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public interface PostgresConfiguration extends Configuration {
@@ -32,7 +31,7 @@ public interface PostgresConfiguration extends Configuration {
     boolean FLYWAY_ENABLED_DEFAULT_VALUE = true;
 
     String FLYWAY_TABLE_PROPERTY_NAME = "flyway.table";
-    Optional<String> FLYWAY_TABLE_DEFAULT_VALUE = Optional.empty();
+    String FLYWAY_TABLE_DEFAULT_VALUE = "schema_version";
 
     // The defaults are currently in line with the HikariConfig defaults, which are unfortunately private.
     String CONNECTION_POOL_MAX_SIZE_PROPERTY_NAME = "conductor.postgres.connection.pool.size.max";
@@ -73,8 +72,8 @@ public interface PostgresConfiguration extends Configuration {
         return getBoolProperty(FLYWAY_ENABLED_PROPERTY_NAME, FLYWAY_ENABLED_DEFAULT_VALUE);
     }
 
-    default Optional<String> getFlywayTable() {
-        return Optional.ofNullable(getProperty(FLYWAY_TABLE_PROPERTY_NAME, null));
+    default String getFlywayTable() {
+        return getProperty(FLYWAY_TABLE_PROPERTY_NAME, FLYWAY_TABLE_DEFAULT_VALUE);
     }
 
     default int getConnectionPoolMaxSize() {

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresDataSourceProvider.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresDataSourceProvider.java
@@ -16,6 +16,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,16 +82,17 @@ public class PostgresDataSourceProvider implements Provider<DataSource> {
             return;
         }
 
+        FluentConfiguration flywayConfiguration = Flyway.configure()
+                .locations(Paths.get("db","migration_postgres").toString())
+                .dataSource(dataSource)
+                .placeholderReplacement(false);
 
-        Flyway flyway = new Flyway();
         configuration.getFlywayTable().ifPresent(tableName -> {
             logger.debug("Using Flyway migration table '{}'", tableName);
-            flyway.setTable(tableName);
+            flywayConfiguration.table(tableName);
         });
 
-        flyway.setLocations(Paths.get("db","migration_postgres").toString());
-        flyway.setDataSource(dataSource);
-        flyway.setPlaceholderReplacement(false);
+        Flyway flyway = flywayConfiguration.load();
         flyway.migrate();
     }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresDataSourceProvider.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/PostgresDataSourceProvider.java
@@ -81,16 +81,14 @@ public class PostgresDataSourceProvider implements Provider<DataSource> {
             logger.debug("Flyway migrations are disabled");
             return;
         }
+        String flywayTable = configuration.getFlywayTable();
+        logger.debug("Using Flyway migration table '{}'", flywayTable);
 
         FluentConfiguration flywayConfiguration = Flyway.configure()
+                .table(flywayTable)
                 .locations(Paths.get("db","migration_postgres").toString())
                 .dataSource(dataSource)
                 .placeholderReplacement(false);
-
-        configuration.getFlywayTable().ifPresent(tableName -> {
-            logger.debug("Using Flyway migration table '{}'", tableName);
-            flywayConfiguration.table(tableName);
-        });
 
         Flyway flyway = flywayConfiguration.load();
         flyway.migrate();

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresDAOTestUtil.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresDAOTestUtil.java
@@ -18,6 +18,7 @@ import com.netflix.conductor.config.TestConfiguration;
 import com.netflix.conductor.core.config.Configuration;
 import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,11 +75,14 @@ public class PostgresDAOTestUtil {
 
     private void flywayMigrate(DataSource dataSource) {
 
-        Flyway flyway = new Flyway();
-        flyway.setLocations(Paths.get("db","migration_postgres").toString());
-        flyway.setDataSource(dataSource);
-        flyway.setPlaceholderReplacement(false);
+        FluentConfiguration flywayConfiguration = Flyway.configure()
+                .locations(Paths.get("db","migration_postgres").toString())
+                .dataSource(dataSource)
+                .placeholderReplacement(false);
+
+        Flyway flyway = flywayConfiguration.load();
         flyway.migrate();
+
     }
 
     public HikariDataSource getDataSource() {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresDAOTestUtil.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/dao/postgres/PostgresDAOTestUtil.java
@@ -76,6 +76,7 @@ public class PostgresDAOTestUtil {
     private void flywayMigrate(DataSource dataSource) {
 
         FluentConfiguration flywayConfiguration = Flyway.configure()
+                .table("schema_version")
                 .locations(Paths.get("db","migration_postgres").toString())
                 .dataSource(dataSource)
                 .placeholderReplacement(false);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -447,10 +448,14 @@ public class PerformanceTest {
     }
 
     private void flywayMigrate(DataSource dataSource) {
-        Flyway flyway = new Flyway();
-        flyway.setDataSource(dataSource);
-        flyway.setPlaceholderReplacement(false);
-        flyway.setLocations(Paths.get("db", "migration_postgres").toString());
+
+        FluentConfiguration flywayConfiguration = Flyway.configure()
+                .locations(Paths.get("db","migration_postgres").toString())
+                .dataSource(dataSource)
+                .placeholderReplacement(false);
+
+        Flyway flyway = flywayConfiguration.load();
+
         try {
             flyway.migrate();
         } catch (FlywayException e) {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/performance/PerformanceTest.java
@@ -450,6 +450,7 @@ public class PerformanceTest {
     private void flywayMigrate(DataSource dataSource) {
 
         FluentConfiguration flywayConfiguration = Flyway.configure()
+                .table(configuration.getFlywayTable())
                 .locations(Paths.get("db","migration_postgres").toString())
                 .dataSource(dataSource)
                 .placeholderReplacement(false);

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -1520,7 +1520,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -3296,7 +3296,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -5072,7 +5072,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -6848,7 +6848,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -9692,7 +9692,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -11468,7 +11468,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -13211,7 +13211,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -14998,7 +14998,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -16796,7 +16796,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -18594,7 +18594,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -20392,7 +20392,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -405,7 +405,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -851,7 +851,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1297,7 +1297,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1743,7 +1743,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -2259,7 +2259,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -2705,7 +2705,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -3151,7 +3151,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -3601,7 +3601,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -4055,7 +4055,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -4509,7 +4509,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -4963,7 +4963,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -537,7 +537,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1118,7 +1118,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1699,7 +1699,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -2280,7 +2280,7 @@
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "4.0.3"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -1756,7 +1756,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -3747,7 +3747,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -5738,7 +5738,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -7729,7 +7729,7 @@
             ]
         },
         "org.flywaydb:flyway-core": {
-            "locked": "4.0.3",
+            "locked": "7.5.2",
             "transitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -15,7 +15,7 @@ ext {
     revElasticSearch5Client = '5.6.8'
     revElasticSearch6 = '6.8.12'
     revEurekaClient = '1.8.7'
-    revFlywayCore ='4.0.3'
+    revFlywayCore ='7.5.2'
     revGrpc = '1.14.+'
     revGuavaRetrying = '2.0.0'
     revGuice = '4.1.0'


### PR DESCRIPTION
Hi,
Our conductor setup consists of multiple instances. If we start the instances simultaneously, sometimes we got the following error:

```
2021-02-01 12:42:08,339 [main] ERROR error migration DB
org.flywaydb.core.internal.dbsupport.FlywaySqlScriptException:
Script failed
-------------
SQL State  : 23505
Error Code : 0
Message    : ERROR: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
  Detail: Key (typname, typnamespace)=(schema_version, 2200) already exists.
Line       : 17
Statement  : CREATE TABLE "public"."schema_version" (
    "installed_rank" INT NOT NULL,
    "version" VARCHAR(50),
    "description" VARCHAR(200) NOT NULL,
    "type" VARCHAR(20) NOT NULL,
    "script" VARCHAR(1000) NOT NULL,
    "checksum" INTEGER,
    "installed_by" VARCHAR(100) NOT NULL,
    "installed_on" TIMESTAMP NOT NULL DEFAULT now(),
    "execution_time" INTEGER NOT NULL,
    "success" BOOLEAN NOT NULL
) WITH (
  OIDS=FALSE
)

        at org.flywaydb.core.internal.dbsupport.SqlScript.execute(SqlScript.java:117)
        at org.flywaydb.core.internal.metadatatable.MetaDataTableImpl.createIfNotExists(MetaDataTableImpl.java:104)
        at org.flywaydb.core.internal.metadatatable.MetaDataTableImpl.lock(MetaDataTableImpl.java:111)
        at org.flywaydb.core.internal.command.DbMigrate$2.doInTransaction(DbMigrate.java:175)
        at org.flywaydb.core.internal.command.DbMigrate$2.doInTransaction(DbMigrate.java:173)
        at org.flywaydb.core.internal.util.jdbc.TransactionTemplate.execute(TransactionTemplate.java:72)
        at org.flywaydb.core.internal.command.DbMigrate.migrate(DbMigrate.java:173)
        at org.flywaydb.core.Flyway$1.execute(Flyway.java:959)
        at org.flywaydb.core.Flyway$1.execute(Flyway.java:917)
        at org.flywaydb.core.Flyway.execute(Flyway.java:1373)
        at org.flywaydb.core.Flyway.migrate(Flyway.java:917)
        at com.netflix.conductor.postgres.PostgresDataSourceProvider.flywayMigrate(PostgresDataSourceProvider.java:94)
        at com.netflix.conductor.postgres.PostgresDataSourceProvider.get(PostgresDataSourceProvider.java:43)
        at com.netflix.conductor.postgres.PostgresDataSourceProvider.get(PostgresDataSourceProvider.java:28)
```


This issue is related to flyway (conductor is using flyway:4.0.3, this issue is fixed in 5.1.0):
https://github.com/flyway/flyway/issues/1067
https://github.com/flyway/flyway/issues/1983

In this PR, I updated the flyway version to the latest one which solves this issue.