### PR TITLE
UI Dispatch Fix

### DIFF
--- a/ui/src/actions/metadata.js
+++ b/ui/src/actions/metadata.js
@@ -3,6 +3,7 @@ import http from '../core/HttpClientClientSide';
 export const FETCH_WORKFLOW_METADATA = "FETCH_WORKFLOW_METADATA";
 export const RECEIVE_WORKFLOW_METADATA = "RECEIVE_WORKFLOW_METADATA";
 export const FAIL_WORKFLOW_METADATA = "FAIL_WORKFLOW_METADATA";
+export const REQUEST_ERROR = "REQUEST_ERROR";
 
 export function fetchWorkflowMetadata() {
   return {type: FETCH_WORKFLOW_METADATA};
@@ -15,7 +16,7 @@ export function receiveWorkflowMetadata(workflows) {
 export function failWorkflowMetadata(error) {
   return function(dispatch) {
     dispatch({type: FAIL_WORKFLOW_METADATA, error});
-    dispatch({type: 'REQUEST_ERROR', e});
+    dispatch({type: REQUEST_ERROR, error});
   };
 }
 


### PR DESCRIPTION
Pretty sure this wasn't intended. Conforming code to structure.

The `ui/src/actions/metadata.js` file seems to have a typo and wasn't following the rest of the code structure. 

Basically added a variable to define a dispatch type, and changed it from returning an undefined object `e` to return the object `error`.