### PR TITLE
send notification on workflow finalization

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisher.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisher.java
@@ -35,6 +35,7 @@ public class ConductorQueueStatusPublisher implements WorkflowStatusListener {
 
     private final String successStatusQueue;
     private final String failureStatusQueue;
+    private final String finalizeStatusQueue;
 
     public ConductorQueueStatusPublisher(QueueDAO queueDAO, ObjectMapper objectMapper,
         ConductorQueueStatusPublisherProperties properties) {
@@ -42,6 +43,7 @@ public class ConductorQueueStatusPublisher implements WorkflowStatusListener {
         this.objectMapper = objectMapper;
         this.successStatusQueue = properties.getSuccessQueue();
         this.failureStatusQueue = properties.getFailureQueue();
+        this.finalizeStatusQueue = properties.getFinalizeQueue();
     }
 
     @Override
@@ -54,6 +56,12 @@ public class ConductorQueueStatusPublisher implements WorkflowStatusListener {
     public void onWorkflowTerminated(Workflow workflow) {
         LOGGER.info("Publishing callback of workflow {} on termination", workflow.getWorkflowId());
         queueDAO.push(failureStatusQueue, Collections.singletonList(workflowToMessage(workflow)));
+    }
+
+    @Override
+    public void onWorkflowFinalized(Workflow workflow) {
+        LOGGER.info("Publishing callback of workflow {} on finalization", workflow.getWorkflowId());
+        queueDAO.push(finalizeStatusQueue, Collections.singletonList(workflowToMessage(workflow)));
     }
 
     private Message workflowToMessage(Workflow workflow) {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisherProperties.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/conductorqueue/ConductorQueueStatusPublisherProperties.java
@@ -21,6 +21,8 @@ public class ConductorQueueStatusPublisherProperties {
 
     private String failureQueue = "_callbackFailureQueue";
 
+    private String finalizeQueue = "_callbackFinalizeQueue";
+
     public String getSuccessQueue() {
         return successQueue;
     }
@@ -35,5 +37,13 @@ public class ConductorQueueStatusPublisherProperties {
 
     public void setFailureQueue(String failureQueue) {
         this.failureQueue = failureQueue;
+    }
+
+    public String getFinalizeQueue() {
+        return finalizeQueue;
+    }
+
+    public void setFinalizeQueue(String finalizeQueue) {
+        this.finalizeQueue = finalizeQueue;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -638,7 +638,6 @@ public class WorkflowExecutor {
         return parentWorkflow;
     }
 
-
     private boolean findLastFailedOrTimeOutTask(Task task) {
         return task.getStatus().equals(FAILED) || task.getStatus().equals(FAILED_WITH_TERMINAL_ERROR) || task.getStatus().equals(TIMED_OUT);
     }
@@ -651,7 +650,6 @@ public class WorkflowExecutor {
             updateParentWorkflowRecursively(parentWorkflow);
         }
     }
-
 
     /**
      * Reschedule a task
@@ -749,18 +747,14 @@ public class WorkflowExecutor {
         workflow.setExternalOutputPayloadStoragePath(wf.getExternalOutputPayloadStoragePath());
         executionDAOFacade.updateWorkflow(workflow);
         LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
-
-        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
-            workflowStatusListener.onWorkflowCompleted(workflow);
-        }
+        workflowStatusListener.onWorkflowCompletedIfEnabled(workflow);
+        Monitors.recordWorkflowCompletion(workflow.getWorkflowName(), workflow.getEndTime() - workflow.getStartTime(),
+            workflow.getOwnerApp());
 
         if (StringUtils.isNotEmpty(workflow.getParentWorkflowId())) {
             updateParentWorkflowTask(workflow);
             decide(workflow.getParentWorkflowId());
         }
-        Monitors.recordWorkflowCompletion(workflow.getWorkflowName(), workflow.getEndTime() - workflow.getStartTime(),
-            workflow.getOwnerApp());
-        queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());    //remove from the sweep queue
 
         executionLockService.releaseLock(workflow.getWorkflowId());
         executionLockService.deleteLock(workflow.getWorkflowId());
@@ -799,17 +793,16 @@ public class WorkflowExecutor {
             String workflowId = workflow.getWorkflowId();
             workflow.setReasonForIncompletion(reason);
             executionDAOFacade.updateWorkflow(workflow);
+            workflowStatusListener.onWorkflowTerminatedIfEnabled(workflow);
+            Monitors.recordWorkflowTermination(workflow.getWorkflowName(), workflow.getStatus(), workflow.getOwnerApp());
 
             List<Task> tasks = workflow.getTasks();
-
             try {
                 // Remove from the task queue if they were there
                 tasks.forEach(task -> queueDAO.remove(QueueUtils.getQueueName(task), task.getTaskId()));
             } catch (Exception e) {
                 LOGGER.warn("Error removing task(s) from queue during workflow termination : {}", workflowId, e);
             }
-
-            List<String> erroredTasks = cancelNonTerminalTasks(workflow);
 
             if (workflow.getParentWorkflowId() != null) {
                 updateParentWorkflowTask(workflow);
@@ -848,21 +841,8 @@ public class WorkflowExecutor {
             }
             executionDAOFacade.removeFromPendingWorkflow(workflow.getWorkflowName(), workflow.getWorkflowId());
 
-            // Send to atlas
-            Monitors
-                .recordWorkflowTermination(workflow.getWorkflowName(), workflow.getStatus(), workflow.getOwnerApp());
-
-            if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
-                workflowStatusListener.onWorkflowTerminated(workflow);
-            }
-
-            if (erroredTasks.isEmpty()) {
-                try {
-                    queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
-                } catch (Exception e) {
-                    LOGGER.error("Error removing workflow: {} from decider queue", workflow.getWorkflowId(), e);
-                }
-            } else {
+            List<String> erroredTasks = cancelNonTerminalTasks(workflow);
+            if (!erroredTasks.isEmpty()) {
                 throw new ApplicationException(Code.INTERNAL_ERROR, String.format("Error canceling system tasks: %s",
                     String.join(",", erroredTasks)));
             }
@@ -1189,6 +1169,14 @@ public class WorkflowExecutor {
                     }
                 }
                 executionDAOFacade.updateTask(task);
+            }
+        }
+        if (erroredTasks.isEmpty()) {
+            try {
+                queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
+                workflowStatusListener.onWorkflowFinalizedIfEnabled(workflow);
+            } catch (Exception e) {
+                LOGGER.error("Error removing workflow: {} from decider queue", workflow.getWorkflowId(), e);
             }
         }
         return erroredTasks;

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
@@ -19,7 +19,29 @@ import com.netflix.conductor.common.run.Workflow;
  */
 public interface WorkflowStatusListener {
 
+    default void onWorkflowCompletedIfEnabled(Workflow workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowCompleted(workflow);
+        }
+    }
+
+    default void onWorkflowTerminatedIfEnabled(Workflow workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowTerminated(workflow);
+        }
+    }
+
+    default void onWorkflowFinalizedIfEnabled(Workflow workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowFinalized(workflow);
+        }
+    }
+
     void onWorkflowCompleted(Workflow workflow);
 
     void onWorkflowTerminated(Workflow workflow);
+
+    default void onWorkflowFinalized(Workflow workflow) {
+
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListenerStub.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListenerStub.java
@@ -32,4 +32,9 @@ public class WorkflowStatusListenerStub implements WorkflowStatusListener {
     public void onWorkflowTerminated(Workflow workflow) {
         LOGGER.debug("Workflow {} is terminated", workflow.getWorkflowId());
     }
+
+    @Override
+    public void onWorkflowFinalized(Workflow workflow) {
+        LOGGER.debug("Workflow {} is finalized", workflow.getWorkflowId());
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -55,7 +55,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Trace
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+ @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Service
 public class ExecutionService {
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -360,19 +360,21 @@ public class TestWorkflowExecutor {
         assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus());
         assertEquals(1, updateWorkflowCalledCounter.get());
         assertEquals(0, updateTasksCalledCounter.get());
-        assertEquals(1, removeQueueEntryCalledCounter.get());
+        assertEquals(0, removeQueueEntryCalledCounter.get());
 
-        verify(workflowStatusListener, times(0)).onWorkflowCompleted(any(Workflow.class));
+        verify(workflowStatusListener, times(1)).onWorkflowCompletedIfEnabled(any(Workflow.class));
+        verify(workflowStatusListener, times(0)).onWorkflowFinalizedIfEnabled(any(Workflow.class));
 
         def.setWorkflowStatusListenerEnabled(true);
         workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
         workflowExecutor.completeWorkflow(workflow);
-        verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));
+        verify(workflowStatusListener, times(2)).onWorkflowCompletedIfEnabled(any(Workflow.class));
+        verify(workflowStatusListener, times(0)).onWorkflowFinalizedIfEnabled(any(Workflow.class));
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testTerminatedWorkflow() {
+    public void testTerminateWorkflow() {
         WorkflowDef def = new WorkflowDef();
         def.setName("test");
 
@@ -411,11 +413,13 @@ public class TestWorkflowExecutor {
         assertEquals(1, removeQueueEntryCalledCounter.get());
 
         verify(workflowStatusListener, times(0)).onWorkflowTerminated(any(Workflow.class));
+        verify(workflowStatusListener, times(0)).onWorkflowFinalized(any(Workflow.class));
 
         def.setWorkflowStatusListenerEnabled(true);
         workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
         workflowExecutor.completeWorkflow(workflow);
-        verify(workflowStatusListener, times(1)).onWorkflowCompleted(any(Workflow.class));
+        verify(workflowStatusListener, times(1)).onWorkflowCompletedIfEnabled(any(Workflow.class));
+        verify(workflowStatusListener, times(1)).onWorkflowFinalizedIfEnabled(any(Workflow.class));
     }
 
     @Test
@@ -453,7 +457,7 @@ public class TestWorkflowExecutor {
         workflowExecutor.terminateWorkflow("workflowId", "reason");
         assertEquals(Workflow.WorkflowStatus.TERMINATED, workflow.getStatus());
         assertEquals(1, updateWorkflowCalledCounter.get());
-        verify(workflowStatusListener, times(1)).onWorkflowTerminated(any(Workflow.class));
+        verify(workflowStatusListener, times(1)).onWorkflowTerminatedIfEnabled(any(Workflow.class));
     }
 
     @Test
@@ -1325,7 +1329,7 @@ public class TestWorkflowExecutor {
     }
 
     @Test(expected = ApplicationException.class)
-    public void testTerminateWorkflow() {
+    public void testTerminateCompletedWorkflow() {
         Workflow workflow = new Workflow();
         workflow.setWorkflowId("testTerminateTerminalWorkflow");
         workflow.setStatus(Workflow.WorkflowStatus.COMPLETED);
@@ -1591,7 +1595,11 @@ public class TestWorkflowExecutor {
 
     @Test
     public void testCancelNonTerminalTasks() {
+        WorkflowDef def = new WorkflowDef();
+        def.setWorkflowStatusListenerEnabled(true);
+
         Workflow workflow = generateSampleWorkflow();
+        workflow.setWorkflowDefinition(def);
 
         Task subWorkflowTask = new Task();
         subWorkflowTask.setTaskId(UUID.randomUUID().toString());
@@ -1619,6 +1627,7 @@ public class TestWorkflowExecutor {
         assertEquals(Status.CANCELED, argumentCaptor.getAllValues().get(0).getStatus());
         assertEquals(TaskType.LAMBDA.name(), argumentCaptor.getAllValues().get(1).getTaskType());
         assertEquals(Status.CANCELED, argumentCaptor.getAllValues().get(1).getStatus());
+        verify(workflowStatusListener, times(1)).onWorkflowFinalizedIfEnabled(any(Workflow.class));
     }
 
     private Workflow generateSampleWorkflow() {


### PR DESCRIPTION
Workflow completion notification will be sent immediately after a workflow moves to COMPLETED state.
Workflow termination notification will be sent immediately after a workflow moves to TERMINATED/FAILED/TIMED_OUT state.

Workflow finalization notification will be sent after all the tasks within the workflow have been moved to an expected terminal state, the parent workflow (if any) has been updated, the failure workflow (if any) has been triggered and the workflow is cleaned up from the decider queue to stop any further evaluations.