### PR TITLE
Workflow/Task Summary Input/Output Json Serialization

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
@@ -15,19 +15,17 @@
  */
 package com.netflix.conductor.common.run;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.utils.SummaryUtil;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Viren
@@ -40,9 +38,6 @@ public class TaskSummary {
 	 * The time should be stored as GMT
 	 */
 	private static final TimeZone gmt = TimeZone.getTimeZone("GMT");
-	private static final Logger logger = LoggerFactory.getLogger(TaskSummary.class);
-	private static final ObjectMapper objectMapper = new ObjectMapper();
-	private static boolean isInputOutputJSONSerializationEnabled = false;
 
 	@ProtoField(id = 1)
 	private String workflowId;
@@ -109,9 +104,9 @@ public class TaskSummary {
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     	sdf.setTimeZone(gmt);
     	
-    this.taskId = task.getTaskId();
-    this.taskDefName = task.getTaskDefName();
-    this.taskType = task.getTaskType();
+		this.taskId = task.getTaskId();
+		this.taskDefName = task.getTaskDefName();
+		this.taskType = task.getTaskType();
 		this.workflowId = task.getWorkflowInstanceId();
 		this.workflowType = task.getWorkflowType();
 		this.workflowPriority = task.getWorkflowPriority();
@@ -124,11 +119,11 @@ public class TaskSummary {
 		this.reasonForIncompletion = task.getReasonForIncompletion();
 		this.queueWaitTime = task.getQueueWaitTime();
 		if (task.getInputData() != null) {
-			this.input = this.serializeInputOutput(task.getInputData(), "input");
+			this.input = SummaryUtil.serializeInputOutput(task.getInputData());
 		}
 		
 		if (task.getOutputData() != null) {
-			this.output = this.serializeInputOutput(task.getOutputData(), "output");
+			this.output = SummaryUtil.serializeInputOutput(task.getOutputData());
 		}
 		
 		
@@ -141,21 +136,6 @@ public class TaskSummary {
 		}
 		if (StringUtils.isNotBlank(task.getExternalOutputPayloadStoragePath())) {
 			this.externalOutputPayloadStoragePath = task.getExternalOutputPayloadStoragePath();
-		}
-	}
-
-	private String serializeInputOutput(Map<String, Object> object, String inputOutput) {
-		logger.info("isEnabled {0}", isInputOutputJSONSerializationEnabled);
-		if (isInputOutputJSONSerializationEnabled == false) {
-			// Using default configuration (false), simply use Java's toString
-			return object.toString();
-		}
-
-		try {
-			return objectMapper.writeValueAsString(object);
-		} catch (Exception e) {
-			logger.error("The {0} value could not be serialized as JSON", inputOutput, e);
-			return ""; // what to do here
 		}
 	}
 
@@ -427,10 +407,6 @@ public class TaskSummary {
 	 */
 	public void setWorkflowPriority(int workflowPriority) {
 		this.workflowPriority = workflowPriority;
-	}
-
-	public static void setInputOutputSerializationEnabled(boolean isEnabled) {
-		isInputOutputJSONSerializationEnabled = isEnabled;
 	}
 
 	@Override

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -115,11 +115,11 @@ public class WorkflowSummary {
 		}
 		this.status = workflow.getStatus();
 		if(workflow.getInput() != null){
-                        this.input = SummaryUtil.serializeInputOutput(workflow.getInput());
+			this.input = SummaryUtil.serializeInputOutput(workflow.getInput());
 		}
-                if(workflow.getOutput() != null){
-                        this.output = SummaryUtil.serializeInputOutput(workflow.getOutput());
-                }
+		if(workflow.getOutput() != null){
+			this.output = SummaryUtil.serializeInputOutput(workflow.getOutput());
+		}
 		this.reasonForIncompletion = workflow.getReasonForIncompletion();
 		if(workflow.getEndTime() > 0){
 			this.executionTime = workflow.getEndTime() - workflow.getStartTime();

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -15,19 +15,17 @@
  */
 package com.netflix.conductor.common.run;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.vmg.protogen.annotations.ProtoField;
 import com.github.vmg.protogen.annotations.ProtoMessage;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
+import com.netflix.conductor.common.utils.SummaryUtil;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Captures workflow summary info to be indexed in Elastic Search.
@@ -41,9 +39,6 @@ public class WorkflowSummary {
 	 * The time should be stored as GMT
 	 */
 	private static final TimeZone gmt = TimeZone.getTimeZone("GMT");
-	private static final Logger logger = LoggerFactory.getLogger(WorkflowSummary.class);
-	private static final ObjectMapper objectMapper = new ObjectMapper();
-	private static boolean isInputOutputJSONSerializationEnabled = false;
 
 	@ProtoField(id = 1)
 	private String workflowType;
@@ -120,10 +115,10 @@ public class WorkflowSummary {
 		}
 		this.status = workflow.getStatus();
 		if(workflow.getInput() != null){
-      this.input = this.serializeInputOutput(workflow.getInput(), "input");
+      this.input = SummaryUtil.serializeInputOutput(workflow.getInput());
 		}
     if(workflow.getOutput() != null){
-      this.output = this.serializeInputOutput(workflow.getOutput(), "output");
+      this.output = SummaryUtil.serializeInputOutput(workflow.getOutput());
     }
 		this.reasonForIncompletion = workflow.getReasonForIncompletion();
 		if(workflow.getEndTime() > 0){
@@ -136,21 +131,6 @@ public class WorkflowSummary {
 		}
 		if (StringUtils.isNotBlank(workflow.getExternalOutputPayloadStoragePath())) {
 			this.externalOutputPayloadStoragePath = workflow.getExternalOutputPayloadStoragePath();
-		}
-	}
-
-	private String serializeInputOutput(Map<String, Object> object, String inputOutput) {
-		logger.info("isEnabled {0}", isInputOutputJSONSerializationEnabled);
-		if (isInputOutputJSONSerializationEnabled == false) {
-			// Using default configuration (false), simply use Java's toString
-			return object.toString();
-		}
-
-		try {
-			return objectMapper.writeValueAsString(object);
-		} catch (Exception e) {
-			logger.error("The {0} value could not be serialized", inputOutput, e);
-			return ""; // what to do here
 		}
 	}
 
@@ -360,10 +340,6 @@ public class WorkflowSummary {
 	 */
 	public void setPriority(int priority) {
 		this.priority = priority;
-	}
-
-	public static void setInputOutputSerializationEnabled(boolean isEnabled) {
-		isInputOutputJSONSerializationEnabled = isEnabled;
 	}
 
 	@Override

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -115,11 +115,11 @@ public class WorkflowSummary {
 		}
 		this.status = workflow.getStatus();
 		if(workflow.getInput() != null){
-      this.input = SummaryUtil.serializeInputOutput(workflow.getInput());
+                        this.input = SummaryUtil.serializeInputOutput(workflow.getInput());
 		}
-    if(workflow.getOutput() != null){
-      this.output = SummaryUtil.serializeInputOutput(workflow.getOutput());
-    }
+                if(workflow.getOutput() != null){
+                        this.output = SummaryUtil.serializeInputOutput(workflow.getOutput());
+                }
 		this.reasonForIncompletion = workflow.getReasonForIncompletion();
 		if(workflow.getEndTime() > 0){
 			this.executionTime = workflow.getEndTime() - workflow.getStartTime();

--- a/common/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.netflix.conductor.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SummaryUtil {
+  private static final Logger logger = LoggerFactory.getLogger(SummaryUtil.class);
+  private static final ObjectMapper objectMapper = new JsonMapperProvider().get();
+	private static boolean isSummaryInputOutputJsonSerializationEnabled = false;
+  
+  /**
+	 * Serializes the Workflow or Task's Input/Output object by Java's toString (default), or by
+	 * a Json ObjectMapper (@see Configuration.isSummaryInputOutputJsonSerializationEnabled)
+	 * @param object the Input or Output Object to serialize
+	 * @return the serialized string of the Input or Output object
+	 */
+	public static String serializeInputOutput(Map<String, Object> object) {
+		if (isSummaryInputOutputJsonSerializationEnabled == false) {
+			return object.toString();
+		}
+
+		try {
+			return objectMapper.writeValueAsString(object);
+		} catch (JsonProcessingException e) {
+			logger.error("The provided value ({}) could not be serialized as Json", object.toString(), e);
+			throw new RuntimeException(e);
+		}
+	}
+
+  /**
+   * @param isEnabled (default) false for Java toString, true for Json serialized string
+   */
+  public static void setSummaryInputOutputJsonSerializationEnabled(boolean isEnabled) {
+    isSummaryInputOutputJsonSerializationEnabled = isEnabled;
+  }
+}

--- a/common/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
@@ -20,8 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SummaryUtil {
-  private static final Logger logger = LoggerFactory.getLogger(SummaryUtil.class);
-  private static final ObjectMapper objectMapper = new JsonMapperProvider().get();
+	private static final Logger logger = LoggerFactory.getLogger(SummaryUtil.class);
+	private static final ObjectMapper objectMapper = new JsonMapperProvider().get();
 	private static boolean isSummaryInputOutputJsonSerializationEnabled = false;
   
   /**

--- a/common/src/test/java/com/netflix/conductor/common/utils/SummaryUtilTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/utils/SummaryUtilTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.netflix.conductor.common.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SummaryUtilTest {
+    private Map<String, Object> testObject;
+
+    public SummaryUtilTest() {
+        Map<String, Object> child = new HashMap<String, Object>();
+        child.put("testStr", "childTestStr");
+        
+        Map<String, Object> obj = new HashMap<String, Object>();
+        obj.put("testStr", "stringValue");
+        obj.put("testArray", new ArrayList<Integer>(Arrays.asList(1,2,3)));
+        obj.put("testObj", child);
+        obj.put("testNull", null);
+      
+        this.testObject = obj;
+    }
+
+    @Test
+    public void testSerializeInputOutput_defaultToString() throws Exception {
+        SummaryUtil.setSummaryInputOutputJsonSerializationEnabled(false);
+        String serialized = SummaryUtil.serializeInputOutput(this.testObject);
+        
+        assertEquals("The Java.toString() Serialization should match the serialized Test Object", 
+            this.testObject.toString(), serialized);
+    }
+
+    @Test
+    public void testSerializeInputOutput_jsonSerializationEnabled() throws Exception {
+        ObjectMapper objectMapper = new JsonMapperProvider().get();
+        SummaryUtil.setSummaryInputOutputJsonSerializationEnabled(true);
+        String serialized = SummaryUtil.serializeInputOutput(this.testObject);
+        
+        assertEquals("The ObjectMapper Json Serialization should match the serialized Test Object", 
+            objectMapper.writeValueAsString(this.testObject), serialized);
+    }
+
+}

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -119,7 +119,7 @@ public interface Configuration {
     String WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_PROPERTY_NAME = "workflow.archival.delay.queue.worker.thread.count";
     int WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_DEFAULT_VALUE = 5;
 
-    String SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_PROPERTY_NAME = "summary.input.output.json.serialized";
+    String SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_PROPERTY_NAME = "summary.input.output.json.serialization.enabled";
     boolean SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_DEFAULT_VALUE = false;
 
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
@@ -373,10 +373,10 @@ public interface Configuration {
     }
 
     /**
-     * @return if true, Workflow/Task Summary Input and Output are serialized as JSON strings.
-     * By default, this value is false, meaning that Java's default toString() method is used instead.
+     * By default, this value is false, meaning that Java's default toString() method is used.
+     * @return if true, Workflow/Task Summary Input and Output are serialized as Json strings.
      */
-    default boolean isSummaryInputOutputJSONSerializationEnabled()
+    default boolean isSummaryInputOutputJsonSerializationEnabled()
     {
         return getBooleanProperty(SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_PROPERTY_NAME, SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_DEFAULT_VALUE);
     }

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -119,6 +119,9 @@ public interface Configuration {
     String WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_PROPERTY_NAME = "workflow.archival.delay.queue.worker.thread.count";
     int WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_DEFAULT_VALUE = 5;
 
+    String SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_PROPERTY_NAME = "summary.input.output.json.serialized";
+    boolean SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_DEFAULT_VALUE = false;
+
     String OWNER_EMAIL_MANDATORY_NAME = "workflow.owner.email.mandatory";
     boolean OWNER_EMAIL_MANDATORY_DEFAULT_VALUE = true;
 
@@ -369,6 +372,14 @@ public interface Configuration {
         return getIntProperty(WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_PROPERTY_NAME, WORKFLOW_ARCHIVAL_DELAY_QUEUE_WORKER_THREAD_COUNT_DEFAULT_VALUE);
     }
 
+    /**
+     * @return if true, Workflow/Task Summary Input and Output are serialized as JSON strings.
+     * By default, this value is false, meaning that Java's default toString() method is used instead.
+     */
+    default boolean isSummaryInputOutputJSONSerializationEnabled()
+    {
+        return getBooleanProperty(SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_PROPERTY_NAME, SUMMARY_INPUT_OUTPUT_JSON_SERIALIZATION_ENABLED_DEFAULT_VALUE);
+    }
 
     /**
      * @return the number of threads to be use in Scheduler used for polling events from multiple event queues.

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -56,5 +56,8 @@ workflow.elasticsearch.index.name=conductor
 # conductor.additional.modules=com.netflix.conductor.contribs.metrics.MetricsRegistryModule,com.netflix.conductor.contribs.metrics.LoggingMetricsModule
 # com.netflix.conductor.contribs.metrics.LoggingMetricsModule.reportPeriodSeconds=15
 
+# To enable Workflow/Task Summary Input/Output JSON Serialization, use the following:
+# summary.input.output.json.serialization.enabled=true
+
 # Load sample kitchen sink workflow
 loadSample=true

--- a/server/src/main/java/com/netflix/conductor/bootstrap/BootstrapUtil.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/BootstrapUtil.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.conductor.bootstrap;
 
+import com.netflix.conductor.common.utils.SummaryUtil;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearch;
 import com.netflix.conductor.grpc.server.GRPCServer;
@@ -51,6 +53,13 @@ public class BootstrapUtil {
             System.out.println("Error setting up elasticsearch index");
             e.printStackTrace(System.err);
             System.exit(3);
+        }
+    }
+
+    public static void configureSummaryUtil(Configuration configuration) {
+        if (configuration.isSummaryInputOutputJsonSerializationEnabled() == true) {
+            System.out.println("Enabling Summary Input/Output Json Serialization based on configuration");
+            SummaryUtil.setSummaryInputOutputJsonSerializationEnabled(true);
         }
     }
 

--- a/server/src/main/java/com/netflix/conductor/bootstrap/Main.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/Main.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.bootstrap;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.dao.IndexDAO;
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearch;
 import com.netflix.conductor.elasticsearch.EmbeddedElasticSearchProvider;
@@ -56,6 +57,7 @@ public class Main {
             System.exit(3);
         }
 
+        BootstrapUtil.configureSummaryUtil(serverInjector.getInstance(Configuration.class));
 
         System.out.println("\n\n\n");
         System.out.println("                     _            _             ");

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -16,6 +16,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.ProvisionException;
 import com.google.inject.util.Modules;
 import com.netflix.conductor.cassandra.CassandraModule;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.common.utils.JsonMapperProvider;
 import com.netflix.conductor.contribs.http.HttpTask;
@@ -171,6 +173,14 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         } else {
             modules.add(new NoopLockModule());
             logger.warn("Starting locking module using Noop Lock.");
+        }
+
+        if (configuration.isSummaryInputOutputJSONSerializationEnabled() == true) {
+            logger.info("\r\n\r\nJSON SERIALIZATION ENABLED\r\n\r\n");
+            WorkflowSummary.setInputOutputSerializationEnabled(true);
+            TaskSummary.setInputOutputSerializationEnabled(true);
+        } else {
+            logger.info("\r\n\r\nJSON SERIALIZATION DISABLED\r\n\r\n");
         }
 
         ExternalPayloadStorageType externalPayloadStorageType = null;

--- a/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
+++ b/server/src/main/java/com/netflix/conductor/bootstrap/ModulesProvider.java
@@ -16,8 +16,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.ProvisionException;
 import com.google.inject.util.Modules;
 import com.netflix.conductor.cassandra.CassandraModule;
-import com.netflix.conductor.common.run.TaskSummary;
-import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.common.utils.JsonMapperProvider;
 import com.netflix.conductor.contribs.http.HttpTask;
@@ -173,14 +171,6 @@ public class ModulesProvider implements Provider<List<AbstractModule>> {
         } else {
             modules.add(new NoopLockModule());
             logger.warn("Starting locking module using Noop Lock.");
-        }
-
-        if (configuration.isSummaryInputOutputJSONSerializationEnabled() == true) {
-            logger.info("\r\n\r\nJSON SERIALIZATION ENABLED\r\n\r\n");
-            WorkflowSummary.setInputOutputSerializationEnabled(true);
-            TaskSummary.setInputOutputSerializationEnabled(true);
-        } else {
-            logger.info("\r\n\r\nJSON SERIALIZATION DISABLED\r\n\r\n");
         }
 
         ExternalPayloadStorageType externalPayloadStorageType = null;

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -95,3 +95,5 @@ workflow.decider.locking.leaseTimeInSeconds=60
 # Setting is ignored if the value is lower or equals to 0
 # workflow.event.queues.amqp.maxPriority=-1
 
+# To enable Workflow/Task Summary Input/Output JSON Serialization, use the following:
+# summary.input.output.json.serialization.enabled=true


### PR DESCRIPTION
This feature allows for users to configure the string serialization method used for WorkflowSummary and TaskSummary Input/Output objects when *Summary classes are created either for storing in ElasticSearch or when being pulled back from ElasticSearch. 

For my company's current use-case, all of our microservices which interact with the conductor server API we have running are written in JavaScript, so having the *Summary class Input/Output strings be JSON-serialized means we can trivially interact with the *Summary types in JS instead of trying to hand-parse Java's toString() serialization. Searching for Workflows and Tasks by fields of the input still works as expected regardless of serialization mechanism.

The default Java toString() methodology is kept in place, so the change will not affect any users who do not intentionally enable the summaryInputOutputJsonSerializationEnabled configuration. The configurations were added into the standard server.properties and config.properties (commented out with a note on what they do), and a Unit Test was written to flex the new logic and ensure everything is copacetic.

*NOTE: My original implementation wanted to try and use the Configuration class directly in SummaryUtil, but given the /common/ code is a leaf in the dependency tree and /core/, which has Configuration, is higher in the dependency tree, I had to avoid the dependency circle. To do so, I inserted the BootstrapUtil.configureSummaryUtil call into the Server's main startup function. Please let me know if there would be a better location/manner to handle this, but after trying a few different things, what I currently have seemed the cleanest. I'm more than happy to make adjustments if this doesn't quite meet the standards.