### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
 	repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
@@ -25,11 +28,26 @@ allprojects {
     apply plugin: 'eclipse'
 
     repositories {
-        jcenter()
+        mavenCentral()
 
         // oss-candidate for -rc.* verions:
         maven {
-            url "https://dl.bintray.com/netflixoss/oss-candidate"
+            url "https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates"
+        }
+
+        /**
+         * This repository locates artifacts that don't exist in maven central but we had to backup from jcenter
+         * The exclusiveContent
+         */
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url "https://artifactory-oss.prod.netflix.net/artifactory/required-jcenter-modules-backup"
+                }
+            }
+            filter {
+                includeGroupByRegex "com\\.github\\.vmg.*"
+            }
         }
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "com.github.vmg.protogen:protogen-codegen:${revProtogenCodegen}"

--- a/mysql-persistence/build.gradle
+++ b/mysql-persistence/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {

--- a/postgres-persistence/build.gradle
+++ b/postgres-persistence/build.gradle
@@ -1,7 +1,10 @@
 buildscript {
 
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -1,7 +1,10 @@
 buildscript {
 
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {


### PR DESCRIPTION
This replaces jcenter with maven central

Also noticed that artifacts from net.andreinc.* are in use for some mantis samples and those are in jcenter only. I went ahead and create a backup in our own repos so when jcenter goes away, we will be fine