### PR TITLE
add support for escaped expressions

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
@@ -61,16 +61,16 @@ public class ConstraintParamUtil {
             return errorList;
         }
 
-        String[] values = value.split( "(?=\\$\\{)|(?<=\\})" );
+        String[] values = value.split( "(?=(?<!\\$)\\$\\{)|(?<=\\})" );
 
-        for (int i = 0; i < values.length; i++)
-            if (values[i].startsWith( "${" ) && values[i].endsWith( "}" )) {
-                String paramPath = values[i].substring( 2, values[i].length() - 1 );
+        for (String s : values)
+            if (s.startsWith("${") && s.endsWith("}")) {
+                String paramPath = s.substring(2, s.length() - 1);
 
                 if (StringUtils.containsWhitespace(paramPath)) {
                     String message = String.format("key: %s input parameter value: %s is not valid",
                             key, paramPath);
-                    errorList.add( message );
+                    errorList.add(message);
                 } else if (EnvUtils.isEnvironmentVariable(paramPath)) {
                     // if it one of the predefined enums skip validation
                     boolean isPredefinedEnum = false;
@@ -83,21 +83,21 @@ public class ConstraintParamUtil {
                     }
 
                     if (!isPredefinedEnum) {
-                        String sysValue = EnvUtils.getSystemParametersValue(paramPath,"" );
+                        String sysValue = EnvUtils.getSystemParametersValue(paramPath, "");
                         if (sysValue == null) {
                             String errorMessage = String.format("environment variable: %s for given task: %s" +
                                     " input value: %s" + " of input parameter: %s is not valid", paramPath, taskName, key, value);
-                            errorList.add( errorMessage );
+                            errorList.add(errorMessage);
                         }
                     }
                 } //workflow, or task reference name
                 else {
-                    String[] components = paramPath.split( "\\." );
-                    if (!"workflow".equals( components[0] )) {
-                        WorkflowTask task = workflow.getTaskByRefName( components[0] );
+                    String[] components = paramPath.split("\\.");
+                    if (!"workflow".equals(components[0])) {
+                        WorkflowTask task = workflow.getTaskByRefName(components[0]);
                         if (task == null) {
-                            String message = String.format( "taskReferenceName: %s for given task: %s input value: %s of input" + " parameter: %s" + " is not defined in workflow definition.", components[0], taskName, key, value );
-                            errorList.add( message );
+                            String message = String.format("taskReferenceName: %s for given task: %s input value: %s of input" + " parameter: %s" + " is not defined in workflow definition.", components[0], taskName, key, value);
+                            errorList.add(message);
                         }
                     }
                 }

--- a/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
@@ -244,4 +244,26 @@ public class ConstraintParamUtilTest {
         List<String> results = ConstraintParamUtil.validateInputParam(inputParam,"task_1", workflowDef);
         assertEquals(results.size(), 0);
     }
+
+    @Test
+    public void testExtractParamPathComponentsWithEscapedChar() {
+        WorkflowDef workflowDef = constructWorkflowDef();
+
+        WorkflowTask workflowTask_1 = new WorkflowTask();
+        workflowTask_1.setName("task_1");
+        workflowTask_1.setTaskReferenceName("task_1");
+        workflowTask_1.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        Map<String, Object> inputParam = new HashMap<>();
+        inputParam.put("taskId", "$${expression with spaces}");
+        workflowTask_1.setInputParameters(inputParam);
+
+        List<WorkflowTask> tasks = new ArrayList<>();
+        tasks.add(workflowTask_1);
+
+        workflowDef.setTasks(tasks);
+
+        List<String> results = ConstraintParamUtil.validateInputParam(inputParam,"task_1", workflowDef);
+        assertEquals(results.size(), 0);
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
@@ -28,11 +28,7 @@ import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.utils.EnvUtils;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import com.netflix.conductor.common.utils.JsonMapperProvider;
@@ -202,11 +198,11 @@ public class ParametersUtils {
     }
 
     private Object replaceVariables(String paramString, DocumentContext documentContext, String taskId) {
-        String[] values = paramString.split("(?=\\$\\{)|(?<=\\})");
+        String[] values = paramString.split("(?=(?<!\\$)\\$\\{)|(?<=\\})");
         Object[] convertedValues = new Object[values.length];
         for (int i = 0; i < values.length; i++) {
             convertedValues[i] = values[i];
-            if (values !=null && values[i].startsWith("${") && values[i].endsWith("}")) {
+            if (values[i].startsWith("${") && values[i].endsWith("}")) {
                 String paramPath = values[i].substring(2, values[i].length() - 1);
                 if (EnvUtils.isEnvironmentVariable(paramPath)) {
                     String sysValue = EnvUtils.getSystemParametersValue(paramPath, taskId);
@@ -222,7 +218,8 @@ public class ParametersUtils {
                         convertedValues[i] = null;
                     }
                 }
-
+            } else if (values[i].contains("$${")) {
+                convertedValues[i] = values[i].replaceAll("\\$\\$\\{", "\\${");
             }
         }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestParametersUtils.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestParametersUtils.java
@@ -215,12 +215,14 @@ public class TestParametersUtils {
 
 		Map<String, String> mapValue = new HashMap<>();
 		mapValue.put("a", "${someString}");
-		mapValue.put("b", "$${someNumber}");
+		mapValue.put("b", "${someNumber}");
+		mapValue.put("c", "$${someString} ${someNumber}");
 		input.put("map", mapValue);
 
 		List<String> listValue = new ArrayList<>();
-		listValue.add("$${someString}");
+		listValue.add("${someString}");
 		listValue.add("${someNumber}");
+		listValue.add("${someString} $${someNumber}");
 		input.put("list", listValue);
 
 		Object jsonObj = objectMapper.readValue(objectMapper.writeValueAsString(map), Object.class);
@@ -235,15 +237,28 @@ public class TestParametersUtils {
 		assertEquals("${$.someString} afterText", replaced.get("k4"));
 		assertEquals("beforeText ${$.someString}", replaced.get("k5"));
 
+		Map replacedMap = (Map) replaced.get("map");
+		assertEquals("conductor", replacedMap.get("a"));
+		assertEquals(2, replacedMap.get("b"));
+		assertEquals("${someString} 2", replacedMap.get("c"));
+
+		List replacedList = (List) replaced.get("list");
+		assertEquals(3, replacedList.size());
+		assertEquals("conductor", replacedList.get(0));
+		assertEquals(2, replacedList.get(1));
+		assertEquals("conductor ${someNumber}", replacedList.get(2));
+
 		// Verify that input map is not mutated
 		Map inputMap = (Map) input.get("map");
 		assertEquals("${someString}", inputMap.get("a"));
-		assertEquals("$${someNumber}", inputMap.get("b"));
+		assertEquals("${someNumber}", inputMap.get("b"));
+		assertEquals("$${someString} ${someNumber}", inputMap.get("c"));
 
 		// Verify that input list is not mutated
 		List inputList = (List) input.get("list");
-		assertEquals(2, inputList.size());
-		assertEquals("$${someString}", inputList.get(0));
+		assertEquals(3, inputList.size());
+		assertEquals("${someString}", inputList.get(0));
 		assertEquals("${someNumber}", inputList.get(1));
+		assertEquals("${someString} $${someNumber}", inputList.get(2));
 	}
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestParametersUtils.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestParametersUtils.java
@@ -185,7 +185,6 @@ public class TestParametersUtils {
 		assertEquals("conductor", replacedList.get(0));
 		assertEquals(2, replacedList.get(1));
 
-
 		// Verify that input map is not mutated
 		assertEquals("${$.externalId}", input.get("k1"));
 		assertEquals("${name}", input.get("k2"));
@@ -199,5 +198,52 @@ public class TestParametersUtils {
 		assertEquals(2, inputList.size());
 		assertEquals("${name}", inputList.get(0));
 		assertEquals("${version}", inputList.get(1));
+	}
+
+	@Test
+	public void testReplaceWithEscapedTags() throws Exception {
+		Map<String, Object> map = new HashMap<>();
+		map.put("someString", "conductor");
+		map.put("someNumber", 2);
+
+		Map<String, Object> input = new HashMap<>();
+		input.put("k1", "${$.someString} $${$.someNumber}${$.someNumber} ${$.someNumber}$${$.someString}");
+		input.put("k2", "$${$.someString}afterText");
+		input.put("k3", "beforeText$${$.someString}");
+		input.put("k4", "$${$.someString} afterText");
+		input.put("k5", "beforeText $${$.someString}");
+
+		Map<String, String> mapValue = new HashMap<>();
+		mapValue.put("a", "${someString}");
+		mapValue.put("b", "$${someNumber}");
+		input.put("map", mapValue);
+
+		List<String> listValue = new ArrayList<>();
+		listValue.add("$${someString}");
+		listValue.add("${someNumber}");
+		input.put("list", listValue);
+
+		Object jsonObj = objectMapper.readValue(objectMapper.writeValueAsString(map), Object.class);
+
+		Map<String, Object> replaced = parametersUtils.replace(input, jsonObj);
+		assertNotNull(replaced);
+
+		// Verify that values are replaced correctly.
+		assertEquals("conductor ${$.someNumber}2 2${$.someString}", replaced.get("k1"));
+		assertEquals("${$.someString}afterText", replaced.get("k2"));
+		assertEquals("beforeText${$.someString}", replaced.get("k3"));
+		assertEquals("${$.someString} afterText", replaced.get("k4"));
+		assertEquals("beforeText ${$.someString}", replaced.get("k5"));
+
+		// Verify that input map is not mutated
+		Map inputMap = (Map) input.get("map");
+		assertEquals("${someString}", inputMap.get("a"));
+		assertEquals("$${someNumber}", inputMap.get("b"));
+
+		// Verify that input list is not mutated
+		List inputList = (List) input.get("list");
+		assertEquals(2, inputList.size());
+		assertEquals("$${someString}", inputList.get(0));
+		assertEquals("${someNumber}", inputList.get(1));
 	}
 }

--- a/docs/docs/configuration/workflowdef.md
+++ b/docs/docs/configuration/workflowdef.md
@@ -93,6 +93,9 @@ __${SOURCE.input/output.JSONPath}__
 !!! note "JSON Path Support"
 	Conductor supports [JSONPath](http://goessner.net/articles/JsonPath/) specification and uses Java implementation from [here](https://github.com/jayway/JsonPath).
 
+!!! note "Escaping expressions"
+	To escape an expression, prefix it with an extra _$_ character (ex.: ```$${workflow.input...}```).
+
 **Example**
 
 Consider a task with input configured to use input/output parameters from workflow and a task named __loc_task__.


### PR DESCRIPTION
Hi, my first contribution here 👋🏻. We're evaluating Netflix conductor as a workflow executor for our custom automation. In our tests, we have a service that receives a template string like conductor expressions ```${variableName}```. So, we had to escape the expression to send it to our service. I think it's a simple and useful feature to start contributing here 🤩.

To escape an expression, prefix it with an extra _$_ character. So, as an example, the expression will be  ```$${variableName}```.