### PR TITLE
Bug/#2124 Make retry and max time to wait when connection exhausts  configurable

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/jedis/DynomiteJedisProvider.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/jedis/DynomiteJedisProvider.java
@@ -49,7 +49,9 @@ public class DynomiteJedisProvider implements Provider<JedisCommands> {
                 .setConnectTimeout(0)
                 .setMaxConnsPerHost(
                         configuration.getMaxConnectionsPerHost()
-                );
+                )
+                .setMaxTimeoutWhenExhausted(configuration.getMaxTimeoutWhenExhausted())
+                .setRetryPolicyFactory(configuration.getConnectionRetryPolicy());
 
         return new DynoJedisClient.Builder()
                 .withHostSupplier(hostSupplier)


### PR DESCRIPTION
Hi All

I have made the retries to acquire the connection and max time to wait when connection exhausted as configurable. I have followed the same approach as max connections per host. The default values are the same as the hardcoded in the dyno client library.

@kishorebanala   Can you please review this?

Thanks
Guru