### PR TITLE
Enable modification of JettyServer thread pool configuration (for ver 2.x)

### DIFF
--- a/server/src/main/java/com/netflix/conductor/jetty/server/JettyServerConfiguration.java
+++ b/server/src/main/java/com/netflix/conductor/jetty/server/JettyServerConfiguration.java
@@ -12,6 +12,12 @@ public interface JettyServerConfiguration extends Configuration {
     String JOIN_PROPERTY_NAME = "conductor.jetty.server.join";
     boolean JOIN_DEFAULT_VALUE = true;
 
+    String THREAD_POOL_MIN_THREADS_PROPERTY_NAME="conductor.jetty.server.threadpool.minThreads";
+    int  THREAD_POOL_MIN_THREADS_DEFAULT_VALUE = 8;
+
+    String THREAD_POOL_MAX_THREADS_PROPERTY_NAME="conductor.jetty.server.threadpool.maxThreads";
+    int  THREAD_POOL_MAX_THREADS_DEFAULT_VALUE = 200;
+
     default boolean isEnabled(){
         return getBooleanProperty(ENABLED_PROPERTY_NAME, ENABLED_DEFAULT_VALUE);
     }
@@ -22,5 +28,13 @@ public interface JettyServerConfiguration extends Configuration {
 
     default boolean isJoin(){
         return getBooleanProperty(JOIN_PROPERTY_NAME, JOIN_DEFAULT_VALUE);
+    }
+
+    default int getThreadPoolMinThreads() {
+        return getIntProperty(THREAD_POOL_MIN_THREADS_PROPERTY_NAME,THREAD_POOL_MIN_THREADS_DEFAULT_VALUE);
+    }
+
+    default int getThreadPoolMaxThreads() {
+        return getIntProperty(THREAD_POOL_MAX_THREADS_PROPERTY_NAME,THREAD_POOL_MAX_THREADS_DEFAULT_VALUE);
     }
 }

--- a/server/src/main/java/com/netflix/conductor/jetty/server/JettyServerProvider.java
+++ b/server/src/main/java/com/netflix/conductor/jetty/server/JettyServerProvider.java
@@ -19,7 +19,9 @@ public class JettyServerProvider implements Provider<Optional<JettyServer>> {
                 Optional.of(
                         new JettyServer(
                                 configuration.getPort(),
-                                configuration.isJoin()
+                                configuration.isJoin(),
+                                configuration.getThreadPoolMaxThreads(),
+                                configuration.getThreadPoolMinThreads()
                         ))
                 : Optional.empty();
     }

--- a/server/src/test/java/com/netflix/conductor/jetty/server/JettyServerTest.java
+++ b/server/src/test/java/com/netflix/conductor/jetty/server/JettyServerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.jetty.server;
+
+import org.junit.Test;
+
+public class JettyServerTest {
+    @Test
+    public void testCreateJettyServerWithDefaultThreadPoolConfiguration() throws Exception {
+        JettyServer jettyServer = new JettyServer(8083, false);
+        jettyServer.start();
+        jettyServer.stop();
+    }
+
+    @Test
+    public void testCreateJettyServerWithValidThreadPoolConfiguration() throws Exception {
+        JettyServer jettyServer = new JettyServer(8083, false,20,8);
+        jettyServer.start();
+        jettyServer.stop();
+
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateJettyServerWithInvalidThreadPoolConfiguration() throws Exception {
+        JettyServer jettyServer = new JettyServer(8083, false,8,20);
+        jettyServer.start();
+        jettyServer.stop();
+    }
+}


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Externalize JettyServer thread pool configuration so that minThreads and maxThreads properties can be configured through configuration file
Issue #2162


