### PR TITLE
Customizable lease duration when popping workflow ids from decider queue

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -49,6 +49,12 @@ public class ConductorProperties {
     private Duration workflowOffsetTimeout = Duration.ofSeconds(30);
 
     /**
+     * The lease duration to use when a workflow is popped from the decider queue.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration workflowLeaseDuration = Duration.ofMinutes(5);
+
+    /**
      * The number of threads to use to do background sweep on active workflows.
      */
     private int sweeperThreadCount = Runtime.getRuntime().availableProcessors() * 2;
@@ -534,6 +540,14 @@ public class ConductorProperties {
 
     public void setMaxWorkflowVariablesPayloadSizeThreshold(DataSize maxWorkflowVariablesPayloadSizeThreshold) {
         this.maxWorkflowVariablesPayloadSizeThreshold = maxWorkflowVariablesPayloadSizeThreshold;
+    }
+
+    public Duration getWorkflowLeaseDuration() {
+        return workflowLeaseDuration;
+    }
+
+    public void setWorkflowLeaseDuration(Duration workflowLeaseDuration) {
+        this.workflowLeaseDuration = workflowLeaseDuration;
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowPoller.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowPoller.java
@@ -52,7 +52,7 @@ public class WorkflowPoller extends LifecycleAwareComponent {
                 LOGGER.debug("Component stopped, skip workflow sweep");
             } else {
                 List<String> workflowIds = queueDAO.pop(DECIDER_QUEUE,
-                    properties.getSweeperThreadCount(), 2000);
+                    properties.getSweeperThreadCount(), 2000, properties.getWorkflowLeaseDuration().getSeconds());
                 if (workflowIds != null) {
                     // wait for all workflow ids to be "swept"
                     CompletableFuture.allOf(workflowIds


### PR DESCRIPTION
Pull Request type
----
- [ ] Feature

Changes in this PR
----
_A new property called `conductor.app.workflow-lease-duration` added with a default of 5 minutes. This property is used when `WorkflowPoller` pops workflow ids from the decider queue. A shorter lease duration ensures that workflow ids are expired and available for re-processing at a reasonable time._