### PR TITLE
Improve onWorkflowFinalizedIfEnabled

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1146,9 +1146,9 @@ public class WorkflowExecutor {
         }
         if (erroredTasks.isEmpty()) {
             try {
-                queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
                 workflowStatusListener.onWorkflowFinalizedIfEnabled(workflow);
-            } catch (Exception e) {
+                queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
+	    } catch (Exception e) {
                 LOGGER.error("Error removing workflow: {} from decider queue", workflow.getWorkflowId(), e);
             }
         }


### PR DESCRIPTION
Here, onWorkflowFinalizedIfEnabled is better to be called before the workflow id is removed from the decider queue. So if it fails, it will be retried later.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

onWorkflowFinalizedIfEnabled will be called before the workflow id is removed from the decider queue to give an at-least-once guarantee.
