### PR TITLE
Ensure async complete system tasks are not response timed out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/
 target/
 .DS_Store
 .vscode/
+buildscan.log
 
 # publishing secrets
 secrets/signing-key

--- a/contribs/src/test/java/com/netflix/conductor/contribs/metrics/LoggingMetricsConfigurationTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/metrics/LoggingMetricsConfigurationTest.java
@@ -12,9 +12,15 @@
  */
 package com.netflix.conductor.contribs.metrics;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
 import com.codahale.metrics.MetricRegistry;
 import com.netflix.conductor.contribs.metrics.LoggingMetricsConfiguration.Slf4jReporterProvider;
-import org.junit.Ignore;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -22,18 +28,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {"conductor.metrics-logger.enabled=true"})
-@Ignore
-// Test causes "OutOfMemoryError: GC overhead limit reached" error during build
 public class LoggingMetricsConfigurationTest {
 
     @Test

--- a/contribs/src/test/java/com/netflix/conductor/contribs/metrics/PrometheusMetricsConfigurationTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/metrics/PrometheusMetricsConfigurationTest.java
@@ -14,35 +14,34 @@ package com.netflix.conductor.contribs.metrics;
 
 import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Spectator;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {"conductor.metrics-prometheus.enabled=true"})
-@Ignore
+@SuppressWarnings("unchecked")
 public class PrometheusMetricsConfigurationTest {
-  @Test
-  public void testCollector() {
-    new ApplicationContextRunner()
-        .withPropertyValues("conductor.metrics-prometheus.enabled:true")
-        .withUserConfiguration(PrometheusMetricsConfiguration.class)
-        .run(context -> {
-          final Optional<Field> registries = Arrays
-              .stream(Spectator.globalRegistry().getClass().getDeclaredFields())
-              .filter(f -> f.getName().equals("registries")).findFirst();
-          Assert.assertTrue(registries.isPresent());
-          registries.get().setAccessible(true);
-          Assert.assertEquals(1, ((List<Meter>)registries.get().get(Spectator.globalRegistry())).size());
-        });
-  }
+
+    @Test
+    public void testCollector() {
+        new ApplicationContextRunner()
+            .withPropertyValues("conductor.metrics-prometheus.enabled:true")
+            .withUserConfiguration(PrometheusMetricsConfiguration.class)
+            .run(context -> {
+                final Optional<Field> registries = Arrays
+                    .stream(Spectator.globalRegistry().getClass().getDeclaredFields())
+                    .filter(f -> f.getName().equals("registries")).findFirst();
+                Assert.assertTrue(registries.isPresent());
+                registries.get().setAccessible(true);
+                Assert.assertEquals(1, ((List<Meter>) registries.get().get(Spectator.globalRegistry())).size());
+            });
+    }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -1008,7 +1008,7 @@ public class TestWorkflowExecutor {
         workflowDef.setVersion(1);
         subWorkflow.setWorkflowDefinition(workflowDef);
         subWorkflow.setStatus(Workflow.WorkflowStatus.FAILED);
-        subWorkflow.getTasks().addAll(Arrays.asList(task,task1));
+        subWorkflow.getTasks().addAll(Arrays.asList(task, task1));
         subWorkflow.setParentWorkflowId("testRunWorkflowId");
 
         Task task2 = new Task();
@@ -1040,9 +1040,9 @@ public class TestWorkflowExecutor {
 
         //then
         assertEquals(task.getStatus(), Status.COMPLETED);
-        assertEquals(task1.getStatus(),Status.IN_PROGRESS);
-        assertEquals(workflow.getStatus(),WorkflowStatus.RUNNING);
-        assertEquals(subWorkflow.getStatus(),WorkflowStatus.RUNNING);
+        assertEquals(task1.getStatus(), Status.IN_PROGRESS);
+        assertEquals(workflow.getStatus(), WorkflowStatus.RUNNING);
+        assertEquals(subWorkflow.getStatus(), WorkflowStatus.RUNNING);
     }
 
     @Test
@@ -1651,25 +1651,5 @@ public class TestWorkflowExecutor {
         }
 
         return tasks;
-    }
-
-    private static class WorkflowSystemTaskStub extends WorkflowSystemTask {
-
-        private boolean started = false;
-
-        public WorkflowSystemTaskStub(String name) {
-            super(name);
-        }
-
-        @Override
-        public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
-            started = true;
-            task.setStatus(Status.COMPLETED);
-            super.start(workflow, task, executor);
-        }
-
-        public boolean isStarted() {
-            return started;
-        }
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/WorkflowSystemTaskStub.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/WorkflowSystemTaskStub.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2021 Netflix, Inc.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.Task.Status;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+
+public class WorkflowSystemTaskStub extends WorkflowSystemTask {
+
+    private boolean started = false;
+
+    public WorkflowSystemTaskStub(String taskType) {
+        super(taskType);
+    }
+
+    @Override
+    public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
+        started = true;
+        task.setStatus(Status.COMPLETED);
+        super.start(workflow, task, executor);
+    }
+
+    public boolean isStarted() {
+        return started;
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
This change ensures that system tasks that are configured to be async complete are not response timed out. Such tasks are not expected to be monitored for completion by Conductor and hence, do not need to evaluated for response timeouts.

Re-enable ignored tests since the error may have been addressed.