### PR TITLE
Docker & Docker Compose fixes - 3.X

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+server/build/libs

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,6 +12,11 @@ services:
       - internal
     ports:
       - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl","-I" ,"-XGET", "http://localhost:8080/health"]
+      interval: 60s
+      timeout: 30s
+      retries: 12
     links:
       - elasticsearch:es
       - dynomite:dyno1
@@ -20,6 +25,23 @@ services:
         condition: service_healthy
       dynomite:
         condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+  dynomite:
+    image: v1r3n/dynomite
+    networks:
+      - internal
+    ports:
+      - 8102:8102
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/8102'
+      interval: 5s
+      timeout: 5s
+      retries: 12
     logging:
       driver: "json-file"
       options:
@@ -40,28 +62,10 @@ services:
     links:
       - conductor-server
 
-  dynomite:
-    image: v1r3n/dynomite
-    networks:
-      - internal
-    ports:
-      - 8102:8102
-    healthcheck:
-      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/8102'
-      interval: 5s
-      timeout: 5s
-      retries: 12
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "1k"
-        max-file: "3"
-
-  # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.8
+    image: elasticsearch:6.8.15
     environment:
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
       - transport.host=0.0.0.0
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # 0. Builder stage
-FROM openjdk:8-jdk AS builder
+FROM openjdk:11-jdk AS builder
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 
@@ -15,7 +15,7 @@ WORKDIR /conductor
 RUN ./gradlew build -x test
 
 # 1. Bin stage
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre
 
 MAINTAINER Netflix OSS <conductor@netflix.com>
 
@@ -32,6 +32,8 @@ RUN chmod +x /app/startup.sh
 
 EXPOSE 8080
 EXPOSE 8090
+
+HEALTHCHECK --interval=60s --timeout=30s --retries=10 CMD curl -I -XGET http://localhost:8080/health || exit 1
 
 CMD [ "/app/startup.sh" ]
 ENTRYPOINT [ "/bin/sh"]

--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -32,4 +32,4 @@ fi
 
 echo "Using java options config: $JAVA_OPTS"
 
-java ${JAVA_OPTS} -jar conductor-server-*-all.jar $config_file $log4j_file
+java ${JAVA_OPTS} -jar conductor-server-*-boot.jar $config_file $log4j_file

--- a/docker/server/config/config-mysql-grpc.properties
+++ b/docker/server/config/config-mysql-grpc.properties
@@ -5,13 +5,18 @@ conductor.grpc-server.enabled=true
 conductor.db.type=mysql
 
 conductor.mysql.jdbcUrl=jdbc:mysql://mysql:3306/conductor
+conductor.mysql.jdbcUsername=conductor
+conductor.mysql.jdbcPassword=conductor
 
 # Hikari pool sizes are -1 by default and prevent startup
 conductor.mysql.connectionPoolMaxSize=10
 conductor.mysql.connectionPoolMinIdle=2
 
+# Elastic search instance indexing is enabled.
+conductor.indexing.enabled=true
+
 # Transport address to elasticsearch
-conductor.elasticsearch.url=elasticsearch:9300
+conductor.elasticsearch.url=http://es:9200
 
 # Name of the elasticsearch cluster
 conductor.elasticsearch.indexName=conductor

--- a/docker/server/config/config-mysql.properties
+++ b/docker/server/config/config-mysql.properties
@@ -5,13 +5,18 @@ conductor.grpc-server.enabled=false
 conductor.db.type=mysql
 
 conductor.mysql.jdbcUrl=jdbc:mysql://mysql:3306/conductor
+conductor.mysql.jdbcUsername=conductor
+conductor.mysql.jdbcPassword=conductor
 
 # Hikari pool sizes are -1 by default and prevent startup
 conductor.mysql.connectionPoolMaxSize=10
 conductor.mysql.connectionPoolMinIdle=2
 
+# Elastic search instance indexing is enabled.
+conductor.indexing.enabled=true
+
 # Transport address to elasticsearch
-conductor.elasticsearch.url=elasticsearch:9300
+conductor.elasticsearch.url=http://es:9200
 
 # Name of the elasticsearch cluster
 conductor.elasticsearch.indexName=conductor

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -28,8 +28,11 @@ conductor.app.workflowRepairServiceEnabled=true
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
 conductor.redis.queuesNonQuorumPort=22122
 
+# Elastic search instance indexing is enabled.
+conductor.indexing.enabled=true
+
 # Transport address to elasticsearch
-conductor.elasticsearch.url=es:9300
+conductor.elasticsearch.url=http://es:9200
 
 # Name of the elasticsearch cluster
 conductor.elasticsearch.indexName=conductor

--- a/server/src/main/java/com/netflix/conductor/Conductor.java
+++ b/server/src/main/java/com/netflix/conductor/Conductor.java
@@ -16,20 +16,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.Properties;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {CassandraAutoConfiguration.class, DataSourceAutoConfiguration.class})
 public class Conductor {
 
     private static final Logger log = LoggerFactory.getLogger(Conductor.class);
 
     public static void main(String[] args) throws IOException {
         loadExternalConfig();
-
+        loadExternalConfigFromArgs(args);
+        
         SpringApplication.run(Conductor.class, args);
     }
 
@@ -55,5 +58,24 @@ public class Conductor {
                 log.warn("Ignoring {} since it does not exist", configFile);
             }
         }
+    }
+    
+    private static void loadExternalConfigFromArgs(String[] args) throws IOException {
+    	if(null!=args && args.length>0) {
+    		for(String configFile: args)
+    		{
+    			if (!StringUtils.isEmpty(configFile)) {
+    	            FileSystemResource resource = new FileSystemResource(configFile);
+    	            if (resource.exists()) {
+    	                Properties properties = new Properties();
+    	                properties.load(resource.getInputStream());
+    	                properties.forEach((key, value) -> System.setProperty((String) key, (String) value));
+    	                log.info("Loaded {} properties from {}", properties.size(), configFile);
+    	            }else {
+    	                log.warn("Ignoring {} since it does not exist", configFile);
+    	            }
+    	        }
+    		}
+    	}
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [x] Feature

Changes in this PR
----

Issue # 1. Docker Builds are failing due to

1. Incorrect JDK & JRE versions - jdk8 & jre8. Whereas jdk11 and jre11 have to be used for conductor 3.x
2. Incorrect startup jar name in startup script is causing "No such file or directory" issue. The conductor-server-*-boot.jar has to be used for conductor 3.x instead of conductor-server-*-all.jar

Issue # 2. Docker Compose configuration missing out indexing property.

1. Docker Compose though specifies an elasticsearch container, misses out configuring the indexing property in config*.properties excluding config-local.properties.

All the above mentioned are fixed and tested.

Feature # Added Healtcheck to Dockerfile for conductor

Alternatives considered
----

No alternative possible as these are required changes for 2.x to 3.x migration.
