### PR TITLE
remove codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,0 @@
-codecov:
-  branch: dev
-  # strict_yaml_branch: master # Enable this if we want to use the yml file in master to dictate the reports for all branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
 - openjdk8
-after_success:
-- bash <(curl -s https://codecov.io/bash)
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 git:


### PR DESCRIPTION
While we were not affected by the https://about.codecov.io/security-update/

We suggest to move away from this pattern of curling codecov.io to get the bash script

This is to prevent potential problems in the future