### PR TITLE
Removed TaskType#isSystemTask in favor SystemTaskRegistry#isSystemTask

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskType.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskType.java
@@ -20,28 +20,28 @@ import java.util.Set;
 @ProtoEnum
 public enum TaskType {
 
-    SIMPLE(true),
-    DYNAMIC(true),
-    FORK_JOIN(true),
-    FORK_JOIN_DYNAMIC(true),
-    DECISION(true),
-    JOIN(true),
-    DO_WHILE(true),
-    SUB_WORKFLOW(true),
-    EVENT(true),
-    WAIT(true),
-    USER_DEFINED(false),
-    HTTP(true),
-    LAMBDA(true),
-    EXCLUSIVE_JOIN(true),
-    TERMINATE(true),
-    KAFKA_PUBLISH(true),
-    JSON_JQ_TRANSFORM(true),
-    SET_VARIABLE(true);
+    SIMPLE,
+    DYNAMIC,
+    FORK_JOIN,
+    FORK_JOIN_DYNAMIC,
+    DECISION,
+    JOIN,
+    DO_WHILE,
+    SUB_WORKFLOW,
+    EVENT,
+    WAIT,
+    USER_DEFINED,
+    HTTP,
+    LAMBDA,
+    EXCLUSIVE_JOIN,
+    TERMINATE,
+    KAFKA_PUBLISH,
+    JSON_JQ_TRANSFORM,
+    SET_VARIABLE;
 
     /**
      * TaskType constants representing each of the possible enumeration values. Motivation: to not have any
-     * hardcoded/inline strings used in the code. Example of use: CoreModule
+     * hardcoded/inline strings used in the code.
      */
     public static final String TASK_TYPE_DECISION = "DECISION";
     public static final String TASK_TYPE_DYNAMIC = "DYNAMIC";
@@ -52,7 +52,6 @@ public enum TaskType {
     public static final String TASK_TYPE_WAIT = "WAIT";
     public static final String TASK_TYPE_SUB_WORKFLOW = "SUB_WORKFLOW";
     public static final String TASK_TYPE_FORK_JOIN = "FORK_JOIN";
-    public static final String TASK_TYPE_USER_DEFINED = "USER_DEFINED";
     public static final String TASK_TYPE_SIMPLE = "SIMPLE";
     public static final String TASK_TYPE_HTTP = "HTTP";
     public static final String TASK_TYPE_LAMBDA = "LAMBDA";
@@ -73,22 +72,20 @@ public enum TaskType {
         BUILT_IN_TASKS.add(TASK_TYPE_DO_WHILE);
     }
 
-    private final boolean isSystemTask;
-
-    TaskType(boolean isSystemTask) {
-        this.isSystemTask = isSystemTask;
-    }
-
-    /*
-     * TODO: Update code to use only enums rather than Strings.
-     * This method is only used as a helper until the transition is done.
+    /**
+     * Converts a task type string to {@link TaskType}. For an unknown string, the value is defaulted
+     * to {@link TaskType#USER_DEFINED}.
+     * <p>
+     * NOTE: Use {@link Enum#valueOf(Class, String)} if the default of USER_DEFINED is not necessary.
+     *
+     * @param taskType The task type string.
+     * @return The {@link TaskType} enum.
      */
-    public static boolean isSystemTask(String name) {
+    public static TaskType of(String taskType) {
         try {
-            TaskType taskType = TaskType.valueOf(name);
-            return taskType.isSystemTask;
+            return TaskType.valueOf(taskType);
         } catch (IllegalArgumentException iae) {
-            return false;
+            return TaskType.USER_DEFINED;
         }
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -494,12 +494,8 @@ public class WorkflowTask {
 
     private Collection<List<WorkflowTask>> children() {
         Collection<List<WorkflowTask>> workflowTaskLists = new LinkedList<>();
-        TaskType taskType = TaskType.USER_DEFINED;
-        if (TaskType.isSystemTask(type)) {
-            taskType = TaskType.valueOf(type);
-        }
 
-        switch (taskType) {
+        switch (TaskType.of(type)) {
             case DECISION:
                 workflowTaskLists.addAll(decisionCases.values());
                 workflowTaskLists.add(defaultCase);
@@ -529,10 +525,7 @@ public class WorkflowTask {
     }
 
     public WorkflowTask next(String taskReferenceName, WorkflowTask parent) {
-        TaskType taskType = TaskType.USER_DEFINED;
-        if (TaskType.isSystemTask(type)) {
-            taskType = TaskType.valueOf(type);
-        }
+        TaskType taskType = TaskType.of(type);
 
         switch (taskType) {
             case DO_WHILE:
@@ -606,12 +599,7 @@ public class WorkflowTask {
             return true;
         }
 
-        TaskType taskType = TaskType.USER_DEFINED;
-        if (TaskType.isSystemTask(type)) {
-            taskType = TaskType.valueOf(type);
-        }
-
-        switch (taskType) {
+        switch (TaskType.of(type)) {
             case DECISION:
             case DO_WHILE:
             case FORK_JOIN:

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -51,7 +51,6 @@ import com.netflix.conductor.service.ExecutionLockService;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -87,7 +86,6 @@ import static com.netflix.conductor.core.exception.ApplicationException.Code.NOT
  * Workflow services provider interface
  */
 @Trace
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Component
 public class WorkflowExecutor {
 
@@ -119,7 +117,6 @@ public class WorkflowExecutor {
 
     private static final Predicate<Task> NON_TERMINAL_TASK = task -> !task.getStatus().isTerminal();
 
-    @Autowired
     public WorkflowExecutor(DeciderService deciderService, MetadataDAO metadataDAO, QueueDAO queueDAO,
                             MetadataMapperService metadataMapperService, WorkflowStatusListener workflowStatusListener,
                             ExecutionDAOFacade executionDAOFacade, ConductorProperties properties,
@@ -1472,7 +1469,7 @@ public class WorkflowExecutor {
                 String[] domains = domainstr.split(",");
                 tasks.forEach(task -> {
                     // Filter out SystemTask
-                    if (!TaskType.isSystemTask(task.getTaskType())) {
+                    if (!systemTaskRegistry.isSystemTask(task.getTaskType())) {
                         // Check which domain worker is polling
                         // Set the task domain
                         task.setDomain(getActiveDomain(task.getTaskType(), domains));
@@ -1481,7 +1478,7 @@ public class WorkflowExecutor {
             }
             // Step 2: Override additional mappings.
             tasks.forEach(task -> {
-                if (!TaskType.isSystemTask(task.getTaskType())) {
+                if (!systemTaskRegistry.isSystemTask(task.getTaskType())) {
                     String taskDomainstr = taskToDomain.get(task.getTaskType());
                     if (taskDomainstr != null) {
                         task.setDomain(getActiveDomain(task.getTaskType(), taskDomainstr.split(",")));


### PR DESCRIPTION
Pull Request type
----

- [x] Refactoring (no functional changes, no api changes)

Changes in this PR
----

_Code consolidation: The check to find if a task is a system task existed in two places. SystemTaskRegistry and TaskType. TaskType only considered hardcoded tasks  as system tasks whereas SystemTaskRegistry considered any instance of WorkflowSystemTask. Replacing the TaskType#isSystemTask with SystemTaskRegistry#isSystemTask fixes the possibility that some code is only executed hardcoded system tasks and not all. In places where TaskType#isSystemTask is used as a litmus test in task type String to Enum conversion, a new method TaskType#of is used._