### PR TITLE
Remove the unused grpc health library

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -10,15 +10,10 @@ plugins {
     id "com.google.protobuf" version "0.8.15"
 }
 
-repositories{
-    maven { url "https://dl.bintray.com/chaos-systems/mvn" }
-}
-
 dependencies {
     compile project(':conductor-common')
     compile project(':conductor-core')
 
-    protobuf 'io.chaossystems.grpc:grpc-healthcheck:1.0.+:protos'
     compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
     compile "io.grpc:grpc-protobuf:${revGrpc}"
     compile "io.grpc:grpc-stub:${revGrpc}"


### PR DESCRIPTION
Pull Request type
----

- [ ] Build related changes

Changes in this PR
----

_Remove the unused grpc health library that is hosted in bintray which got decommissioned_
