### PR TITLE
Allow retrying timed_out workflow with no unsuccessful tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -18,6 +18,7 @@ import static com.netflix.conductor.common.metadata.tasks.Task.Status.FAILED_WIT
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRESS;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.SKIPPED;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.valueOf;
 import static com.netflix.conductor.common.metadata.tasks.TaskType.SUB_WORKFLOW;
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_JOIN;
@@ -632,9 +633,11 @@ public class WorkflowExecutor {
             }
         }
 
-        if (retriableMap.values().size() == 0) {
+        // if workflow TIMED_OUT due to timeoutSeconds configured in the workflow definition,
+        // it may not have any unsuccessful tasks that can be retried
+        if (retriableMap.values().size() == 0 && workflow.getStatus() != WorkflowStatus.TIMED_OUT) {
             throw new ApplicationException(CONFLICT,
-                    "There are no retriable tasks! Use restart if you want to attempt entire workflow execution again.");
+                    "There are no retryable tasks! Use restart if you want to attempt entire workflow execution again.");
         }
 
         // Update Workflow with new status.

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "conductor.workflow-monitor.enabled",
-      "type": "java.lang.Integer",
+      "type": "java.lang.Boolean",
       "description": "Enables the workflow monitor that publishes workflow and task metrics.",
       "defaultValue": "true",
       "sourceType": "com.netflix.conductor.metrics.WorkflowMonitor"


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
_Allow workflows that TIMED_OUT because of the timeoutSeconds configuration at the workflow level to be retried. In such workflows, there may not be any unsuccessful tasks, but the workflows should be able to be retried by the user._

_The workflow will be set to RUNNING state by the action and will be acted upon later by the sweeper._
