### PR TITLE
Get all IP addresses for redis cluster

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -17,7 +17,7 @@ import com.netflix.conductor.redis.jedis.JedisCluster;
 import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
-import java.util.HashSet;
+import java.util.stream.Collectors;
 import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,10 +34,9 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
         HostSupplier hostSupplier, TokenMapSupplier tokenMapSupplier) {
         GenericObjectPoolConfig genericObjectPoolConfig = new GenericObjectPoolConfig();
         genericObjectPoolConfig.setMaxTotal(properties.getMaxConnectionsPerHost());
-        Set hosts = new HashSet<>();
-        for(Host h : hostSupplier.getHosts()){
-            hosts.add(new HostAndPort(h.getHostName(), h.getPort()));
-        }
+        Set hosts = hostSupplier.getHosts().stream()
+            .map(h -> new HostAndPort(h.getHostName(), h.getPort()))
+            .collect(Collectors.toSet());
         return new JedisCluster(new redis.clients.jedis.JedisCluster(hosts, genericObjectPoolConfig));
     }
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -17,6 +17,8 @@ import com.netflix.conductor.redis.jedis.JedisCluster;
 import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -32,9 +34,10 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
         HostSupplier hostSupplier, TokenMapSupplier tokenMapSupplier) {
         GenericObjectPoolConfig genericObjectPoolConfig = new GenericObjectPoolConfig();
         genericObjectPoolConfig.setMaxTotal(properties.getMaxConnectionsPerHost());
-        Host host = hostSupplier.getHosts().get(0);
-        return new JedisCluster(
-            new redis.clients.jedis.JedisCluster(new HostAndPort(host.getHostName(), host.getPort()),
-                genericObjectPoolConfig));
+        Set hosts = new HashSet<>();
+        for(Host h : hostSupplier.getHosts()){
+            hosts.add(new HostAndPort(h.getHostName(), h.getPort()));
+        }
+        return new JedisCluster(new redis.clients.jedis.JedisCluster(hosts, genericObjectPoolConfig));
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #2132 

Redis cluster configuration now gets all IP addresses for a cluster, rather than just the first IP address.

Alternatives considered
----

_Describe alternative implementation you have considered_
