### PR TITLE
Remove workflow operation from task update

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -12,6 +12,13 @@
  */
 package com.netflix.conductor.core.execution;
 
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.COMPLETED_WITH_ERRORS;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRESS;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.SKIPPED;
+import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TERMINATE;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
@@ -33,14 +40,6 @@ import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.metrics.Monitors;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Service;
-
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,13 +51,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import static com.netflix.conductor.common.metadata.tasks.Task.Status.COMPLETED_WITH_ERRORS;
-import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRESS;
-import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
-import static com.netflix.conductor.common.metadata.tasks.Task.Status.SKIPPED;
-import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
-import static com.netflix.conductor.common.metadata.tasks.TaskType.TERMINATE;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
 
 /**
  * Decider evaluates the state of the workflow by inspecting the current state along with the blueprint. The result of
@@ -605,8 +604,8 @@ public class DeciderService {
             return;
         }
 
-        String reason = String.format("Workflow '%s' timed out after %d seconds. Timeout configured as %d. " +
-                "Timeout policy configured to %s", workflow.getWorkflowId(), elapsedTime / 1000L, timeout,
+        String reason = String.format("Workflow timed out after %d seconds. Timeout configured as %d seconds. " +
+                "Timeout policy configured to %s", elapsedTime / 1000L, workflowDef.getTimeoutSeconds(),
             workflowDef.getTimeoutPolicy().name());
 
         switch (workflowDef.getTimeoutPolicy()) {
@@ -641,7 +640,7 @@ public class DeciderService {
         }
 
         String reason = String.format("Task timed out after %d seconds. Timeout configured as %d seconds. "
-                + "Timeout policy configured to %s", elapsedTime / 1000L, timeout / 1000L,
+                + "Timeout policy configured to %s", elapsedTime / 1000L, taskDef.getTimeoutSeconds(),
             taskDef.getTimeoutPolicy().name());
         timeoutTaskWithTimeoutPolicy(reason, taskDef, task);
     }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1150,7 +1150,7 @@ public class TestDeciderService {
         try {
             deciderService.checkWorkflowTimeout(workflow);
         } catch (TerminateWorkflowException twe) {
-            assertTrue(twe.getMessage().contains("Workflow 'workflow_id' timed out"));
+            assertTrue(twe.getMessage().contains("Workflow timed out"));
         }
 
         // for a retried workflow
@@ -1158,7 +1158,7 @@ public class TestDeciderService {
         try {
             deciderService.checkWorkflowTimeout(workflow);
         } catch (TerminateWorkflowException twe) {
-            assertTrue(twe.getMessage().contains("Workflow 'workflow_id' timed out"));
+            assertTrue(twe.getMessage().contains("Workflow timed out"));
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -99,19 +99,6 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.service.ExecutionLockService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -136,6 +123,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
@@ -198,7 +198,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
         taskResult.addOutputData('ErrorMessage', 'There was a terminal error')
 
         workflowExecutionService.updateTask(taskResult)
-        workflowExecutor.decide(workflowInstanceId)
+        sweep(workflowInstanceId)
 
         then: "The first polled task is integration_task_1 and the workflowInstanceId of the task is same as running workflowInstanceId"
         polledIntegrationTask1
@@ -212,6 +212,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             output['o1'] == 'p1 value'
             output['validationErrors'] == 'There was a terminal error'
             getTaskByRefName('t1').retryCount == 0
+            failedReferenceTaskNames == ['t1'] as HashSet
         }
 
         cleanup:
@@ -599,6 +600,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             tasks[3].status == Task.Status.COMPLETED
             tasks[1].taskId == tasks[2].retriedTaskId
             tasks[2].taskId == tasks[3].retriedTaskId
+            failedReferenceTaskNames == ['t2'] as HashSet
         }
 
         cleanup:
@@ -699,6 +701,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             tasks.size() == 4
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].status == Task.Status.COMPLETED
+            failedReferenceTaskNames == ['t1'] as HashSet
         }
 
         cleanup:


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
_Updating fields in the workflow and the workflow consecutively that are performed as part of the updateTask operation are removed. Since these updates are performed out of band without acquiring the lock, these can lead to possible race conditions._

_Also, removed unused method - `skipTasksAffectedByTerminateTask`_
