### PR TITLE
New Search APIs that return Workflow/Task instead of WorkflowSummary/TaskSummary

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
@@ -57,6 +57,9 @@ public class TaskClient extends ClientBase {
     private static final GenericType<SearchResult<TaskSummary>> searchResultTaskSummary = new GenericType<SearchResult<TaskSummary>>() {
     };
 
+    private static final GenericType<SearchResult<Task>> searchResultTask = new GenericType<SearchResult<Task>>() {
+    };
+
     private static final GenericType<Map<String, Integer>> queueSizeMap = new GenericType<Map<String, Integer>>() {
     };
 
@@ -371,6 +374,16 @@ public class TaskClient extends ClientBase {
     }
 
     /**
+     * Search for tasks based on payload
+     *
+     * @param query the search string
+     * @return returns the {@link SearchResult} containing the {@link Task} matching the query
+     */
+    public SearchResult<Task> searchV2(String query) {
+        return getForEntity("tasks/search-v2", new Object[]{"query", query}, searchResultTask);
+    }
+
+    /**
      * Paginated search for tasks based on payload
      *
      * @param start    start value of page
@@ -384,5 +397,21 @@ public class TaskClient extends ClientBase {
         Object[] params = new Object[]{"start", start, "size", size, "sort", sort, "freeText", freeText, "query",
             query};
         return getForEntity("tasks/search", params, searchResultTaskSummary);
+    }
+
+    /**
+     * Paginated search for tasks based on payload
+     *
+     * @param start    start value of page
+     * @param size     number of tasks to be returned
+     * @param sort     sort order
+     * @param freeText additional free text query
+     * @param query    the search query
+     * @return the {@link SearchResult} containing the {@link Task} that match the query
+     */
+    public SearchResult<Task> searchV2(Integer start, Integer size, String sort, String freeText, String query) {
+        Object[] params = new Object[]{"start", start, "size", size, "sort", sort, "freeText", freeText, "query",
+            query};
+        return getForEntity("tasks/search-v2", params, searchResultTask);
     }
 }

--- a/client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
@@ -43,6 +43,9 @@ public class WorkflowClient extends ClientBase {
     private static final GenericType<SearchResult<WorkflowSummary>> searchResultWorkflowSummary = new GenericType<SearchResult<WorkflowSummary>>() {
     };
 
+    private static final GenericType<SearchResult<Workflow>> searchResultWorkflow = new GenericType<SearchResult<Workflow>>() {
+    };
+
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowClient.class);
 
     /**
@@ -376,6 +379,16 @@ public class WorkflowClient extends ClientBase {
     }
 
     /**
+     * Search for workflows based on payload
+     *
+     * @param query the search query
+     * @return the {@link SearchResult} containing the {@link Workflow} that match the query
+     */
+    public SearchResult<Workflow> searchV2(String query) {
+        return getForEntity("workflow/search-v2", new Object[]{"query", query}, searchResultWorkflow);
+    }
+
+    /**
      * Paginated search for workflows based on payload
      *
      * @param start    start value of page
@@ -391,4 +404,20 @@ public class WorkflowClient extends ClientBase {
             query};
         return getForEntity("workflow/search", params, searchResultWorkflowSummary);
     }
+
+    /**
+     * Paginated search for workflows based on payload
+     *
+     * @param start    start value of page
+     * @param size     number of workflows to be returned
+     * @param sort     sort order
+     * @param freeText additional free text query
+     * @param query    the search query
+     * @return the {@link SearchResult} containing the {@link Workflow} that match the query
+     */
+    public SearchResult<Workflow> searchV2(Integer start, Integer size, String sort, String freeText, String query) {
+        Object[] params = new Object[]{"start", start, "size", size, "sort", sort, "freeText", freeText, "query", query};
+        return getForEntity("workflow/search-v2", params, searchResultWorkflow);
+    }
 }
+

--- a/client/src/test/java/com/netflix/conductor/client/http/TaskClientTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/TaskClientTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.http;
+
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.sun.jersey.api.client.ClientHandler;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.config.ClientConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.lang.reflect.ParameterizedType;
+import java.net.URI;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class TaskClientTest {
+
+    @Mock
+    private ClientHandler clientHandler;
+
+    @Mock
+    private ClientConfig clientConfig;
+
+    private TaskClient taskClient;
+
+    @Before
+    public void before() {
+        this.taskClient = new TaskClient(clientConfig, clientHandler);
+        this.taskClient.setRootURI("http://myuri:8080/");
+    }
+
+    @Test
+    public void testSearch() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<TaskSummary> taskSearchResult = new SearchResult<>();
+
+        taskSearchResult.setTotalHits(1);
+        TaskSummary taskSummary = mock(TaskSummary.class);
+
+        taskSearchResult.setResults(Collections.singletonList(taskSummary));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<TaskSummary>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(TaskSummary.class)
+        ))).thenReturn(taskSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/tasks/search?query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<TaskSummary> searchResult = taskClient.search("my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(taskSummary), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchV2() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<Task> taskSearchResult = new SearchResult<>();
+        taskSearchResult.setTotalHits(1);
+        Task task = mock(Task.class);
+        taskSearchResult.setResults(Collections.singletonList(task));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<Task>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(Task.class)
+        ))).thenReturn(taskSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/tasks/search-v2?query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<Task> searchResult = taskClient.searchV2("my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(task), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchWithParams() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<TaskSummary> taskSearchResult = new SearchResult<>();
+
+        taskSearchResult.setTotalHits(1);
+        TaskSummary taskSummary = mock(TaskSummary.class);
+
+        taskSearchResult.setResults(Collections.singletonList(taskSummary));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<TaskSummary>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(TaskSummary.class)
+        ))).thenReturn(taskSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/tasks/search?start=0&size=10&sort=sort&freeText=text&query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<TaskSummary> searchResult = taskClient.search(0,10,"sort","text","my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(taskSummary), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchV2WithParams() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<Task> taskSearchResult = new SearchResult<>();
+        taskSearchResult.setTotalHits(1);
+        Task task = mock(Task.class);
+        taskSearchResult.setResults(Collections.singletonList(task));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<Task>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(Task.class)
+        ))).thenReturn(taskSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/tasks/search-v2?start=0&size=10&sort=sort&freeText=text&query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<Task> searchResult = taskClient.searchV2(0,10,"sort","text","my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(task), searchResult.getResults());
+    }
+}

--- a/client/src/test/java/com/netflix/conductor/client/http/WorkflowClientTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/WorkflowClientTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.client.http;
 
 

--- a/client/src/test/java/com/netflix/conductor/client/http/WorkflowClientTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/WorkflowClientTest.java
@@ -1,0 +1,118 @@
+package com.netflix.conductor.client.http;
+
+
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.sun.jersey.api.client.ClientHandler;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.config.ClientConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.lang.reflect.ParameterizedType;
+import java.net.URI;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class WorkflowClientTest {
+
+    @Mock
+    private ClientHandler clientHandler;
+
+    @Mock
+    private ClientConfig clientConfig;
+
+    private WorkflowClient workflowClient;
+
+    @Before
+    public void before() {
+        this.workflowClient = new WorkflowClient(clientConfig, clientHandler);
+        this.workflowClient.setRootURI("http://myuri:8080/");
+    }
+
+    @Test
+    public void testSearch() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<WorkflowSummary> workflowSearchResult = new SearchResult<>();
+
+        workflowSearchResult.setTotalHits(1);
+        WorkflowSummary workflowSummary = mock(WorkflowSummary.class);
+
+        workflowSearchResult.setResults(Collections.singletonList(workflowSummary));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<WorkflowSummary>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(WorkflowSummary.class)
+        ))).thenReturn(workflowSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/workflow/search?query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<WorkflowSummary> searchResult = workflowClient.search("my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflowSummary), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchV2() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<Workflow> workflowSearchResult = new SearchResult<>();
+        workflowSearchResult.setTotalHits(1);
+        Workflow workflow = mock(Workflow.class);
+        workflowSearchResult.setResults(Collections.singletonList(workflow));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<Workflow>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(Workflow.class)
+        ))).thenReturn(workflowSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/workflow/search-v2?query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<Workflow> searchResult = workflowClient.searchV2("my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflow), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchWithParams() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<WorkflowSummary> workflowSearchResult = new SearchResult<>();
+
+        workflowSearchResult.setTotalHits(1);
+        WorkflowSummary workflowSummary = mock(WorkflowSummary.class);
+
+        workflowSearchResult.setResults(Collections.singletonList(workflowSummary));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<WorkflowSummary>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(WorkflowSummary.class)
+        ))).thenReturn(workflowSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/workflow/search?start=0&size=10&sort=sort&freeText=text&query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<WorkflowSummary> searchResult = workflowClient.search(0,10,"sort","text","my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflowSummary), searchResult.getResults());
+    }
+
+    @Test
+    public void testSearchV2WithParams() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        SearchResult<Workflow> workflowSearchResult = new SearchResult<>();
+        workflowSearchResult.setTotalHits(1);
+        Workflow workflow = mock(Workflow.class);
+        workflowSearchResult.setResults(Collections.singletonList(workflow));
+        when(clientResponse.getEntity(argThat((GenericType<SearchResult<Workflow>> type) ->
+                ((ParameterizedType) type.getType()).getRawType().equals(SearchResult.class) &&
+                        ((ParameterizedType) type.getType()).getActualTypeArguments()[0].equals(Workflow.class)
+        ))).thenReturn(workflowSearchResult);
+        when(clientHandler.handle(argThat(argument -> argument.getURI().equals(URI.create("http://myuri:8080/workflow/search-v2?start=0&size=10&sort=sort&freeText=text&query=my_complex_query")))))
+                .thenReturn(clientResponse);
+        SearchResult<Workflow> searchResult = workflowClient.searchV2(0,10,"sort","text","my_complex_query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflow), searchResult.getResults());
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/TaskSummary.java
@@ -17,7 +17,6 @@ import com.github.vmg.protogen.annotations.ProtoMessage;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.utils.SummaryUtil;
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.SimpleDateFormat;
@@ -25,7 +24,7 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;
 
-@ProtoMessage(fromProto = false)
+@ProtoMessage
 public class TaskSummary {
 
     /**
@@ -139,15 +138,25 @@ public class TaskSummary {
         return workflowId;
     }
 
-    public String getWorkflowType() {
-        return workflowType;
-    }
-
     /**
      * @param workflowId the workflowId to set
      */
     public void setWorkflowId(String workflowId) {
         this.workflowId = workflowId;
+    }
+
+    /**
+     * @return the workflowType
+     */
+    public String getWorkflowType() {
+        return workflowType;
+    }
+
+    /**
+     * @param workflowType the workflowType to set
+     */
+    public void setWorkflowType(String workflowType) {
+        this.workflowType = workflowType;
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -351,6 +351,22 @@ public class ExecutionService {
         return new SearchResult<>(totalHits, workflows);
     }
 
+    public SearchResult<Workflow> searchV2(String query, String freeText, int start, int size, List<String> sortOptions) {
+
+        SearchResult<String> result = executionDAOFacade.searchWorkflows(query, freeText, start, size, sortOptions);
+        List<Workflow> workflows = result.getResults().stream().parallel().map(workflowId -> {
+            try {
+                return executionDAOFacade.getWorkflowById(workflowId, false);
+            } catch(Exception e) {
+                LOGGER.error("Error fetching workflow by id: {}", workflowId, e);
+                return null;
+            }
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+        int missing = result.getResults().size() - workflows.size();
+        long totalHits = result.getTotalHits() - missing;
+        return new SearchResult<>(totalHits, workflows);
+    }
+
     public SearchResult<WorkflowSummary> searchWorkflowByTasks(String query, String freeText, int start, int size,
         List<String> sortOptions) {
         SearchResult<TaskSummary> taskSummarySearchResult = searchTasks(query, freeText, start, size, sortOptions);
@@ -373,19 +389,38 @@ public class ExecutionService {
         return new SearchResult<>(totalHits, workflowSummaries);
     }
 
+    public SearchResult<Workflow> searchWorkflowByTasksV2(String query, String freeText, int start, int size, List<String> sortOptions) {
+        SearchResult<TaskSummary> taskSummarySearchResult = searchTasks(query, freeText, start, size, sortOptions);
+        List<Workflow> workflows = taskSummarySearchResult.getResults().stream()
+                .parallel()
+                .map(taskSummary -> {
+                    try {
+                        String workflowId = taskSummary.getWorkflowId();
+                        return executionDAOFacade.getWorkflowById(workflowId, false);
+                    } catch (Exception e) {
+                        LOGGER.error("Error fetching workflow by id: {}", taskSummary.getWorkflowId(), e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        int missing = taskSummarySearchResult.getResults().size() - workflows.size();
+        long totalHits = taskSummarySearchResult.getTotalHits() - missing;
+        return new SearchResult<>(totalHits, workflows);
+    }
+
     public SearchResult<TaskSummary> searchTasks(String query, String freeText, int start, int size,
         List<String> sortOptions) {
 
         SearchResult<String> result = executionDAOFacade.searchTasks(query, freeText, start, size, sortOptions);
         List<TaskSummary> workflows = result.getResults().stream()
             .parallel()
-            .map(executionDAOFacade::getTaskById)
-            .filter(Objects::nonNull)
             .map(task -> {
                 try {
-                    return new TaskSummary(task);
+                    return new TaskSummary(executionDAOFacade.getTaskById(task));
                 } catch (Exception e) {
-                    LOGGER.error("Error fetching task by id: {}", task.getTaskId(), e);
+                    LOGGER.error("Error fetching task by id: {}", task, e);
                     return null;
                 }
             })

--- a/core/src/main/java/com/netflix/conductor/service/TaskService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskService.java
@@ -198,6 +198,19 @@ public interface TaskService {
     SearchResult<TaskSummary> search(int start, int size, String sort, String freeText, String query);
 
     /**
+     * Search for tasks based in payload and other parameters. Use sort options as ASC or DESC e.g. sort=name or
+     * sort=workflowId. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    SearchResult<Task> searchV2(int start, int size, String sort, String freeText, String query);
+
+    /**
      * Get the external storage location where the task output payload is stored/to be stored
      *
      * @param path        the path for which the external storage location is to be populated

--- a/core/src/main/java/com/netflix/conductor/service/TaskServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/TaskServiceImpl.java
@@ -313,6 +313,21 @@ public class TaskServiceImpl implements TaskService {
     }
 
     /**
+     * Search for tasks based in payload and other parameters. Use sort options as ASC or DESC e.g. sort=name or
+     * sort=workflowId. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    public SearchResult<Task> searchV2(int start, int size, String sort, String freeText, String query) {
+        return executionService.getSearchTasksV2(query, freeText, start, size, sort);
+    }
+
+    /**
      * Get the external storage location where the task output payload is stored/to be stored
      *
      * @param path      the path for which the external storage location is to be populated

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -249,6 +249,21 @@ public interface WorkflowService {
         String sort, String freeText, String query);
 
     /**
+     * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC
+     * e.g. sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    SearchResult<Workflow> searchWorkflowsV2(int start,
+        @Max(value = 5_000, message = "Cannot return more than {value} workflows. Please use pagination.") int size,
+        String sort, String freeText, String query);
+
+    /**
      * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC e.g. sort=name or
      * sort=workflowId:DESC. If order is not specified, defaults to ASC.
      *
@@ -263,6 +278,20 @@ public interface WorkflowService {
         @Max(value = 5_000, message = "Cannot return more than {value} workflows. Please use pagination.") int size,
         List<String> sort, String freeText, String query);
 
+    /**
+     * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC
+     * e.g. sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     list of sorting options, separated by "|" delimiter
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    SearchResult<Workflow> searchWorkflowsV2(int start,
+        @Max(value = 5_000, message = "Cannot return more than {value} workflows. Please use pagination.") int size,
+        List<String> sort, String freeText, String query);
 
     /**
      * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g. sort=name or
@@ -279,6 +308,19 @@ public interface WorkflowService {
         String query);
 
     /**
+     * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g.
+     * sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    SearchResult<Workflow> searchWorkflowsByTasksV2(int start, int size, String sort, String freeText, String query);
+
+    /**
      * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g. sort=name or
      * sort=workflowId:DESC. If order is not specified, defaults to ASC.
      *
@@ -290,6 +332,20 @@ public interface WorkflowService {
      * @return instance of {@link SearchResult}
      */
     SearchResult<WorkflowSummary> searchWorkflowsByTasks(int start, int size, List<String> sort, String freeText,
+        String query);
+
+    /**
+     * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g.
+     * sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     list of sorting options, separated by "|" delimiter
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    SearchResult<Workflow> searchWorkflowsByTasksV2(int start, int size, List<String> sort, String freeText,
         String query);
 
     /**

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -355,6 +355,21 @@ public class WorkflowServiceImpl implements WorkflowService {
     }
 
     /**
+     * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC
+     * e.g. sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    public SearchResult<Workflow> searchWorkflowsV2(int start, int size, String sort, String freeText, String query) {
+        return executionService.searchV2(query, freeText, start, size, Utils.convertStringToList(sort));
+    }
+
+    /**
      * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC e.g. sort=name or
      * sort=workflowId:DESC. If order is not specified, defaults to ASC.
      *
@@ -370,6 +385,21 @@ public class WorkflowServiceImpl implements WorkflowService {
         return executionService.search(query, freeText, start, size, sort);
     }
 
+    /**
+     * Search for workflows based on payload and given parameters. Use sort options as sort ASCor DESC
+     * e.g. sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     list of sorting options, separated by "|" delimiter
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    public SearchResult<Workflow> searchWorkflowsV2(int start, int size, List<String> sort, String freeText,
+        String query) {
+        return executionService.searchV2(query, freeText, start, size, sort);
+    }
 
     /**
      * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g. sort=name or
@@ -389,6 +419,22 @@ public class WorkflowServiceImpl implements WorkflowService {
     }
 
     /**
+     * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g.
+     * sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     Sorting type ASC|DESC
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    public SearchResult<Workflow> searchWorkflowsByTasksV2(int start, int size, String sort, String freeText,
+        String query) {
+        return executionService.searchWorkflowByTasksV2(query, freeText, start, size,  Utils.convertStringToList(sort));
+    }
+
+    /**
      * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g. sort=name or
      * sort=workflowId:DESC. If order is not specified, defaults to ASC.
      *
@@ -402,6 +448,22 @@ public class WorkflowServiceImpl implements WorkflowService {
     public SearchResult<WorkflowSummary> searchWorkflowsByTasks(int start, int size, List<String> sort, String freeText,
         String query) {
         return executionService.searchWorkflowByTasks(query, freeText, start, size, sort);
+    }
+
+    /**
+     * Search for workflows based on task parameters. Use sort options as sort ASC or DESC e.g.
+     * sort=name or sort=workflowId:DESC. If order is not specified, defaults to ASC.
+     *
+     * @param start    Start index of pagination
+     * @param size     Number of entries
+     * @param sort     list of sorting options, separated by "|" delimiter
+     * @param freeText Text you want to search
+     * @param query    Query you want to search
+     * @return instance of {@link SearchResult}
+     */
+    public SearchResult<Workflow> searchWorkflowsByTasksV2(int start, int size, List<String> sort, String freeText,
+        String query) {
+        return executionService.searchWorkflowByTasksV2(query, freeText, start, size, sort);
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
@@ -1,0 +1,172 @@
+package com.netflix.conductor.service;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
+import com.netflix.conductor.core.orchestration.ExecutionDAOFacade;
+import com.netflix.conductor.dao.QueueDAO;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class ExecutionServiceTest {
+
+    @Mock
+    private WorkflowExecutor workflowExecutor;
+    @Mock
+    private ExecutionDAOFacade executionDAOFacade;
+    @Mock
+    private QueueDAO queueDAO;
+    @Mock
+    private ConductorProperties conductorProperties;
+    @Mock
+    private ExternalPayloadStorage externalPayloadStorage;
+    @Mock
+    private SystemTaskRegistry systemTaskRegistry;
+
+    private ExecutionService executionService;
+
+    private Workflow workflow1;
+    private Workflow workflow2;
+    private Task taskWorkflow1;
+    private Task taskWorkflow2;
+    private final List<String> sort = Collections.singletonList("Sort");
+
+    @Before
+    public void setup() {
+        when(conductorProperties.getTaskExecutionPostponeDuration()).thenReturn(Duration.ofSeconds(60));
+        executionService = new ExecutionService(workflowExecutor, executionDAOFacade, queueDAO,
+                conductorProperties, externalPayloadStorage, systemTaskRegistry);
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflow1 = new Workflow();
+        workflow1.setWorkflowId("wf1");
+        workflow1.setWorkflowDefinition(workflowDef);
+        workflow2 = new Workflow();
+        workflow2.setWorkflowId("wf2");
+        workflow2.setWorkflowDefinition(workflowDef);
+        taskWorkflow1 = new Task();
+        taskWorkflow1.setTaskId("task1");
+        taskWorkflow1.setWorkflowInstanceId("wf1");
+        taskWorkflow2 = new Task();
+        taskWorkflow2.setTaskId("task2");
+        taskWorkflow2.setWorkflowInstanceId("wf2");
+    }
+
+
+    @Test
+    public void searchTest() {
+        when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenReturn(workflow2);
+        SearchResult<WorkflowSummary> searchResult = executionService.search("query", "*", 0, 2, sort);
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(2, searchResult.getResults().size());
+        assertEquals(workflow1.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+        assertEquals(workflow2.getWorkflowId(), searchResult.getResults().get(1).getWorkflowId());
+    }
+
+    @Test
+    public void searchExceptionTest() {
+        when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenThrow(new RuntimeException());
+        SearchResult<WorkflowSummary> searchResult = executionService.search("query", "*", 0, 2, sort);
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(1, searchResult.getResults().size());
+        assertEquals(workflow1.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void searchV2Test() {
+        when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenReturn(workflow2);
+        SearchResult<Workflow> searchResult = executionService.searchV2("query", "*", 0, 2, sort);
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(Arrays.asList(workflow1, workflow2), searchResult.getResults());
+    }
+
+    @Test
+    public void searchV2ExceptionTest() {
+        when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenThrow(new RuntimeException());
+        SearchResult<Workflow> searchResult = executionService.searchV2("query", "*", 0, 2, sort);
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflow1), searchResult.getResults());
+    }
+
+    @Test
+    public void searchByTasksTest() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenReturn(taskWorkflow2);
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenReturn(workflow2);
+        SearchResult<WorkflowSummary> searchResult = executionService.searchWorkflowByTasks("query", "*", 0, 2, sort);
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(2, searchResult.getResults().size());
+        assertEquals(workflow1.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+        assertEquals(workflow2.getWorkflowId(), searchResult.getResults().get(1).getWorkflowId());
+    }
+
+    @Test
+    public void searchByTasksExceptionTest() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenThrow(new RuntimeException());
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        SearchResult<WorkflowSummary> searchResult = executionService.searchWorkflowByTasks("query", "*", 0, 2, sort);
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(1, searchResult.getResults().size());
+        assertEquals(workflow1.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+    }
+
+    @Test
+    public void searchByTasksV2Test() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenReturn(taskWorkflow2);
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        when(executionDAOFacade.getWorkflowById(workflow2.getWorkflowId(), false)).thenReturn(workflow2);
+        SearchResult<Workflow> searchResult = executionService.searchWorkflowByTasksV2("query", "*", 0, 2, sort);
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(Arrays.asList(workflow1, workflow2), searchResult.getResults());
+    }
+
+    @Test
+    public void searchByTasksV2ExceptionTest() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenThrow(new RuntimeException());
+        when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
+        SearchResult<Workflow> searchResult = executionService.searchWorkflowByTasksV2("query", "*", 0, 2, sort);
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(workflow1), searchResult.getResults());
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
@@ -1,8 +1,21 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.service;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
@@ -71,7 +84,7 @@ public class ExecutionServiceTest {
 
 
     @Test
-    public void searchTest() {
+    public void workflowSearchTest() {
         when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
         when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
@@ -84,7 +97,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchExceptionTest() {
+    public void workflowSearchExceptionTest() {
         when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
         when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
@@ -96,7 +109,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchV2Test() {
+    public void workflowSearchV2Test() {
         when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
         when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
@@ -107,7 +120,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchV2ExceptionTest() {
+    public void workflowSearchV2ExceptionTest() {
         when(executionDAOFacade.searchWorkflows("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(workflow1.getWorkflowId(), workflow2.getWorkflowId())));
         when(executionDAOFacade.getWorkflowById(workflow1.getWorkflowId(), false)).thenReturn(workflow1);
@@ -118,7 +131,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchByTasksTest() {
+    public void workflowSearchByTasksTest() {
         when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
         when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
@@ -133,7 +146,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchByTasksExceptionTest() {
+    public void workflowSearchByTasksExceptionTest() {
         when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
         when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
@@ -146,7 +159,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchByTasksV2Test() {
+    public void workflowSearchByTasksV2Test() {
         when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
         when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
@@ -159,7 +172,7 @@ public class ExecutionServiceTest {
     }
 
     @Test
-    public void searchByTasksV2ExceptionTest() {
+    public void workflowSearchByTasksV2ExceptionTest() {
         when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
                 .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
         when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
@@ -168,5 +181,58 @@ public class ExecutionServiceTest {
         SearchResult<Workflow> searchResult = executionService.searchWorkflowByTasksV2("query", "*", 0, 2, sort);
         assertEquals(1, searchResult.getTotalHits());
         assertEquals(Collections.singletonList(workflow1), searchResult.getResults());
+    }
+
+    @Test
+    public void TaskSearchTest() {
+        List<String> taskList = Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId());
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, taskList));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenReturn(taskWorkflow2);
+        SearchResult<TaskSummary> searchResult =
+                executionService.getSearchTasks("query", "*", 0, 2, "Sort");
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(2, searchResult.getResults().size());
+        assertEquals(taskWorkflow1.getTaskId(), searchResult.getResults().get(0).getTaskId());
+        assertEquals(taskWorkflow2.getTaskId(), searchResult.getResults().get(1).getTaskId());
+    }
+
+    @Test
+    public void TaskSearchExceptionTest() {
+        List<String> taskList = Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId());
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, taskList));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenThrow(new RuntimeException());
+        SearchResult<TaskSummary> searchResult =
+                executionService.getSearchTasks("query", "*", 0, 2, "Sort");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(1, searchResult.getResults().size());
+        assertEquals(taskWorkflow1.getTaskId(), searchResult.getResults().get(0).getTaskId());
+    }
+
+    @Test
+    public void TaskSearchV2Test() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenReturn(taskWorkflow2);
+        SearchResult<Task> searchResult =
+                executionService.getSearchTasksV2("query", "*", 0, 2, "Sort");
+        assertEquals(2, searchResult.getTotalHits());
+        assertEquals(Arrays.asList(taskWorkflow1, taskWorkflow2), searchResult.getResults());
+    }
+
+    @Test
+    public void TaskSearchV2ExceptionTest() {
+        when(executionDAOFacade.searchTasks("query", "*", 0, 2, sort))
+                .thenReturn(new SearchResult<>(2, Arrays.asList(taskWorkflow1.getTaskId(), taskWorkflow2.getTaskId())));
+        when(executionDAOFacade.getTaskById(taskWorkflow1.getTaskId())).thenReturn(taskWorkflow1);
+        when(executionDAOFacade.getTaskById(taskWorkflow2.getTaskId())).thenThrow(new RuntimeException());
+        SearchResult<Task> searchResult =
+                executionService.getSearchTasksV2("query", "*", 0, 2, "Sort");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(Collections.singletonList(taskWorkflow1), searchResult.getResults());
     }
 }

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/ClientBase.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/ClientBase.java
@@ -13,11 +13,13 @@
 package com.netflix.conductor.client.grpc;
 
 import com.netflix.conductor.grpc.ProtoMapper;
+import com.netflix.conductor.grpc.SearchPb;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 abstract class ClientBase {
@@ -37,5 +39,22 @@ abstract class ClientBase {
 
     public void shutdown() throws InterruptedException {
         channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    SearchPb.Request createSearchRequest(
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
+        SearchPb.Request.Builder request = SearchPb.Request.newBuilder();
+        if (start != null)
+            request.setStart(start);
+        if (size != null)
+            request.setSize(size);
+        if (sort != null)
+            request.setSort(sort);
+        if (freeText != null)
+            request.setFreeText(freeText);
+        if (query != null)
+            request.setQuery(query);
+        return request.build();
     }
 }

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/TaskClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/TaskClient.java
@@ -18,6 +18,9 @@ import com.google.common.collect.Lists;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.grpc.SearchPb;
 import com.netflix.conductor.grpc.TaskServiceGrpc;
 import com.netflix.conductor.grpc.TaskServicePb;
 import com.netflix.conductor.proto.TaskPb;
@@ -174,4 +177,36 @@ public class TaskClient extends ClientBase {
 
         return sizes.getQueueForTaskOrDefault(taskType, 0);
     }
+
+
+    public SearchResult<TaskSummary> search(String query) {
+        return search(null, null, null, null, query);
+    }
+
+    public SearchResult<Task> searchV2(String query) {
+        return searchV2(null, null, null, null, query);
+    }
+
+    public SearchResult<TaskSummary> search(
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
+        SearchPb.Request searchRequest = createSearchRequest(start, size, sort, freeText, query);
+        TaskServicePb.TaskSummarySearchResult result = stub.search(searchRequest);
+        return new SearchResult<>(
+                result.getTotalHits(),
+                result.getResultsList().stream().map(protoMapper::fromProto).collect(Collectors.toList())
+        );
+    }
+
+    public SearchResult<Task> searchV2(
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
+        SearchPb.Request searchRequest = createSearchRequest(start, size, sort, freeText, query);
+        TaskServicePb.TaskSearchResult result = stub.searchV2(searchRequest);
+        return new SearchResult<>(
+                result.getTotalHits(),
+                result.getResultsList().stream().map(protoMapper::fromProto).collect(Collectors.toList())
+        );
+    }
+
 }

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
@@ -341,20 +341,4 @@ public class WorkflowClient extends ClientBase {
         );
     }
 
-    private SearchPb.Request createSearchRequest(
-            @Nullable Integer start, @Nullable Integer size,
-            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
-        SearchPb.Request.Builder request = SearchPb.Request.newBuilder();
-        if (start != null)
-            request.setStart(start);
-        if (size != null)
-            request.setSize(size);
-        if (sort != null)
-            request.setSort(sort);
-        if (freeText != null)
-            request.setFreeText(freeText);
-        if (query != null)
-            request.setQuery(query);
-        return request.build();
-    }
 }

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
@@ -24,7 +24,6 @@ import com.netflix.conductor.grpc.WorkflowServicePb;
 import com.netflix.conductor.proto.WorkflowPb;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -285,8 +284,18 @@ public class WorkflowClient extends ClientBase {
      * @param query the search query
      * @return the {@link SearchResult} containing the {@link WorkflowSummary} that match the query
      */
-    public SearchResult<WorkflowSummary> search(@Nonnull String query) {
+    public SearchResult<WorkflowSummary> search(String query) {
         return search(null, null, null, null, query);
+    }
+
+    /**
+     * Search for workflows based on payload
+     *
+     * @param query the search query
+     * @return the {@link SearchResult} containing the {@link Workflow} that match the query
+     */
+    public SearchResult<Workflow> searchV2(String query) {
+        return searchV2(null, null, null, null, query);
     }
 
     /**
@@ -300,29 +309,52 @@ public class WorkflowClient extends ClientBase {
      * @return the {@link SearchResult} containing the {@link WorkflowSummary} that match the query
      */
     public SearchResult<WorkflowSummary> search(
-        @Nullable Integer start, @Nullable Integer size,
-        @Nullable String sort, @Nullable String freeText, @Nonnull String query) {
-        Preconditions.checkNotNull(query, "query cannot be null");
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
 
-        SearchPb.Request.Builder request = SearchPb.Request.newBuilder();
-        request.setQuery(query);
-        if (start != null) {
-            request.setStart(start);
-        }
-        if (size != null) {
-            request.setSize(size);
-        }
-        if (sort != null) {
-            request.setSort(sort);
-        }
-        if (freeText != null) {
-            request.setFreeText(freeText);
-        }
-
-        WorkflowServicePb.WorkflowSummarySearchResult result = stub.search(request.build());
-        return new SearchResult<WorkflowSummary>(
-            result.getTotalHits(),
-            result.getResultsList().stream().map(protoMapper::fromProto).collect(Collectors.toList())
+        SearchPb.Request searchRequest = createSearchRequest(start, size, sort, freeText, query);
+        WorkflowServicePb.WorkflowSummarySearchResult result = stub.search(searchRequest);
+        return new SearchResult<>(
+                result.getTotalHits(),
+                result.getResultsList().stream().map(protoMapper::fromProto).collect(Collectors.toList())
         );
+    }
+
+    /**
+     * Paginated search for workflows based on payload
+     *
+     * @param start    start value of page
+     * @param size     number of workflows to be returned
+     * @param sort     sort order
+     * @param freeText additional free text query
+     * @param query    the search query
+     * @return the {@link SearchResult} containing the {@link Workflow} that match the query
+     */
+    public SearchResult<Workflow> searchV2(
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
+        SearchPb.Request searchRequest = createSearchRequest(start, size, sort, freeText, query);
+        WorkflowServicePb.WorkflowSearchResult result = stub.searchV2(searchRequest);
+        return new SearchResult<>(
+                result.getTotalHits(),
+                result.getResultsList().stream().map(protoMapper::fromProto).collect(Collectors.toList())
+        );
+    }
+
+    private SearchPb.Request createSearchRequest(
+            @Nullable Integer start, @Nullable Integer size,
+            @Nullable String sort, @Nullable String freeText, @Nullable String query) {
+        SearchPb.Request.Builder request = SearchPb.Request.newBuilder();
+        if (start != null)
+            request.setStart(start);
+        if (size != null)
+            request.setSize(size);
+        if (sort != null)
+            request.setSort(sort);
+        if (freeText != null)
+            request.setFreeText(freeText);
+        if (query != null)
+            request.setQuery(query);
+        return request.build();
     }
 }

--- a/grpc-client/src/test/java/com/netflix/conductor/client/grpc/TaskClientTest.java
+++ b/grpc-client/src/test/java/com/netflix/conductor/client/grpc/TaskClientTest.java
@@ -12,15 +12,15 @@
  */
 package com.netflix.conductor.client.grpc;
 
+import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.run.SearchResult;
-import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.grpc.ProtoMapper;
 import com.netflix.conductor.grpc.SearchPb;
-import com.netflix.conductor.grpc.WorkflowServiceGrpc;
-import com.netflix.conductor.grpc.WorkflowServicePb;
-import com.netflix.conductor.proto.WorkflowPb;
-import com.netflix.conductor.proto.WorkflowSummaryPb;
+import com.netflix.conductor.grpc.TaskServiceGrpc;
+import com.netflix.conductor.grpc.TaskServicePb;
+import com.netflix.conductor.proto.TaskPb;
+import com.netflix.conductor.proto.TaskSummaryPb;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,69 +33,69 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-public class WorkflowClientTest {
+public class TaskClientTest {
 
     @Mock
     ProtoMapper mockedProtoMapper;
 
     @Mock
-    WorkflowServiceGrpc.WorkflowServiceBlockingStub mockedStub;
+    TaskServiceGrpc.TaskServiceBlockingStub mockedStub;
 
-    WorkflowClient workflowClient;
+    TaskClient taskClient;
 
     @Before
     public void init() {
-        workflowClient = new WorkflowClient("test", 0);
-        ReflectionTestUtils.setField(workflowClient, "stub", mockedStub);
-        ReflectionTestUtils.setField(workflowClient, "protoMapper", mockedProtoMapper);
+        taskClient = new TaskClient("test", 0);
+        ReflectionTestUtils.setField(taskClient, "stub", mockedStub);
+        ReflectionTestUtils.setField(taskClient, "protoMapper", mockedProtoMapper);
     }
 
     @Test
     public void testSearch() {
-        WorkflowSummary workflow = mock(WorkflowSummary.class);
-        WorkflowSummaryPb.WorkflowSummary workflowPB = mock(WorkflowSummaryPb.WorkflowSummary.class);
-        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
-        WorkflowServicePb.WorkflowSummarySearchResult result = WorkflowServicePb.WorkflowSummarySearchResult
+        TaskSummary taskSummary = mock(TaskSummary.class);
+        TaskSummaryPb.TaskSummary taskSummaryPB = mock(TaskSummaryPb.TaskSummary.class);
+        when(mockedProtoMapper.fromProto(taskSummaryPB)).thenReturn(taskSummary);
+        TaskServicePb.TaskSummarySearchResult result = TaskServicePb.TaskSummarySearchResult
                 .newBuilder()
-                .addResults(workflowPB)
+                .addResults(taskSummaryPB)
                 .setTotalHits(1)
                 .build();
         SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
                 .setQuery("test query")
                 .build();
         when(mockedStub.search(searchRequest)).thenReturn(result);
-        SearchResult<WorkflowSummary> searchResult = workflowClient.search("test query");
+        SearchResult<TaskSummary> searchResult = taskClient.search("test query");
         assertEquals(1, searchResult.getTotalHits());
-        assertEquals(workflow, searchResult.getResults().get(0));
+        assertEquals(taskSummary, searchResult.getResults().get(0));
     }
 
     @Test
     public void testSearchV2() {
-        Workflow workflow = mock(Workflow.class);
-        WorkflowPb.Workflow workflowPB = mock(WorkflowPb.Workflow.class);
-        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
-        WorkflowServicePb.WorkflowSearchResult result = WorkflowServicePb.WorkflowSearchResult
+        Task task = mock(Task.class);
+        TaskPb.Task taskPB = mock(TaskPb.Task.class);
+        when(mockedProtoMapper.fromProto(taskPB)).thenReturn(task);
+        TaskServicePb.TaskSearchResult result = TaskServicePb.TaskSearchResult
                 .newBuilder()
-                .addResults(workflowPB)
+                .addResults(taskPB)
                 .setTotalHits(1)
                 .build();
         SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
                 .setQuery("test query")
                 .build();
         when(mockedStub.searchV2(searchRequest)).thenReturn(result);
-        SearchResult<Workflow> searchResult = workflowClient.searchV2("test query");
+        SearchResult<Task> searchResult = taskClient.searchV2("test query");
         assertEquals(1, searchResult.getTotalHits());
-        assertEquals(workflow, searchResult.getResults().get(0));
+        assertEquals(task, searchResult.getResults().get(0));
     }
 
     @Test
     public void testSearchWithParams() {
-        WorkflowSummary workflow = mock(WorkflowSummary.class);
-        WorkflowSummaryPb.WorkflowSummary workflowPB = mock(WorkflowSummaryPb.WorkflowSummary.class);
-        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
-        WorkflowServicePb.WorkflowSummarySearchResult result = WorkflowServicePb.WorkflowSummarySearchResult
+        TaskSummary taskSummary = mock(TaskSummary.class);
+        TaskSummaryPb.TaskSummary taskSummaryPB = mock(TaskSummaryPb.TaskSummary.class);
+        when(mockedProtoMapper.fromProto(taskSummaryPB)).thenReturn(taskSummary);
+        TaskServicePb.TaskSummarySearchResult result = TaskServicePb.TaskSummarySearchResult
                 .newBuilder()
-                .addResults(workflowPB)
+                .addResults(taskSummaryPB)
                 .setTotalHits(1)
                 .build();
         SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
@@ -106,20 +106,20 @@ public class WorkflowClientTest {
                 .setQuery("test query")
                 .build();
         when(mockedStub.search(searchRequest)).thenReturn(result);
-        SearchResult<WorkflowSummary> searchResult =
-                workflowClient.search(1,5,"*","*","test query");
+        SearchResult<TaskSummary> searchResult =
+                taskClient.search(1,5,"*","*","test query");
         assertEquals(1, searchResult.getTotalHits());
-        assertEquals(workflow, searchResult.getResults().get(0));
+        assertEquals(taskSummary, searchResult.getResults().get(0));
     }
 
     @Test
     public void testSearchV2WithParams() {
-        Workflow workflow = mock(Workflow.class);
-        WorkflowPb.Workflow workflowPB = mock(WorkflowPb.Workflow.class);
-        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
-        WorkflowServicePb.WorkflowSearchResult result = WorkflowServicePb.WorkflowSearchResult
+        Task task = mock(Task.class);
+        TaskPb.Task taskPB = mock(TaskPb.Task.class);
+        when(mockedProtoMapper.fromProto(taskPB)).thenReturn(task);
+        TaskServicePb.TaskSearchResult result = TaskServicePb.TaskSearchResult
                 .newBuilder()
-                .addResults(workflowPB)
+                .addResults(taskPB)
                 .setTotalHits(1)
                 .build();
         SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
@@ -130,10 +130,10 @@ public class WorkflowClientTest {
                 .setQuery("test query")
                 .build();
         when(mockedStub.searchV2(searchRequest)).thenReturn(result);
-        SearchResult<Workflow> searchResult =
-                workflowClient.searchV2(1,5,"*","*","test query");
+        SearchResult<Task> searchResult =
+                taskClient.searchV2(1,5,"*","*","test query");
         assertEquals(1, searchResult.getTotalHits());
-        assertEquals(workflow, searchResult.getResults().get(0));
+        assertEquals(task, searchResult.getResults().get(0));
     }
 
 }

--- a/grpc-client/src/test/java/com/netflix/conductor/client/grpc/WorkflowClientTest.java
+++ b/grpc-client/src/test/java/com/netflix/conductor/client/grpc/WorkflowClientTest.java
@@ -1,0 +1,127 @@
+package com.netflix.conductor.client.grpc;
+
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.grpc.ProtoMapper;
+import com.netflix.conductor.grpc.SearchPb;
+import com.netflix.conductor.grpc.WorkflowServiceGrpc;
+import com.netflix.conductor.grpc.WorkflowServicePb;
+import com.netflix.conductor.proto.WorkflowPb;
+import com.netflix.conductor.proto.WorkflowSummaryPb;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class WorkflowClientTest {
+
+    @Mock
+    ProtoMapper mockedProtoMapper;
+
+    @Mock
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub mockedStub;
+
+    WorkflowClient workflowClient;
+
+    @Before
+    public void init() {
+        workflowClient = new WorkflowClient("test", 0);
+        ReflectionTestUtils.setField(workflowClient, "stub", mockedStub);
+        ReflectionTestUtils.setField(workflowClient, "protoMapper", mockedProtoMapper);
+    }
+
+    @Test
+    public void testSearch() {
+        WorkflowSummary workflow = mock(WorkflowSummary.class);
+        WorkflowSummaryPb.WorkflowSummary workflowPB = mock(WorkflowSummaryPb.WorkflowSummary.class);
+        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
+        WorkflowServicePb.WorkflowSummarySearchResult result = WorkflowServicePb.WorkflowSummarySearchResult
+                .newBuilder()
+                .addResults(workflowPB)
+                .setTotalHits(1)
+                .build();
+        SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
+                .setQuery("test query")
+                .build();
+        when(mockedStub.search(searchRequest)).thenReturn(result);
+        SearchResult<WorkflowSummary> searchResult = workflowClient.search("test query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow, searchResult.getResults().get(0));
+    }
+
+    @Test
+    public void testSearchV2() {
+        Workflow workflow = mock(Workflow.class);
+        WorkflowPb.Workflow workflowPB = mock(WorkflowPb.Workflow.class);
+        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
+        WorkflowServicePb.WorkflowSearchResult result = WorkflowServicePb.WorkflowSearchResult
+                .newBuilder()
+                .addResults(workflowPB)
+                .setTotalHits(1)
+                .build();
+        SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
+                .setQuery("test query")
+                .build();
+        when(mockedStub.searchV2(searchRequest)).thenReturn(result);
+        SearchResult<Workflow> searchResult = workflowClient.searchV2("test query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow, searchResult.getResults().get(0));
+    }
+
+    @Test
+    public void testSearchWithParams() {
+        WorkflowSummary workflow = mock(WorkflowSummary.class);
+        WorkflowSummaryPb.WorkflowSummary workflowPB = mock(WorkflowSummaryPb.WorkflowSummary.class);
+        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
+        WorkflowServicePb.WorkflowSummarySearchResult result = WorkflowServicePb.WorkflowSummarySearchResult
+                .newBuilder()
+                .addResults(workflowPB)
+                .setTotalHits(1)
+                .build();
+        SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
+                .setStart(1)
+                .setSize(5)
+                .setSort("*")
+                .setFreeText("*")
+                .setQuery("test query")
+                .build();
+        when(mockedStub.search(searchRequest)).thenReturn(result);
+        SearchResult<WorkflowSummary> searchResult =
+                workflowClient.search(1,5,"*","*","test query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow, searchResult.getResults().get(0));
+    }
+
+    @Test
+    public void testSearchV2WithParams() {
+        Workflow workflow = mock(Workflow.class);
+        WorkflowPb.Workflow workflowPB = mock(WorkflowPb.Workflow.class);
+        when(mockedProtoMapper.fromProto(workflowPB)).thenReturn(workflow);
+        WorkflowServicePb.WorkflowSearchResult result = WorkflowServicePb.WorkflowSearchResult
+                .newBuilder()
+                .addResults(workflowPB)
+                .setTotalHits(1)
+                .build();
+        SearchPb.Request searchRequest = SearchPb.Request.newBuilder()
+                .setStart(1)
+                .setSize(5)
+                .setSort("*")
+                .setFreeText("*")
+                .setQuery("test query")
+                .build();
+        when(mockedStub.searchV2(searchRequest)).thenReturn(result);
+        SearchResult<Workflow> searchResult =
+                workflowClient.searchV2(1,5,"*","*","test query");
+        assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow, searchResult.getResults().get(0));
+    }
+
+}

--- a/grpc-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/grpc-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/grpc-server/src/test/java/com/netflix/conductor/grpc/server/service/TaskServiceImplTest.java
+++ b/grpc-server/src/test/java/com/netflix/conductor/grpc/server/service/TaskServiceImplTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.grpc.server.service;
+
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
+import com.netflix.conductor.grpc.SearchPb;
+import com.netflix.conductor.grpc.TaskServicePb;
+import com.netflix.conductor.proto.TaskPb;
+import com.netflix.conductor.proto.TaskSummaryPb;
+import com.netflix.conductor.service.ExecutionService;
+import com.netflix.conductor.service.TaskService;
+import io.grpc.stub.StreamObserver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class TaskServiceImplTest {
+
+    @Mock
+    private TaskService taskService;
+
+    @Mock
+    private ExecutionService executionService;
+
+    private TaskServiceImpl taskServiceImpl;
+
+    @Before
+    public void init() {
+        initMocks(this);
+        taskServiceImpl = new TaskServiceImpl(executionService, taskService, 5000);
+    }
+
+    @Test
+    public void searchExceptionTest() throws InterruptedException {
+        CountDownLatch streamAlive = new CountDownLatch(1);
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+        SearchPb.Request req = SearchPb.Request
+                .newBuilder()
+                .setStart(1)
+                .setSize(50000)
+                .setSort("strings")
+                .setQuery("")
+                .setFreeText("*")
+                .build();
+
+
+        StreamObserver<TaskServicePb.TaskSummarySearchResult> streamObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(TaskServicePb.TaskSummarySearchResult value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                throwable.set(t);
+                streamAlive.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                streamAlive.countDown();
+            }
+        };
+
+        taskServiceImpl.search(req, streamObserver);
+
+        streamAlive.await(10, TimeUnit.MILLISECONDS);
+
+        assertEquals("INVALID_ARGUMENT: Cannot return more than 5000 results", throwable.get().getMessage());
+    }
+
+    @Test
+    public void searchV2ExceptionTest() throws InterruptedException {
+        CountDownLatch streamAlive = new CountDownLatch(1);
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+        SearchPb.Request req = SearchPb.Request
+                .newBuilder()
+                .setStart(1)
+                .setSize(50000)
+                .setSort("strings")
+                .setQuery("")
+                .setFreeText("*")
+                .build();
+
+
+        StreamObserver<TaskServicePb.TaskSearchResult> streamObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(TaskServicePb.TaskSearchResult value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                throwable.set(t);
+                streamAlive.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                streamAlive.countDown();
+            }
+        };
+
+        taskServiceImpl.searchV2(req, streamObserver);
+
+        streamAlive.await(10, TimeUnit.MILLISECONDS);
+
+        assertEquals("INVALID_ARGUMENT: Cannot return more than 5000 results", throwable.get().getMessage());
+    }
+
+    @Test
+    public void searchTest() throws InterruptedException {
+
+        CountDownLatch streamAlive = new CountDownLatch(1);
+        AtomicReference<TaskServicePb.TaskSummarySearchResult> result = new AtomicReference<>();
+
+        SearchPb.Request req = SearchPb.Request
+                .newBuilder()
+                .setStart(1)
+                .setSize(1)
+                .setSort("strings")
+                .setQuery("")
+                .setFreeText("*")
+                .build();
+
+
+        StreamObserver<TaskServicePb.TaskSummarySearchResult> streamObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(TaskServicePb.TaskSummarySearchResult value) {
+                result.set(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                streamAlive.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                streamAlive.countDown();
+            }
+        };
+
+        TaskSummary taskSummary = new TaskSummary();
+        SearchResult<TaskSummary> searchResult = new SearchResult<>();
+        searchResult.setTotalHits(1);
+        searchResult.setResults(Collections.singletonList(taskSummary));
+
+
+        when(taskService.search(1, 1, "strings", "*", ""))
+                .thenReturn(searchResult);
+
+        taskServiceImpl.search(req, streamObserver);
+
+        streamAlive.await(10, TimeUnit.MILLISECONDS);
+
+        TaskServicePb.TaskSummarySearchResult taskSummarySearchResult = result.get();
+
+        assertEquals(1, taskSummarySearchResult.getTotalHits());
+        assertEquals(TaskSummaryPb.TaskSummary.newBuilder().build(),
+                taskSummarySearchResult.getResultsList().get(0));
+    }
+
+    @Test
+    public void searchV2Test() throws InterruptedException {
+
+        CountDownLatch streamAlive = new CountDownLatch(1);
+        AtomicReference<TaskServicePb.TaskSearchResult> result = new AtomicReference<>();
+
+        SearchPb.Request req = SearchPb.Request
+                .newBuilder()
+                .setStart(1)
+                .setSize(1)
+                .setSort("strings")
+                .setQuery("")
+                .setFreeText("*")
+                .build();
+
+
+        StreamObserver<TaskServicePb.TaskSearchResult> streamObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(TaskServicePb.TaskSearchResult value) {
+                result.set(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                streamAlive.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                streamAlive.countDown();
+            }
+        };
+
+        Task task = new Task();
+        SearchResult<Task> searchResult = new SearchResult<>();
+        searchResult.setTotalHits(1);
+        searchResult.setResults(Collections.singletonList(task));
+
+
+        when(taskService.searchV2(1, 1, "strings", "*", ""))
+                .thenReturn(searchResult);
+
+        taskServiceImpl.searchV2(req, streamObserver);
+
+        streamAlive.await(10, TimeUnit.MILLISECONDS);
+
+        TaskServicePb.TaskSearchResult taskSearchResult = result.get();
+
+        assertEquals(1, taskSearchResult.getTotalHits());
+        assertEquals(TaskPb.Task.newBuilder().setCallbackFromWorker(true).build(),
+                taskSearchResult.getResultsList().get(0));
+    }
+
+}

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -925,6 +925,30 @@ public abstract class AbstractProtoMapper {
         return to.build();
     }
 
+    public TaskSummary fromProto(TaskSummaryPb.TaskSummary from) {
+        TaskSummary to = new TaskSummary();
+        to.setWorkflowId( from.getWorkflowId() );
+        to.setWorkflowType( from.getWorkflowType() );
+        to.setCorrelationId( from.getCorrelationId() );
+        to.setScheduledTime( from.getScheduledTime() );
+        to.setStartTime( from.getStartTime() );
+        to.setUpdateTime( from.getUpdateTime() );
+        to.setEndTime( from.getEndTime() );
+        to.setStatus( fromProto( from.getStatus() ) );
+        to.setReasonForIncompletion( from.getReasonForIncompletion() );
+        to.setExecutionTime( from.getExecutionTime() );
+        to.setQueueWaitTime( from.getQueueWaitTime() );
+        to.setTaskDefName( from.getTaskDefName() );
+        to.setTaskType( from.getTaskType() );
+        to.setInput( from.getInput() );
+        to.setOutput( from.getOutput() );
+        to.setTaskId( from.getTaskId() );
+        to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
+        to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
+        to.setWorkflowPriority( from.getWorkflowPriority() );
+        return to;
+    }
+
     public WorkflowPb.Workflow toProto(Workflow from) {
         WorkflowPb.Workflow.Builder to = WorkflowPb.Workflow.newBuilder();
         if (from.getStatus() != null) {

--- a/grpc/src/main/proto/grpc/task_service.proto
+++ b/grpc/src/main/proto/grpc/task_service.proto
@@ -3,7 +3,9 @@ package conductor.grpc.tasks;
 
 import "model/taskexeclog.proto";
 import "model/taskresult.proto";
+import "model/tasksummary.proto";
 import "model/task.proto";
+import "grpc/search.proto";
 
 option java_package = "com.netflix.conductor.grpc";
 option java_outer_classname = "TaskServicePb";
@@ -36,6 +38,12 @@ service TaskService {
 
     // GET /queue/all/verbose
     rpc GetQueueAllInfo(QueueAllInfoRequest) returns (QueueAllInfoResponse);
+
+    // GET /search
+    rpc Search(conductor.grpc.search.Request) returns (TaskSummarySearchResult);
+
+    // GET /searchV2
+    rpc SearchV2(conductor.grpc.search.Request) returns (TaskSearchResult);
 }
 
 message PollRequest {
@@ -112,4 +120,14 @@ message QueueAllInfoResponse {
         map<string, ShardInfo> shards = 1;
     }
     map<string, QueueInfo> queues = 1;
+}
+
+message TaskSummarySearchResult {
+    int64 total_hits = 1;
+    repeated conductor.proto.TaskSummary results = 2;
+}
+
+message TaskSearchResult {
+    int64 total_hits = 1;
+    repeated conductor.proto.Task results = 2;
 }

--- a/grpc/src/main/proto/grpc/workflow_service.proto
+++ b/grpc/src/main/proto/grpc/workflow_service.proto
@@ -58,6 +58,10 @@ service WorkflowService {
     // GET /search
     rpc Search(conductor.grpc.search.Request) returns (WorkflowSummarySearchResult);
     rpc SearchByTasks(conductor.grpc.search.Request) returns (WorkflowSummarySearchResult);
+
+    // GET /searchV2
+    rpc SearchV2(conductor.grpc.search.Request) returns (WorkflowSearchResult);
+    rpc SearchByTasksV2(conductor.grpc.search.Request) returns (WorkflowSearchResult);
 }
 
 message StartWorkflowResponse {
@@ -165,4 +169,9 @@ message TerminateWorkflowResponse {}
 message WorkflowSummarySearchResult {
     int64 total_hits = 1;
     repeated conductor.proto.WorkflowSummary results = 2;
+}
+
+message WorkflowSearchResult {
+    int64 total_hits = 1;
+    repeated conductor.proto.Workflow results = 2;
 }

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -146,6 +146,19 @@ public class TaskResource {
         return taskService.search(start, size, sort, freeText, query);
     }
 
+    @Operation(summary = "Search for tasks based in payload and other parameters",
+            description = "use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC." +
+                    " If order is not specified, defaults to ASC")
+    @GetMapping(value = "/search-v2")
+    public SearchResult<Task> searchV2(
+            @RequestParam(value = "start", defaultValue = "0", required = false) int start,
+            @RequestParam(value = "size", defaultValue = "100", required = false) int size,
+            @RequestParam(value = "sort", required = false) String sort,
+            @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
+            @RequestParam(value = "query", required = false) String query) {
+        return taskService.searchV2(start, size, sort, freeText, query);
+    }
+
     @Operation(summary = "Get the external uri where the task payload is to be stored")
     @GetMapping("/externalstoragelocation")
     public ExternalStorageLocation getExternalStorageLocation(@RequestParam("path") String path,

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
@@ -182,6 +182,19 @@ public class WorkflowResource {
         return workflowService.searchWorkflows(start, size, sort, freeText, query);
     }
 
+    @Operation(summary = "Search for workflows based on payload and other parameters",
+        description = "use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC." +
+            " If order is not specified, defaults to ASC.")
+    @GetMapping(value = "/search-v2")
+    public SearchResult<Workflow> searchV2(
+        @RequestParam(value = "start", defaultValue = "0", required = false) int start,
+        @RequestParam(value = "size", defaultValue = "100", required = false) int size,
+        @RequestParam(value = "sort", required = false) String sort,
+        @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
+        @RequestParam(value = "query", required = false) String query) {
+        return workflowService.searchWorkflowsV2(start, size, sort, freeText, query);
+    }
+
     @Operation(summary = "Search for workflows based on task parameters",
         description = "use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC." +
             " If order is not specified, defaults to ASC")
@@ -193,6 +206,19 @@ public class WorkflowResource {
         @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
         @RequestParam(value = "query", required = false) String query) {
         return workflowService.searchWorkflowsByTasks(start, size, sort, freeText, query);
+    }
+
+    @Operation(summary = "Search for workflows based on task parameters",
+        description = "use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC." +
+            " If order is not specified, defaults to ASC")
+    @GetMapping(value = "/search-by-tasks-v2")
+    public SearchResult<Workflow> searchWorkflowsByTasksV2(
+        @RequestParam(value = "start", defaultValue = "0", required = false) int start,
+        @RequestParam(value = "size", defaultValue = "100", required = false) int size,
+        @RequestParam(value = "sort", required = false) String sort,
+        @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
+        @RequestParam(value = "query", required = false) String query) {
+        return workflowService.searchWorkflowsByTasksV2(start, size, sort, freeText, query);
     }
 
     @Operation(summary = "Get the uri and path of the external storage where the workflow payload is to be stored")

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/TaskResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/TaskResourceTest.java
@@ -27,10 +27,12 @@ import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.service.TaskService;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,7 +120,7 @@ public class TaskResourceTest {
         map.put("test1", 1);
         map.put("test2", 2);
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("test1");
         list.add("test2");
 
@@ -179,21 +181,42 @@ public class TaskResourceTest {
     }
 
     @Test
-    public void search() {
+    public void testSearch() {
         Task task = new Task();
         task.setTaskType("SIMPLE");
         task.setWorkerId("123");
         task.setDomain("test");
         task.setStatus(Task.Status.IN_PROGRESS);
         TaskSummary taskSummary = new TaskSummary(task);
-        ArrayList<TaskSummary> listOfTaskSummary = new ArrayList<TaskSummary>() {{
-            add(taskSummary);
-        }};
-        SearchResult<TaskSummary> searchResult = new SearchResult<TaskSummary>(100, listOfTaskSummary);
-        listOfTaskSummary.add(taskSummary);
+        List<TaskSummary> listOfTaskSummary = Collections.singletonList(taskSummary);
+        SearchResult<TaskSummary> searchResult = new SearchResult<>(100, listOfTaskSummary);
 
-        when(mockTaskService.search(anyInt(), anyInt(), anyString(), anyString(), anyString()))
+        when(mockTaskService.search(0, 100, "asc", "*", "*"))
             .thenReturn(searchResult);
         assertEquals(searchResult, taskResource.search(0, 100, "asc", "*", "*"));
+    }
+
+    @Test
+    public void testSearchV2() {
+        Task task = new Task();
+        task.setTaskType("SIMPLE");
+        task.setWorkerId("123");
+        task.setDomain("test");
+        task.setStatus(Task.Status.IN_PROGRESS);
+        List<Task> listOfTasks = Collections.singletonList(task);
+        SearchResult<Task> searchResult = new SearchResult<>(100, listOfTasks);
+
+        when(mockTaskService.searchV2(0, 100, "asc", "*", "*"))
+            .thenReturn(searchResult);
+        assertEquals(searchResult, taskResource.searchV2(0, 100, "asc", "*", "*"));
+    }
+
+    @Test
+    public void testGetExternalStorageLocation() {
+        ExternalStorageLocation externalStorageLocation = mock(ExternalStorageLocation.class);
+        when(mockTaskService.getExternalStorageLocation("path", "operation", "payloadType"))
+            .thenReturn(externalStorageLocation);
+        assertEquals(externalStorageLocation,
+                taskResource.getExternalStorageLocation("path", "operation", "payloadType"));
     }
 }

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
@@ -78,7 +78,7 @@ public class WorkflowResourceTest {
     public void getWorkflows() {
         Workflow workflow = new Workflow();
         workflow.setCorrelationId("123");
-        ArrayList<Workflow> listOfWorkflows = new ArrayList<Workflow>() {{
+        ArrayList<Workflow> listOfWorkflows = new ArrayList<>() {{
             add(workflow);
         }};
         when(mockWorkflowService.getWorkflows(anyString(), anyString(), anyBoolean(), anyBoolean()))
@@ -91,11 +91,11 @@ public class WorkflowResourceTest {
         Workflow workflow = new Workflow();
         workflow.setCorrelationId("c123");
 
-        List<Workflow> workflowArrayList = new ArrayList<Workflow>() {{
+        List<Workflow> workflowArrayList = new ArrayList<>() {{
             add(workflow);
         }};
 
-        List<String> correlationIdList = new ArrayList<String>() {{
+        List<String> correlationIdList = new ArrayList<>() {{
             add("c123");
         }};
 
@@ -125,7 +125,7 @@ public class WorkflowResourceTest {
 
     @Test
     public void testGetRunningWorkflow() {
-        List<String> listOfWorklfows = new ArrayList<String>() {{
+        List<String> listOfWorklfows = new ArrayList<>() {{
             add("w123");
         }};
         when(mockWorkflowService.getRunningWorkflows(anyString(), anyInt(), anyLong(), anyLong()))
@@ -195,11 +195,28 @@ public class WorkflowResourceTest {
         verify(mockWorkflowService, times(1)).searchWorkflows(anyInt(), anyInt(),
             anyString(), anyString(), anyString());
     }
+    @Test
+    public void testSearchV2() {
+        workflowResource.searchV2(0, 100, "asc", "*", "*");
+        verify(mockWorkflowService).searchWorkflowsV2(0, 100, "asc", "*", "*");
+    }
 
     @Test
     public void testSearchWorkflowsByTasks() {
         workflowResource.searchWorkflowsByTasks(0, 100, "asc", "*", "*");
         verify(mockWorkflowService, times(1)).searchWorkflowsByTasks(anyInt(), anyInt(),
             anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testSearchWorkflowsByTasksV2() {
+        workflowResource.searchWorkflowsByTasksV2(0, 100, "asc", "*", "*");
+        verify(mockWorkflowService).searchWorkflowsByTasksV2(0, 100, "asc", "*", "*");
+    }
+
+    @Test
+    public void testGetExternalStorageLocation() {
+        workflowResource.getExternalStorageLocation("path", "operation", "payloadType");
+        verify(mockWorkflowService).getExternalStorageLocation("path", "operation", "payloadType");
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.common.run.WorkflowSummary;
@@ -171,18 +172,39 @@ public abstract class AbstractGrpcEndToEndTest extends AbstractEndToEndTest {
         assertEquals(1, searchResultV2.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultV2.getResults().get(0).getWorkflowId());
 
-
         SearchResult<WorkflowSummary> searchResultAdvanced = workflowClient.search(0,1,null,null,"workflowType='" + def.getName() + "'");
         assertNotNull(searchResultAdvanced);
         assertEquals(1, searchResultAdvanced.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultAdvanced.getResults().get(0).getWorkflowId());
-
 
         SearchResult<Workflow> searchResultV2Advanced = workflowClient.searchV2(0,1,null,null,"workflowType='" + def.getName() + "'");
         assertNotNull(searchResultV2Advanced);
         assertEquals(1, searchResultV2Advanced.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultV2Advanced.getResults().get(0).getWorkflowId());
 
+        SearchResult<TaskSummary> taskSearchResult =
+                taskClient.search("taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResult);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getName(), taskSearchResult.getResults().get(0).getTaskDefName());
+
+        SearchResult<TaskSummary> taskSearchResultAdvanced =
+                taskClient.search(0,1,null,null,"taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultAdvanced);
+        assertEquals(1, taskSearchResultAdvanced.getTotalHits());
+        assertEquals(t0.getName(), taskSearchResultAdvanced.getResults().get(0).getTaskDefName());
+
+        SearchResult<Task> taskSearchResultV2 =
+                taskClient.searchV2("taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultV2);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getTaskReferenceName(), taskSearchResultV2.getResults().get(0).getReferenceTaskName());
+
+        SearchResult<Task> taskSearchResultV2Advanced =
+                taskClient.searchV2(0,1,null,null,"taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultV2Advanced);
+        assertEquals(1, taskSearchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getTaskReferenceName(), taskSearchResultV2Advanced.getResults().get(0).getReferenceTaskName());
 
         workflowClient.terminateWorkflow(workflowId, "terminate reason");
         workflow = workflowClient.getWorkflow(workflowId, true);

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
@@ -164,6 +164,25 @@ public abstract class AbstractGrpcEndToEndTest extends AbstractEndToEndTest {
         SearchResult<WorkflowSummary> searchResult = workflowClient.search("workflowType='" + def.getName() + "'");
         assertNotNull(searchResult);
         assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+
+        SearchResult<Workflow> searchResultV2 = workflowClient.searchV2("workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultV2);
+        assertEquals(1, searchResultV2.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultV2.getResults().get(0).getWorkflowId());
+
+
+        SearchResult<WorkflowSummary> searchResultAdvanced = workflowClient.search(0,1,null,null,"workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultAdvanced);
+        assertEquals(1, searchResultAdvanced.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultAdvanced.getResults().get(0).getWorkflowId());
+
+
+        SearchResult<Workflow> searchResultV2Advanced = workflowClient.searchV2(0,1,null,null,"workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultV2Advanced);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultV2Advanced.getResults().get(0).getWorkflowId());
+
 
         workflowClient.terminateWorkflow(workflowId, "terminate reason");
         workflow = workflowClient.getWorkflow(workflowId, true);

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
@@ -30,6 +30,7 @@ import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.SearchResult;
+import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.common.run.WorkflowSummary;
@@ -178,24 +179,44 @@ public abstract class AbstractHttpEndToEndTest extends AbstractEndToEndTest {
         assertEquals(1, searchResult.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
 
-
         SearchResult<Workflow> searchResultV2 = workflowClient.searchV2("workflowType='" + def.getName() + "'");
         assertNotNull(searchResultV2);
         assertEquals(1, searchResultV2.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultV2.getResults().get(0).getWorkflowId());
-
 
         SearchResult<WorkflowSummary> searchResultAdvanced = workflowClient.search(0,1,null,null,"workflowType='" + def.getName() + "'");
         assertNotNull(searchResultAdvanced);
         assertEquals(1, searchResultAdvanced.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultAdvanced.getResults().get(0).getWorkflowId());
 
-
         SearchResult<Workflow> searchResultV2Advanced = workflowClient.searchV2(0,1,null,null,"workflowType='" + def.getName() + "'");
         assertNotNull(searchResultV2Advanced);
         assertEquals(1, searchResultV2Advanced.getTotalHits());
         assertEquals(workflow.getWorkflowId(), searchResultV2Advanced.getResults().get(0).getWorkflowId());
 
+        SearchResult<TaskSummary> taskSearchResult =
+                taskClient.search("taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResult);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getName(), taskSearchResult.getResults().get(0).getTaskDefName());
+
+        SearchResult<TaskSummary> taskSearchResultAdvanced =
+                taskClient.search(0,1,null,null,"taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultAdvanced);
+        assertEquals(1, taskSearchResultAdvanced.getTotalHits());
+        assertEquals(t0.getName(), taskSearchResultAdvanced.getResults().get(0).getTaskDefName());
+
+        SearchResult<Task> taskSearchResultV2 =
+                taskClient.searchV2("taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultV2);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getTaskReferenceName(), taskSearchResultV2.getResults().get(0).getReferenceTaskName());
+
+        SearchResult<Task> taskSearchResultV2Advanced =
+                taskClient.searchV2(0,1,null,null,"taskType='" + t0.getName() + "'");
+        assertNotNull(taskSearchResultV2Advanced);
+        assertEquals(1, taskSearchResultV2Advanced.getTotalHits());
+        assertEquals(t0.getTaskReferenceName(), taskSearchResultV2Advanced.getResults().get(0).getReferenceTaskName());
 
         workflowClient.terminateWorkflow(workflowId, "terminate reason");
         workflow = workflowClient.getWorkflow(workflowId, true);

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
@@ -176,6 +176,26 @@ public abstract class AbstractHttpEndToEndTest extends AbstractEndToEndTest {
         SearchResult<WorkflowSummary> searchResult = workflowClient.search("workflowType='" + def.getName() + "'");
         assertNotNull(searchResult);
         assertEquals(1, searchResult.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResult.getResults().get(0).getWorkflowId());
+
+
+        SearchResult<Workflow> searchResultV2 = workflowClient.searchV2("workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultV2);
+        assertEquals(1, searchResultV2.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultV2.getResults().get(0).getWorkflowId());
+
+
+        SearchResult<WorkflowSummary> searchResultAdvanced = workflowClient.search(0,1,null,null,"workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultAdvanced);
+        assertEquals(1, searchResultAdvanced.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultAdvanced.getResults().get(0).getWorkflowId());
+
+
+        SearchResult<Workflow> searchResultV2Advanced = workflowClient.searchV2(0,1,null,null,"workflowType='" + def.getName() + "'");
+        assertNotNull(searchResultV2Advanced);
+        assertEquals(1, searchResultV2Advanced.getTotalHits());
+        assertEquals(workflow.getWorkflowId(), searchResultV2Advanced.getResults().get(0).getWorkflowId());
+
 
         workflowClient.terminateWorkflow(workflowId, "terminate reason");
         workflow = workflowClient.getWorkflow(workflowId, true);


### PR DESCRIPTION
Add a new search API that returns Workflow instead WorkflowSummary.

This feature merged to 2.31 https://github.com/Netflix/conductor/pull/2101, And This PR syncs it to 3.x version.

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Issue #1992 


