### PR TITLE
Add build properties to /admin/config API which is consumed by the UI

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/AdminServiceImpl.java
@@ -20,6 +20,9 @@ import com.netflix.conductor.core.events.EventQueueManager;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.reconciliation.WorkflowRepairService;
 import com.netflix.conductor.dao.QueueDAO;
+import org.springframework.boot.info.BuildProperties;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,14 +39,18 @@ public class AdminServiceImpl implements AdminService {
     private final QueueDAO queueDAO;
     private final WorkflowRepairService workflowRepairService;
     private final EventQueueManager eventQueueManager;
+    private final BuildProperties buildProperties;
+
 
     public AdminServiceImpl(ConductorProperties properties, ExecutionService executionService, QueueDAO queueDAO,
-        Optional<WorkflowRepairService> workflowRepairService, Optional<EventQueueManager> eventQueueManager) {
+        Optional<WorkflowRepairService> workflowRepairService, Optional<EventQueueManager> eventQueueManager,
+        BuildProperties buildProperties) {
         this.properties = properties;
         this.executionService = executionService;
         this.queueDAO = queueDAO;
         this.workflowRepairService = workflowRepairService.orElse(null);
         this.eventQueueManager = eventQueueManager.orElse(null);
+        this.buildProperties = buildProperties;
     }
 
     /**
@@ -52,7 +59,20 @@ public class AdminServiceImpl implements AdminService {
      * @return all the configuration parameters.
      */
     public Map<String, Object> getAllConfig() {
-        return properties.getAll();
+        Map<String, Object> configs = properties.getAll();
+        configs.putAll(getBuildProperties());
+        return configs;
+    }
+
+    /**
+     * Get all build properties
+     * @return all the build properties.
+     */
+    private Map<String, Object> getBuildProperties(){
+        Map<String, Object> buildProps = new HashMap<>();
+        buildProps.put("version", buildProperties.getVersion());
+        buildProps.put("buildDate", buildProperties.getTime());
+        return buildProps;
     }
 
     /**

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -57,3 +57,7 @@ bootJar {
     mainClassName = 'com.netflix.conductor.Conductor'
     classifier = 'boot'
 }
+
+springBoot {
+    buildInfo()
+}


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

In conductor 2.X the /admin/config API also returned the build info (version and time), which is used by the UI.
In version 3.X the conductor was upgraded to use SpringBoot and the build info is not included in the API which causes an error in the UI.

Before the fix:

![image](https://user-images.githubusercontent.com/68654254/118638254-4ea5a280-b7df-11eb-974f-42893b283f66.png)

After the fix:

![image](https://user-images.githubusercontent.com/68654254/118638297-5d8c5500-b7df-11eb-932b-1fc624eba42a.png)


