### PR TITLE
#2263 SQL files are the same as 2.31

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 
 -- --------------------------------------------------------------------------------------------------------------
 -- SCHEMA FOR METADATA DAO

--- a/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
@@ -1,18 +1,2 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 ALTER TABLE `queue_message` CHANGE `created_on` `created_on` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE `queue_message` CHANGE `deliver_on` `deliver_on` TIMESTAMP DEFAULT CURRENT_TIMESTAMP;

--- a/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 SET @dbname = DATABASE();
 SET @tablename = "queue_message";
 SET @columnname = "priority";

--- a/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 # Drop the 'unique_event_execution' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 # Drop the 'workflow_corr_id_index' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 # Drop the 'combo_queue_message' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2021 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 # no longer need separate index if pk is queue_name, message_id
 SET @idx_exists := (SELECT COUNT(INDEX_NAME)
                     FROM information_schema.STATISTICS
@@ -21,7 +5,7 @@ SET @idx_exists := (SELECT COUNT(INDEX_NAME)
                       AND `INDEX_NAME` = 'unique_queue_name_message_id'
                       AND TABLE_SCHEMA = database());
 SET @idxstmt := IF(@idx_exists > 0, 'ALTER TABLE `queue_message` DROP INDEX `unique_queue_name_message_id`',
-                   'SELECT ''INFO: Index unique_queue_name_message_id does not exist.''');
+                                    'SELECT ''INFO: Index unique_queue_name_message_id does not exist.''');
 PREPARE stmt1 FROM @idxstmt;
 EXECUTE stmt1;
 
@@ -32,7 +16,7 @@ set @col_exists := (SELECT COUNT(*)
                       AND `COLUMN_NAME` = 'id'
                       AND TABLE_SCHEMA  = database());
 SET @colstmt := IF(@col_exists > 0, 'ALTER TABLE `queue_message` DROP COLUMN `id`',
-                   'SELECT ''INFO: Column id does not exist.''') ;
+                                    'SELECT ''INFO: Column id does not exist.''') ;
 PREPARE stmt2 from @colstmt;
 EXECUTE stmt2;
 

--- a/mysql-persistence/src/main/resources/db/migration/V8__update_pk.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V8__update_pk.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2021 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 DELIMITER $$
 DROP PROCEDURE IF EXISTS `DropIndexIfExists`$$
 CREATE PROCEDURE `DropIndexIfExists`(IN tableName VARCHAR(128), IN indexName VARCHAR(128))

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V1__initial_schema.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V1__initial_schema.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 
 -- --------------------------------------------------------------------------------------------------------------
 -- SCHEMA FOR METADATA DAO

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 DROP INDEX IF EXISTS unique_event_execution;
 
 CREATE UNIQUE INDEX unique_event_execution ON event_execution (event_handler_name,event_name,execution_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 DROP INDEX IF EXISTS workflow_corr_id_index;
 
 CREATE INDEX workflow_corr_id_index ON workflow (correlation_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2020 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 DROP INDEX IF EXISTS combo_queue_message;
 
 CREATE INDEX combo_queue_message ON queue_message (queue_name,priority,popped,deliver_on,created_on);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2021 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 -- no longer need separate index if pk is queue_name, message_id
 DROP INDEX IF EXISTS unique_queue_name_message_id;
 

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V6__update_pk.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V6__update_pk.sql
@@ -1,19 +1,3 @@
---
--- Copyright 2021 Netflix, Inc.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
-
 -- 1) queue_message
 DROP INDEX IF EXISTS unique_queue_name_message_id;
 ALTER TABLE queue_message DROP CONSTRAINT IF EXISTS queue_message_pkey;


### PR DESCRIPTION
Pull Request type
----

- [ x] Bugfix

Changes in this PR
----

_In the 3.0 release, Flyway migration SQL files included the copyright notice which altered the checksum, resulting in issues for users migrating from 2.x to 3.0. This PR copies the SQL files from the 2.31 branch as-is, so the checksum remains the same._

Issue #2263