### PR TITLE
Added License header to MySQL and Postgres Flyway SQLs

### DIFF
--- a/mysql-persistence/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,3 +1,18 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 
 -- --------------------------------------------------------------------------------------------------------------
 -- SCHEMA FOR METADATA DAO

--- a/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
@@ -1,2 +1,18 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 ALTER TABLE `queue_message` CHANGE `created_on` `created_on` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE `queue_message` CHANGE `deliver_on` `deliver_on` TIMESTAMP DEFAULT CURRENT_TIMESTAMP;

--- a/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 SET @dbname = DATABASE();
 SET @tablename = "queue_message";
 SET @columnname = "priority";

--- a/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 # Drop the 'unique_event_execution' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 # Drop the 'workflow_corr_id_index' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 # Drop the 'combo_queue_message' index if it exists
 SET @exist := (SELECT COUNT(INDEX_NAME)
                FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 # no longer need separate index if pk is queue_name, message_id
 SET @idx_exists := (SELECT COUNT(INDEX_NAME)
                     FROM information_schema.STATISTICS

--- a/mysql-persistence/src/main/resources/db/migration/V8__update_pk.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V8__update_pk.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 DELIMITER $$
 DROP PROCEDURE IF EXISTS `DropIndexIfExists`$$
 CREATE PROCEDURE `DropIndexIfExists`(IN tableName VARCHAR(128), IN indexName VARCHAR(128))

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V1__initial_schema.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V1__initial_schema.sql
@@ -1,3 +1,18 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 
 -- --------------------------------------------------------------------------------------------------------------
 -- SCHEMA FOR METADATA DAO

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V2__1009_Fix_PostgresExecutionDAO_Index.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 DROP INDEX IF EXISTS unique_event_execution;
 
 CREATE UNIQUE INDEX unique_event_execution ON event_execution (event_handler_name,event_name,execution_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V3__correlation_id_index.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 DROP INDEX IF EXISTS workflow_corr_id_index;
 
 CREATE INDEX workflow_corr_id_index ON workflow (correlation_id);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V4__new_qm_index_with_priority.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 DROP INDEX IF EXISTS combo_queue_message;
 
 CREATE INDEX combo_queue_message ON queue_message (queue_name,priority,popped,deliver_on,created_on);

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V5__new_queue_message_pk.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 -- no longer need separate index if pk is queue_name, message_id
 DROP INDEX IF EXISTS unique_queue_name_message_id;
 

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V6__update_pk.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V6__update_pk.sql
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 -- 1) queue_message
 DROP INDEX IF EXISTS unique_queue_name_message_id;
 ALTER TABLE queue_message DROP CONSTRAINT IF EXISTS queue_message_pkey;


### PR DESCRIPTION
Pull Request type
----

- [x] Refactoring (no functional changes, no api changes)

Changes in this PR
----

Added License header to MySQL and Postgres Flyway SQLs, to skip the same during CI Pipeline Buiild stage.

Before adding License : writeLicense task was triggered in CI Pipeline.

> Task :conductor-mysql-persistence:writeLicenseHeader
Missing header in: mysql-persistence/src/main/resources/db/migration/V7__new_queue_message_pk.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V5__correlation_id_index.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V2__queue_message_timestamps.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V1__initial_schema.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V3__queue_add_priority.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V4__1009_Fix_MySQLExecutionDAO_Index.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V8__update_pk.sql
Missing header in: mysql-persistence/src/main/resources/db/migration/V6__new_qm_index_with_priority.sql

After adding License : License was considered up to date.

> Task :conductor-mysql-persistence:licenseTest UP-TO-DATE
> Task :conductor-mysql-persistence:license UP-TO-DATE



Alternatives considered
----

None.
