### PR TITLE
change combo_queue_message index to use descending priority for huge performance increase

### DIFF
--- a/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS combo_queue_message;
+
+CREATE INDEX combo_queue_message ON queue_message USING btree (queue_name , priority desc, popped, deliver_on, created_on)

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
@@ -1,3 +1,4 @@
+-- use descending priority in the index to conform to queries
 DROP INDEX IF EXISTS combo_queue_message;
 
 CREATE INDEX combo_queue_message ON queue_message USING btree (queue_name , priority desc, popped, deliver_on, created_on)


### PR DESCRIPTION
change combo_queue_message index to use descending priority for huge performance increase on databases with millions of workflow and task rows

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----When polling, the postgres implementation does a query that orders by descending priority. For databases with lots of workflows, an index created using ascending priority causes these queries to be extremely slow. Changing the index to use descending priority dramatically increases performance on those polling queries, especially with databases with millions of workflows/tasks.


Alternatives considered
----

_Describe alternative implementation you have considered_
