### PR TITLE
Fix usage of 'in' clause for postgres query in processUnacks and processAllUnacks

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -190,6 +190,8 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
 
         logger.trace("processAllUnacks started");
 
+		// Get queue_name and message_id because those are in an index so using both increases performance
+		
         getWithRetriedTransactions(tx -> {
             String LOCK_TASKS = "SELECT queue_name, message_id FROM queue_message WHERE popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp limit 1000 FOR UPDATE SKIP LOCKED";
 

--- a/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/dao/postgres/PostgresQueueDAO.java
@@ -17,15 +17,16 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.netflix.conductor.core.events.queue.Message;
-import com.netflix.conductor.core.execution.ApplicationException;
 import com.netflix.conductor.dao.QueueDAO;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.sql.DataSource;
+
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -190,10 +191,63 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
         logger.trace("processAllUnacks started");
 
         getWithRetriedTransactions(tx -> {
-            String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
+            String LOCK_TASKS = "SELECT queue_name, message_id FROM queue_message WHERE popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp limit 1000 FOR UPDATE SKIP LOCKED";
+
+            List<QueueMessage> messages = query(tx, LOCK_TASKS, p -> p.executeAndFetch(rs -> {
+            	List<QueueMessage> results = new ArrayList<QueueMessage>();
+                while (rs.next()) {
+                	QueueMessage qm = new QueueMessage();
+                	qm.queueName = rs.getString("queue_name");
+                	qm.messageId = rs.getString("message_id");
+                    results.add(qm);
+                }
+                return results;
+            }));
+
+            if (messages.size() == 0) {
+                return 0;
+            }
+
+            Map<String, List<String>> queueMessageMap = new HashMap<String, List<String>>();
+            for(QueueMessage qm : messages) {
+            	if(!queueMessageMap.containsKey(qm.queueName)) {
+            		queueMessageMap.put(qm.queueName, new ArrayList<String>());
+            	}
+            	queueMessageMap.get(qm.queueName).add(qm.messageId);
+            }
+            
+			int totalUnacked = 0;
+            for(String queueName : queueMessageMap.keySet()) {
+    			Integer unacked = 0;;
+    			try {
+                	final List<String> msgIds = queueMessageMap.get(queueName);
+    		        final String UPDATE_POPPED = String.format(
+    		        		"UPDATE queue_message SET popped = false WHERE queue_name = ? and message_id IN (%s)",
+    		                Query.generateInBindings(msgIds.size()));
+
+    				unacked = query(tx, UPDATE_POPPED, q -> q.addParameter(queueName)
+        					.addParameters(msgIds).executeUpdate());
+    			} catch(Exception e) {
+    				e.printStackTrace();
+    			}            
+    			totalUnacked += unacked;
+                logger.debug("Unacked {} messages from all queues", unacked);
+            }
+
+			if (totalUnacked > 0) {
+                logger.debug("Unacked {} messages from all queues", totalUnacked);
+            }
+            return totalUnacked;
+        });
+    }
+
+    @Override
+    public void processUnacks(String queueName) {
+        getWithRetriedTransactions(tx -> {
+            String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp limit 1000 FOR UPDATE SKIP LOCKED";
 
             List<String> messages = query(tx, LOCK_TASKS, p -> p.executeAndFetch(rs -> {
-                List<String> results = new ArrayList<>();
+            	List<String> results = new ArrayList<String>();
                 while (rs.next()) {
                     results.add(rs.getString("message_id"));
                 }
@@ -203,41 +257,19 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
             if (messages.size() == 0) {
                 return 0;
             }
-            String msgIdsString = String.join(",", messages);
 
-            final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE message_id IN (?)";
-            Integer unacked = query(tx, PROCESS_UNACKS, q -> q.addParameter(msgIdsString).executeUpdate());
-            if (unacked > 0) {
-                logger.debug("Unacked {} messages: {} from all queues", unacked, messages);
-            }
-            return unacked;
-        });
-    }
+			Integer unacked = 0;;
+			try {            
+		        final String UPDATE_POPPED = String.format(
+		        		"UPDATE queue_message SET popped = false WHERE queue_name = ? and message_id IN (%s)",
+		                Query.generateInBindings(messages.size()));
 
-    @Override
-    public void processUnacks(String queueName) {
-        getWithRetriedTransactions(tx -> {
-            String LOCK_TASKS = "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = true AND (deliver_on + (60 ||' seconds')::interval)  <  current_timestamp FOR UPDATE SKIP LOCKED";
-
-            List<String> messages = query(tx, LOCK_TASKS, p -> p.addParameter(queueName)
-                    .executeAndFetch(rs -> {
-                        List<String> results = new ArrayList<>();
-                        while (rs.next()) {
-                            results.add(rs.getString("message_id"));
-                        }
-                        return results;
-                    }));
-
-            if (messages.size() == 0) {
-                return 0;
-            }
-            String msgIdsString = String.join(",", messages);
-
-            final String PROCESS_UNACKS = "UPDATE queue_message SET popped = false WHERE queue_name = ? AND message_id IN (?)";
-            Integer unacked = query(tx, PROCESS_UNACKS, q -> q.addParameter(queueName).addParameter(msgIdsString).executeUpdate());
-            if (unacked > 0) {
-                logger.debug("Unacked {} messages: {} from queue: {}", unacked, messages, queueName);
-            }
+				unacked = query(tx, UPDATE_POPPED, q -> q.addParameter(queueName)
+    					.addParameters(messages).executeUpdate());
+			} catch(Exception e) {
+				logger.error("While processing unacks", e);
+			}            
+            logger.debug("Unacked {} messages from all queues", unacked);
             return unacked;
         });
     }


### PR DESCRIPTION
Fix usage of 'in' clause for postgres query in processUnacks and processAllUnacks

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----The current way that the update portion of the processAllUnacks method works is that a String is created concatenating all of the message ids that should be updated and that String is passed into the query as a parameter to replace the 'in' variable. This does not work in Postgres. We must use the standard Query.generateInBindings method to generate the parameter in the proper syntax.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
