### PR TITLE
Bulk Terminate API uses POST instead of DELETE

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
@@ -12,7 +12,6 @@
  */
 package com.netflix.conductor.client.http;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import com.netflix.conductor.client.config.ConductorClientConfiguration;
 import com.netflix.conductor.client.config.DefaultConductorClientConfiguration;
@@ -227,10 +226,9 @@ public class WorkflowClient extends ClientBase {
      * @param reason      the reason to be logged and displayed
      * @return the {@link BulkResponse} contains bulkErrorResults and bulkSuccessfulResults
      */
-    public BulkResponse terminateWorkflows(List<String> workflowIds, String reason) throws JsonProcessingException {
+    public BulkResponse terminateWorkflows(List<String> workflowIds, String reason) {
         Preconditions.checkArgument(!workflowIds.isEmpty(), "workflow id cannot be blank");
-        return deleteWithRequestBody(new Object[]{"reason", reason}, "workflow/bulk/terminate",
-                objectMapper.writeValueAsString(workflowIds));
+        return postForEntity("workflow/bulk/terminate", workflowIds, new Object[]{"reason", reason}, BulkResponse.class);
     }
 
     /**

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowBulkResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowBulkResource.java
@@ -1,30 +1,30 @@
 /*
- * Copyright 2020 Netflix, Inc.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *  Copyright 2021 Netflix, Inc.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
  */
 package com.netflix.conductor.rest.controllers;
-
-import static com.netflix.conductor.rest.config.RequestMappingConstants.WORKFLOW_BULK;
 
 import com.netflix.conductor.common.model.BulkResponse;
 import com.netflix.conductor.service.WorkflowBulkService;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.List;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.netflix.conductor.rest.config.RequestMappingConstants.WORKFLOW_BULK;
 
 /**
  * Synchronous Bulk APIs to process the workflows in batches
@@ -96,9 +96,9 @@ public class WorkflowBulkResource {
      * @param reason      - description to be specified for the terminated workflow for future references.
      * @return bulk response object containing a list of succeeded workflows and a list of failed ones with errors
      */
-    @DeleteMapping("/terminate")
+    @PostMapping("/terminate")
     @Operation(summary = "Terminate workflows execution")
-    public BulkResponse terminate(@RequestBody List<String> workflowIds, @RequestParam("reason") String reason) {
+    public BulkResponse terminate(@RequestBody List<String> workflowIds, @RequestParam(value = "reason", required = false) String reason) {
         return workflowBulkService.terminate(workflowIds, reason);
     }
 }

--- a/ui/src/api/wfe.js
+++ b/ui/src/api/wfe.js
@@ -211,7 +211,7 @@ router.post('/bulk/restart_with_current_definition', async (req, res, next) => {
   }
 })
 
-router.delete('/bulk/terminate', async (req, res, next) => {
+router.post('/bulk/terminate', async (req, res, next) => {
   try {
     const result = await http.delete(baseURL2 + "bulk/terminate", req.body, req.token);
     res.status(200).send(result);

--- a/ui/src/sagas/bulk.js
+++ b/ui/src/sagas/bulk.js
@@ -28,7 +28,7 @@ function* sendBulkRequest(action) {
         response = yield call(http.put, url, workflows);
         break;
       case "terminate":
-        response = yield call(http.delete, url, workflows);
+        response = yield call(http.post, url, workflows);
         break;
       default:
         throw "Invalid operation requested.";


### PR DESCRIPTION
Pull Request type
----

- [ x] Bugfix

Changes in this PR
----
_Bulk terminate API uses POST since Tomcat does not support DELETE requests with body._