### PR TITLE
Feature/separate database services in docker compose

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -53,7 +53,7 @@ Go to [http://127.0.0.1:9090](http://127.0.0.1:9090).
 
 Elasticsearch timeout
 Standalone(single node) elasticsearch has a yellow status which will cause timeout for conductor server(Required: Green).
-Spin up a cluster(More than once) to prevent timeout or edit the local code(check the issue tagged for more)
+Spin up a cluster(More than one) to prevent timeout or edit the local code(check the issue tagged for more)
 Check issue: https://github.com/Netflix/conductor/issues/2262
 
 Changes does not reflect after changes in config.properties

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,12 +22,14 @@ Running the images:
  - `docker run -p 8080:8080 -d -t conductor:server`
  - `docker run -p 5000:5000 -d -t conductor:ui` (requires elasticsearch running locally)
 
-Using compose:
-`docker-compose up`
+Using compose (with Dynomite):
+`docker-compose -f docker-compose.yaml -f docker-compose-dynomite.yaml up`
+
+Using compose (with Postgres):
+`docker-compose -f docker-compose.yaml -f docker-compose-postgres.yaml up`
 
 ## Exiting Compose
 `ctrl+c` will exit docker compose.
-
 
 To ensure images are stopped do:
  - `docker-compose down`

--- a/docker/docker-compose-dynomite.yaml
+++ b/docker/docker-compose-dynomite.yaml
@@ -1,0 +1,31 @@
+version: '2.3'
+
+services:
+  conductor-server:
+    environment:
+      - CONFIG_PROP=config.properties
+    links:
+      - dynomite:dyno1
+    depends_on:
+      dynomite:
+        condition: service_healthy
+
+  dynomite:
+    image: v1r3n/dynomite
+    networks:
+      - internal
+    ports:
+      - 8102:8102
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/8102'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+networks:
+  internal:

--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -1,0 +1,34 @@
+version: '2.3'
+
+services:
+  conductor-server:
+    environment:
+      - CONFIG_PROP=config-postgres.properties
+    links:
+      - postgres:postgresdb
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=conductor
+      - POSTGRES_PASSWORD=conductor
+    networks:
+      - internal
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/5432'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+networks:
+  internal:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,29 +19,9 @@ services:
       retries: 12
     links:
       - elasticsearch:es
-      - dynomite:dyno1
     depends_on:
       elasticsearch:
         condition: service_healthy
-      dynomite:
-        condition: service_healthy
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "1k"
-        max-file: "3"
-
-  dynomite:
-    image: v1r3n/dynomite
-    networks:
-      - internal
-    ports:
-      - 8102:8102
-    healthcheck:
-      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/8102'
-      interval: 5s
-      timeout: 5s
-      retries: 12
     logging:
       driver: "json-file"
       options:

--- a/docker/server/config/config-postgres.properties
+++ b/docker/server/config/config-postgres.properties
@@ -1,0 +1,25 @@
+# Servers.
+conductor.grpc-server.enabled=false
+
+# Database persistence type.
+conductor.db.type=postgres
+
+spring.datasource.url=jdbc:postgresql://postgres:5432/conductor
+spring.datasource.username=conductor
+spring.datasource.password=conductor
+
+# Hikari pool sizes are -1 by default and prevent startup
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=2
+
+# Elastic search instance indexing is enabled.
+conductor.indexing.enabled=true
+
+# Transport address to elasticsearch
+conductor.elasticsearch.url=http://es:9200
+
+# Name of the elasticsearch cluster
+conductor.elasticsearch.indexName=conductor
+
+# Load sample kitchen sink workflow
+loadSample=true


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Separating database service helps provide flexibility to preferred database. Downside with this is `docker-compose.yaml` cannot be used as is as the database service is detached.`README.md` is updated with new set of instructions to include database related docker compose file when launching the services. This commit provides two database implementations viz. `dynomite` and `postgres` only. More can be extended in future.
----

None.
