### PR TITLE
add descending priority index to combo_queue_message index to make queue queries faster - 3.x

### DIFF
--- a/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V7__new_qm_index_desc_priority.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS combo_queue_message;
+
+CREATE INDEX combo_queue_message ON queue_message USING btree (queue_name , priority desc, popped, deliver_on, created_on)


### PR DESCRIPTION
add descending priority index to combo_queue_message index to make queue queries faster - 3.x

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
