### PR TITLE
feature: allow custom logic in workflow for task retries

### DIFF
--- a/docs/docs/configuration/taskdef.md
+++ b/docs/docs/configuration/taskdef.md
@@ -6,7 +6,6 @@ Conductor maintains a registry of worker tasks.  A task MUST be registered befor
 {
   "name": "encode_task",
   "retryCount": 3,
-  
   "timeoutSeconds": 1200,
   "pollTimeoutSeconds": 3600,
   "inputKeys": [

--- a/docs/docs/configuration/workflowdef.md
+++ b/docs/docs/configuration/workflowdef.md
@@ -20,6 +20,7 @@ Workflows are defined using a JSON based DSL.
       "name": "deploy",
       "taskReferenceName": "d1",
       "type": "SIMPLE",
+      "retryIfJqIsTrue": "if .subkey == 4 then true else false end",
       "inputParameters": {
         "fileLocation": "${encode.output.encodeLocation}"
       }
@@ -60,6 +61,7 @@ Workflows are defined using a JSON based DSL.
 |optional|true  or false.  When set to true - workflow continues even if the task fails.  The status of the task is reflected as `COMPLETED_WITH_ERRORS`|Defaults to `false`|
 |inputParameters|JSON template that defines the input given to the task|See [Wiring Inputs and Outputs](#wiring-inputs-and-outputs) for details|
 |domain|See [Task Domains](/conductor/configuration/taskdomains) for more information.|optional|
+|retryIfJqIsTrue|If present, jq query evaluated on the output of the task. If the result of the jq query evaluation is "true", then the task will be set for a retry if its retryCount is not exhausted yet. This allows to better control if a task should be retried given the context of the workflow it's running in. | optional, defaults to `null` |
 
 In addition to these parameters, System Tasks have their own parameters. Checkout [System Tasks](/conductor/configuration/systask/) for more information.
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This is a proposal to allow workflows to decide _if_ a task should be retried according to its output.
A workflow is the context within which the task is run, and this changes when/if a task should be retried.
This logic would be evaluated by the workflow decider.

I propose this by using a jq query that evaluates to "true" or anything else otherwise.

Why jq?
- makes parsing the output of the task easy (because the output is some kind of json)
- also allows for regexps

Alternatives:

- put the task to be retried in a do_while and followed by a decision: possible, but quite cumbersome.
- use a javascript (Nashorn) expression (just like in the DECISION task): not easier, and with Nashorn going away soon, I don't find it compelling.

Drawbacks:

- the workflow decider could be stuck for a while if the jq expression takes too long. Its execution should be bound to a maximum time (ex: 200ms) to avoid this.

Note: this PR contains a documentation change only at this stage. This is normal, and is here to allow discussing the idea first, and going forward with the implementation later.
