### PR TITLE
Configurable retry delay policy

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -39,7 +39,7 @@ public class TaskDef extends Auditable {
     public enum TimeoutPolicy {RETRY, TIME_OUT_WF, ALERT_ONLY}
 
     @ProtoEnum
-    public enum RetryLogic {FIXED, EXPONENTIAL_BACKOFF}
+    public enum RetryLogic {FIXED, EXPONENTIAL_BACKOFF, CUSTOM}
 
     private static final int ONE_HOUR = 60 * 60;
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -61,6 +61,9 @@ public class TaskResult {
     @ProtoField(id = 8)
     private Any outputMessage;
 
+    @ProtoField(id = 9)
+    private int retryDelaySeconds;
+
     private List<TaskExecLog> logs = new CopyOnWriteArrayList<>();
 
     private String externalOutputPayloadStoragePath;
@@ -76,6 +79,7 @@ public class TaskResult {
         this.outputData = task.getOutputData();
         this.externalOutputPayloadStoragePath = task.getExternalOutputPayloadStoragePath();
         this.subWorkflowId = task.getSubWorkflowId();
+        this.retryDelaySeconds = task.getStartDelayInSeconds();
         switch (task.getStatus()) {
             case CANCELED:
             case COMPLETED_WITH_ERRORS:
@@ -128,6 +132,12 @@ public class TaskResult {
     }
 
     /**
+     * Return the retry delay.
+     * @return
+     */
+    public int getRetryDelaySeconds()  {return retryDelaySeconds; }
+
+    /**
      * When set to non-zero values, the task remains in the queue for the specified seconds before sent back to the
      * worker when polled. Useful for the long running task, where the task is updated as IN_PROGRESS and should not be
      * polled out of the queue for a specified amount of time.  (delayed queue implementation)
@@ -138,6 +148,16 @@ public class TaskResult {
     public void setCallbackAfterSeconds(long callbackAfterSeconds) {
         this.callbackAfterSeconds = callbackAfterSeconds;
     }
+
+    /**
+     * Retry delay. It follows following logic to decide on retry interval:
+     * <p>NO retry delay if the worker sends a negative value (<0) in the TaskResult</p>
+     * <p>Retry delay from the task definition or (workflow task?) if the worker sends 0 in the TaskResult</p>
+     * <p>Retry delay from the workflow task if the worker sends 0 in the TaskResult</p>
+     *
+     * @param retryDelaySeconds
+     */
+    public void setRetryDelaySeconds(int retryDelaySeconds) { this.retryDelaySeconds = retryDelaySeconds; }
 
     public String getWorkerId() {
         return workerId;

--- a/common/src/test/java/com/netflix/conductor/common/tasks/TaskResultTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/tasks/TaskResultTest.java
@@ -36,6 +36,7 @@ public class TaskResultTest {
         task.setWorkerId("worker-id");
         task.setOutputData(new HashMap<>());
         task.setExternalOutputPayloadStoragePath("externalOutput");
+        task.setStartDelayInSeconds(10);
     }
 
     @Test
@@ -78,5 +79,6 @@ public class TaskResultTest {
         assertEquals(task.getWorkerId(), taskResult.getWorkerId());
         assertEquals(task.getOutputData(), taskResult.getOutputData());
         assertEquals(task.getExternalOutputPayloadStoragePath(), taskResult.getExternalOutputPayloadStoragePath());
+        assertEquals(task.getStartDelayInSeconds(), taskResult.getRetryDelaySeconds());
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -478,6 +478,20 @@ public class DeciderService {
                 // Reset integer overflow to max value
                 startDelay = retryDelaySeconds < 0 ? Integer.MAX_VALUE : retryDelaySeconds;
                 break;
+            case CUSTOM:
+                // Custom strategy
+                int taskStartDelay = task.getStartDelayInSeconds();
+                if (taskStartDelay < 0) {
+                    // NO retry delay if the worker sends a negative value (<0) in the TaskResult
+                    startDelay = 0;
+                } else if (taskStartDelay == 0) {
+                    // Retry delay from the task definition if the worker sends 0 in the TaskResult.
+                    startDelay = taskDefinition.getRetryDelaySeconds();
+                } else {
+                    // Retry delay from the WorkflowTask
+                    startDelay = task.getStartDelayInSeconds();
+                }
+                break;
         }
 
         task.setRetried(true);

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -970,6 +970,7 @@ public class WorkflowExecutor {
         task.setCallbackAfterSeconds(taskResult.getCallbackAfterSeconds());
         task.setOutputData(taskResult.getOutputData());
         task.setSubWorkflowId(taskResult.getSubWorkflowId());
+        task.setStartDelayInSeconds(taskResult.getRetryDelaySeconds());
 
         if (task.getOutputData() != null && !task.getOutputData().isEmpty()) {
             deciderService.externalizeTaskData(task);

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -76,7 +76,7 @@ public abstract class AbstractProtoMapper {
         to.setTaskName( from.getTaskName() );
         to.setWorkflowName( from.getWorkflowName() );
         to.setReferenceName( from.getReferenceName() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -136,7 +136,7 @@ public abstract class AbstractProtoMapper {
         to.setCreated( from.getCreated() );
         to.setStatus( fromProto( from.getStatus() ) );
         to.setAction( fromProto( from.getAction() ) );
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -222,7 +222,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCorrelationId( from.getCorrelationId() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -258,7 +258,7 @@ public abstract class AbstractProtoMapper {
         EventHandler.TaskDetails to = new EventHandler.TaskDetails();
         to.setWorkflowId( from.getWorkflowId() );
         to.setTaskRefName( from.getTaskRefName() );
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -373,13 +373,13 @@ public abstract class AbstractProtoMapper {
     public RerunWorkflowRequest fromProto(RerunWorkflowRequestPb.RerunWorkflowRequest from) {
         RerunWorkflowRequest to = new RerunWorkflowRequest();
         to.setReRunFromWorkflowId( from.getReRunFromWorkflowId() );
-        Map<String, Object> workflowInputMap = new HashMap<>();
+        Map<String, Object> workflowInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getWorkflowInputMap().entrySet()) {
             workflowInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setWorkflowInput(workflowInputMap);
         to.setReRunFromTaskId( from.getReRunFromTaskId() );
-        Map<String, Object> taskInputMap = new HashMap<>();
+        Map<String, Object> taskInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskInputMap().entrySet()) {
             taskInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -390,12 +390,12 @@ public abstract class AbstractProtoMapper {
 
     public SkipTaskRequest fromProto(SkipTaskRequestPb.SkipTaskRequest from) {
         SkipTaskRequest to = new SkipTaskRequest();
-        Map<String, Object> taskInputMap = new HashMap<>();
+        Map<String, Object> taskInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskInputMap().entrySet()) {
             taskInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setTaskInput(taskInputMap);
-        Map<String, Object> taskOutputMap = new HashMap<>();
+        Map<String, Object> taskOutputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskOutputMap().entrySet()) {
             taskOutputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -441,7 +441,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCorrelationId( from.getCorrelationId() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -574,7 +574,7 @@ public abstract class AbstractProtoMapper {
         Task to = new Task();
         to.setTaskType( from.getTaskType() );
         to.setStatus( fromProto( from.getStatus() ) );
-        Map<String, Object> inputDataMap = new HashMap<>();
+        Map<String, Object> inputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputDataMap().entrySet()) {
             inputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -601,7 +601,7 @@ public abstract class AbstractProtoMapper {
         to.setReasonForIncompletion( from.getReasonForIncompletion() );
         to.setCallbackAfterSeconds( from.getCallbackAfterSeconds() );
         to.setWorkerId( from.getWorkerId() );
-        Map<String, Object> outputDataMap = new HashMap<>();
+        Map<String, Object> outputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputDataMap().entrySet()) {
             outputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -723,7 +723,7 @@ public abstract class AbstractProtoMapper {
         to.setRetryDelaySeconds( from.getRetryDelaySeconds() );
         to.setResponseTimeoutSeconds( from.getResponseTimeoutSeconds() );
         to.setConcurrentExecLimit( from.getConcurrentExecLimit() );
-        Map<String, Object> inputTemplateMap = new HashMap<>();
+        Map<String, Object> inputTemplateMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputTemplateMap().entrySet()) {
             inputTemplateMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -742,6 +742,7 @@ public abstract class AbstractProtoMapper {
         switch (from) {
             case FIXED: to = TaskDefPb.TaskDef.RetryLogic.FIXED; break;
             case EXPONENTIAL_BACKOFF: to = TaskDefPb.TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
+            case CUSTOM: to = TaskDefPb.TaskDef.RetryLogic.CUSTOM; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;
@@ -752,6 +753,7 @@ public abstract class AbstractProtoMapper {
         switch (from) {
             case FIXED: to = TaskDef.RetryLogic.FIXED; break;
             case EXPONENTIAL_BACKOFF: to = TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
+            case CUSTOM: to = TaskDef.RetryLogic.CUSTOM; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;
@@ -823,6 +825,7 @@ public abstract class AbstractProtoMapper {
         if (from.getOutputMessage() != null) {
             to.setOutputMessage( toProto( from.getOutputMessage() ) );
         }
+        to.setRetryDelaySeconds( from.getRetryDelaySeconds() );
         return to.build();
     }
 
@@ -834,7 +837,7 @@ public abstract class AbstractProtoMapper {
         to.setCallbackAfterSeconds( from.getCallbackAfterSeconds() );
         to.setWorkerId( from.getWorkerId() );
         to.setStatus( fromProto( from.getStatus() ) );
-        Map<String, Object> outputDataMap = new HashMap<>();
+        Map<String, Object> outputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputDataMap().entrySet()) {
             outputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -842,6 +845,7 @@ public abstract class AbstractProtoMapper {
         if (from.hasOutputMessage()) {
             to.setOutputMessage( fromProto( from.getOutputMessage() ) );
         }
+        to.setRetryDelaySeconds( from.getRetryDelaySeconds() );
         return to;
     }
 
@@ -1012,12 +1016,12 @@ public abstract class AbstractProtoMapper {
         to.setParentWorkflowId( from.getParentWorkflowId() );
         to.setParentWorkflowTaskId( from.getParentWorkflowTaskId() );
         to.setTasks( from.getTasksList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setInput(inputMap);
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1034,7 +1038,7 @@ public abstract class AbstractProtoMapper {
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         to.setPriority( from.getPriority() );
-        Map<String, Object> variablesMap = new HashMap<>();
+        Map<String, Object> variablesMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getVariablesMap().entrySet()) {
             variablesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1113,7 +1117,7 @@ public abstract class AbstractProtoMapper {
         to.setVersion( from.getVersion() );
         to.setTasks( from.getTasksList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
         to.setInputParameters( from.getInputParametersList().stream().collect(Collectors.toCollection(ArrayList::new)) );
-        Map<String, Object> outputParametersMap = new HashMap<>();
+        Map<String, Object> outputParametersMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputParametersMap().entrySet()) {
             outputParametersMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1125,7 +1129,7 @@ public abstract class AbstractProtoMapper {
         to.setOwnerEmail( from.getOwnerEmail() );
         to.setTimeoutPolicy( fromProto( from.getTimeoutPolicy() ) );
         to.setTimeoutSeconds( from.getTimeoutSeconds() );
-        Map<String, Object> variablesMap = new HashMap<>();
+        Map<String, Object> variablesMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getVariablesMap().entrySet()) {
             variablesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1305,7 +1309,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setTaskReferenceName( from.getTaskReferenceName() );
         to.setDescription( from.getDescription() );
-        Map<String, Object> inputParametersMap = new HashMap<>();
+        Map<String, Object> inputParametersMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputParametersMap().entrySet()) {
             inputParametersMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1315,7 +1319,7 @@ public abstract class AbstractProtoMapper {
         to.setCaseValueParam( from.getCaseValueParam() );
         to.setCaseExpression( from.getCaseExpression() );
         to.setScriptExpression( from.getScriptExpression() );
-        Map<String, List<WorkflowTask>> decisionCasesMap = new HashMap<>();
+        Map<String, List<WorkflowTask>> decisionCasesMap = new HashMap<String, List<WorkflowTask>>();
         for (Map.Entry<String, WorkflowTaskPb.WorkflowTask.WorkflowTaskList> pair : from.getDecisionCasesMap().entrySet()) {
             decisionCasesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -11,6 +11,7 @@ message TaskDef {
     enum RetryLogic {
         FIXED = 0;
         EXPONENTIAL_BACKOFF = 1;
+        CUSTOM = 2;
     }
     enum TimeoutPolicy {
         RETRY = 0;

--- a/grpc/src/main/proto/model/taskresult.proto
+++ b/grpc/src/main/proto/model/taskresult.proto
@@ -23,4 +23,5 @@ message TaskResult {
     TaskResult.Status status = 6;
     map<string, google.protobuf.Value> output_data = 7;
     google.protobuf.Any output_message = 8;
+    int32 retry_delay_seconds = 9;
 }


### PR DESCRIPTION
Pull Request type
----

 **Feature**

Changes in this PR
----
PR for Task retry delay customization. 

1. CUSTOM retry delay strategy that requires the user to specify retry delay as part of the TaskResult when a task is FAILED.
2. CUSTOM retry strategy uses the retry delay from the task definition if the worker sends 0 in the TaskResult.
3. CUSTOM retry strategy uses NO retry delay if the worker sends a negative value (<0) in the TaskResult.
