### PR TITLE
Fix amqp channel and connection creation in order to prevent "unknown delivery tag"

### DIFF
--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -146,7 +146,7 @@
             "locked": "0.122.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0"
+            "locked": "5.13.0"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14",
@@ -580,7 +580,7 @@
             "locked": "0.122.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0"
+            "locked": "5.13.0"
         },
         "com.spotify:completable-futures": {
             "locked": "0.3.3",
@@ -1082,7 +1082,7 @@
             "locked": "0.122.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0"
+            "locked": "5.13.0"
         },
         "com.sun.mail:mailapi": {
             "locked": "1.6.2",
@@ -2220,7 +2220,7 @@
             "locked": "0.122.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0"
+            "locked": "5.13.0"
         },
         "com.spotify:completable-futures": {
             "locked": "0.3.3",

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -395,14 +395,12 @@ public class AMQPObservableQueue implements ObservableQueue {
             throw new RuntimeException("Exchange type is undefined");
         }
 
-        AMQP.Exchange.DeclareOk declareOk;
         try {
-            declareOk = getOrCreateChannel().exchangeDeclarePassive(name);
+            return getOrCreateChannel().exchangeDeclare(name, type, isDurable, autoDelete, arguments);
         } catch (final IOException e) {
-            LOGGER.warn("Exchange {} of type {} might not exists", name, type, e);
-            declareOk = getOrCreateChannel().exchangeDeclare(name, type, isDurable, autoDelete, arguments);
+            LOGGER.warn("Failed to create exchange {} of type {}", name, type, e);
+            throw e;
         }
-        return declareOk;
     }
 
     private AMQP.Queue.DeclareOk getOrCreateQueue() throws IOException {
@@ -416,14 +414,12 @@ public class AMQPObservableQueue implements ObservableQueue {
             throw new RuntimeException("Queue name is undefined");
         }
 
-        AMQP.Queue.DeclareOk declareOk;
         try {
-            declareOk = getOrCreateChannel().queueDeclarePassive(name);
+            return  getOrCreateChannel().queueDeclare(name, isDurable, isExclusive, autoDelete, arguments);
         } catch (final IOException e) {
-            LOGGER.warn("Queue {} might not exists", name, e);
-            declareOk = getOrCreateChannel().queueDeclare(name, isDurable, isExclusive, autoDelete, arguments);
+             LOGGER.warn("Failed to create queue {}", name, e);
+            throw e;
         }
-        return declareOk;
     }
 
     private void closeConnection() {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -358,10 +358,13 @@ public class AMQPObservableQueue implements ObservableQueue {
         }
     }
 
-    private Channel getOrCreateChannel() {
+    private Channel getOrCreateChannel() throws IOException {
         // Return the existing channel if it was created
         if (channel != null) {
-            return channel;
+            if (channel.isOpen()) {
+                return channel;
+            }
+            throw new IOException("Channel was created but is currently closed");
         }
         // Channel creation is required
         try {

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
@@ -413,16 +413,13 @@ public class AMQPObservableQueueTest {
         runObserve(channel, observableQueue, queueName, useWorkingChannel, batchSize);
 
         if (useWorkingChannel) {
-            if (exists) {
-                verify(channel, atLeastOnce()).exchangeDeclarePassive(eq(name));
-            } else {
-                verify(channel, atLeastOnce()).exchangeDeclare(eq(name), eq(type), eq(settings.isDurable()),
+            verify(channel, atLeastOnce()).exchangeDeclare(eq(name), eq(type), eq(settings.isDurable()),
                     eq(settings.autoDelete()), eq(Collections.emptyMap()));
-                verify(channel, atLeastOnce())
+            verify(channel, atLeastOnce())
                     .queueDeclare(eq(queueName), eq(settings.isDurable()), eq(settings.isExclusive()),
-                        eq(settings.autoDelete()),
-                        anyMap());
-            }
+                            eq(settings.autoDelete()),
+                            anyMap());
+
             verify(channel, atLeastOnce()).queueBind(eq(queueName), eq(name), eq(routingKey));
         }
     }
@@ -468,16 +465,13 @@ public class AMQPObservableQueueTest {
         runObserve(channel, observableQueue, queueName, useWorkingChannel, batchSize);
 
         if (useWorkingChannel) {
-            if (exists) {
-                verify(channel, atLeastOnce()).exchangeDeclarePassive(eq(name));
-            } else {
-                verify(channel, atLeastOnce()).exchangeDeclare(eq(name), eq(type), eq(settings.isDurable()),
+            verify(channel, atLeastOnce()).exchangeDeclare(eq(name), eq(type), eq(settings.isDurable()),
                     eq(settings.autoDelete()), eq(Collections.emptyMap()));
-                verify(channel, atLeastOnce())
+            verify(channel, atLeastOnce())
                     .queueDeclare(eq(queueName), eq(settings.isDurable()), eq(settings.isExclusive()),
-                        eq(settings.autoDelete()),
-                        anyMap());
-            }
+                            eq(settings.autoDelete()),
+                            anyMap());
+
             verify(channel, atLeastOnce()).queueBind(eq(queueName), eq(name), eq(routingKey));
         }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@
  */
 ext {
     revActivation = '1.1.1'
-    revAmqpClient = '5.9.0'
+    revAmqpClient = '5.13.0'
     revAwaitility = '3.1.6'
     revAwsSdk = '1.11.86'
     revAzureStorageBlobSdk = '12.2.0'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     implementation "org.springdoc:springdoc-openapi-ui:${revOpenapi}"
 
+    implementation(group: 'com.rabbitmq', name: 'amqp-client'){ version{require "${revAmqpClient}"}}
     runtimeOnly 'io.micrometer:micrometer-registry-datadog'
 
     runtimeOnly 'com.netflix.spectator:spectator-reg-micrometer'

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -964,7 +964,7 @@
             ]
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0",
+            "locked": "5.13.0",
             "transitive": [
                 "com.netflix.conductor:conductor-contribs"
             ]
@@ -2738,7 +2738,7 @@
             ]
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0",
+            "locked": "5.13.0",
             "transitive": [
                 "com.netflix.conductor:conductor-contribs"
             ]
@@ -5223,7 +5223,7 @@
             ]
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0",
+            "locked": "5.13.0",
             "transitive": [
                 "com.netflix.conductor:conductor-contribs"
             ]

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testImplementation "org.testcontainers:elasticsearch:${revTestContainer}"
     testImplementation "org.testcontainers:mysql:${revTestContainer}"
     testImplementation "org.testcontainers:postgresql:${revTestContainer}"
+    testImplementation(group: 'com.rabbitmq', name: 'amqp-client'){ version{require "${revAmqpClient}"}}
 }
 
 test {

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -1856,7 +1856,7 @@
             ]
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.9.0",
+            "locked": "5.13.0",
             "transitive": [
                 "com.netflix.conductor:conductor-contribs"
             ]


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
After this PR amqp connection and channel will be created once instead of closing and opening channels each time there is a failure.
Upgrade amqp-client version to 5.13.0

_Describe the new behavior from this PR, and why it's needed_
Amqp connection/channel objects will be created once and amqp client will be responsible of restoring channels in case of a failure. 
After this PR Conductor will be able to acknowledge messages with delivery tags from previous channels and process those messages successfully

_Issue_ 
https://github.com/Netflix/conductor/issues/2382


Alternatives considered
----

No
