### PR TITLE
Amqp too many connections

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPConnection.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPConnection.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.queue.amqp;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rabbitmq.client.BlockedListener;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.netflix.conductor.contribs.queue.amqp.util.ConnectionType;
+import com.rabbitmq.client.Address;
+
+public class AMQPConnection {
+	
+	private static Logger logger = LoggerFactory.getLogger(AMQPConnection.class);	
+	private volatile Connection publisherConnection = null;
+	private volatile Connection subscriberConnection = null;
+	private ConnectionFactory factory = null;
+	private Address[] addresses = null;
+	private static AMQPConnection amqpConnection = null;
+	private final static String PUBLISHER = "Publisher";
+	private final static String SUBSCRIBER = "Subscriber";
+	private final static String SEPARATOR = ":";
+	Map<String, Channel> queueNameToChannel = new ConcurrentHashMap<String, Channel>();
+	
+	private AMQPConnection() {
+		
+	}
+	
+	private AMQPConnection(final ConnectionFactory factory,final Address[] address)
+	{		
+		this.factory = factory;
+		this.addresses = address;		
+	}
+	
+	public static synchronized AMQPConnection getInstance(final ConnectionFactory factory, final Address[] address)
+	{
+		if (amqpConnection == null)
+		{
+			amqpConnection = new AMQPConnection(factory,address);
+		}
+		
+		return amqpConnection;
+	}
+	
+	public Address[] getAddresses() {
+		return   addresses;
+	}
+	
+	private Connection createConnection(String connectionPrefix) {
+						
+			try {
+				Connection connection = factory.newConnection(addresses, System.getenv("HOSTNAME") + "-" + connectionPrefix);			
+				if (connection == null || !connection.isOpen()) {
+					throw new RuntimeException("Failed to open connection");
+				}
+				
+				connection.addShutdownListener(new ShutdownListener() {
+					@Override
+					public void shutdownCompleted(ShutdownSignalException cause) {
+						logger.error("Received a shutdown exception for the connection {}. reason {} cause{}",connection.getClientProvidedName(),cause.getMessage(),cause);
+						
+					}
+				});
+				
+				connection.addBlockedListener(new BlockedListener() {				
+					@Override
+					public void handleUnblocked() throws IOException {
+						logger.info("Connection {} is unblocked",connection.getClientProvidedName());					
+					}
+					
+					@Override
+					public void handleBlocked(String reason) throws IOException {
+						logger.error("Connection {} is blocked. reason: {}",connection.getClientProvidedName(),reason);					
+					}
+				});
+				
+				return connection;			
+			} catch (final IOException e) {			
+				final String error = "IO error while connecting to "
+						+ Arrays.stream(addresses).map(address -> address.toString()).collect(Collectors.joining(","));
+				logger.error(error, e);
+				throw new RuntimeException(error, e);
+			} catch (final TimeoutException e) {			
+				final String error = "Timeout while connecting to "
+						+ Arrays.stream(addresses).map(address -> address.toString()).collect(Collectors.joining(","));
+				logger.error(error, e);
+				throw new RuntimeException(error, e);
+			}
+		}
+	
+	public Channel getOrCreateChannel(ConnectionType connectionType, String queueOrExchangeName)
+	{
+		switch (connectionType) {
+		case SUBSCRIBER:
+			return getOrCreateSubscriberChannel(queueOrExchangeName);
+
+		case PUBLISHER:
+			return getOrCreatePublisherChannel(queueOrExchangeName);
+		default:
+			return null;
+		}
+	}
+	
+	private  Channel getOrCreateSubscriberChannel(String queueOrExchangeName) {		
+		
+		String prefix = SUBSCRIBER + SEPARATOR;
+		// Return the existing channel if it's still opened
+		Channel subscriberChannel = queueNameToChannel.get(prefix+ queueOrExchangeName);
+		if (subscriberChannel != null ) {
+			return subscriberChannel;
+		}
+		// Channel creation is required
+		try {
+			synchronized (this) {					
+				if(subscriberConnection == null) {
+					subscriberConnection = createConnection(SUBSCRIBER);
+				}
+				logger.debug("Creating a channel for subscriber");
+				subscriberChannel = subscriberConnection.createChannel();
+				subscriberChannel.addShutdownListener(cause -> {				
+					logger.error("subscription Channel has been shutdown: {}", cause.getMessage(), cause);
+				});
+				if (subscriberChannel == null || !subscriberChannel.isOpen()) {
+					throw new RuntimeException("Fail to open  subscription channel");
+				}
+				queueNameToChannel.putIfAbsent(prefix+queueOrExchangeName, subscriberChannel);
+			}
+		} catch (final IOException e) {
+			throw new RuntimeException("Cannot open subscription channel on "
+					+ Arrays.stream(addresses).map(address -> address.toString()).collect(Collectors.joining(",")), e);
+		}
+		
+		
+		return subscriberChannel;
+	}
+	
+	private Channel getOrCreatePublisherChannel(String queueOrExchangeName) {		
+		
+		String prefix = PUBLISHER + SEPARATOR;
+		Channel publisherChannel = queueNameToChannel.get(prefix +queueOrExchangeName);
+		if (publisherChannel != null ) {
+			return publisherChannel;
+		}
+		// Channel creation is required
+		try {	
+						
+			synchronized (this) {
+				if (publisherConnection == null) {
+					publisherConnection = createConnection(PUBLISHER);
+				}
+				
+				logger.debug("Creating a channel for publisher");
+				publisherChannel = publisherConnection.createChannel();
+				publisherChannel.addShutdownListener(cause -> {				
+					logger.error("Publish Channel has been shutdown: {}", cause.getMessage(), cause);
+				});
+				
+				if (publisherChannel == null || !publisherChannel.isOpen()) {
+					throw new RuntimeException("Fail to open publish channel");
+				}				
+				queueNameToChannel.putIfAbsent(prefix + queueOrExchangeName, publisherChannel);
+			}				
+			
+						
+		} catch (final IOException e) {
+			throw new RuntimeException("Cannot open channel on "
+					+ Arrays.stream(addresses).map(address -> address.toString()).collect(Collectors.joining(",")), e);
+		}
+		return publisherChannel;
+	}
+	
+	public void close() {
+		logger.info("Closing all connections and channels");
+		try {
+			for (Map.Entry<String, Channel> entry : queueNameToChannel.entrySet()) {
+				closeChannel(entry.getValue());
+			}
+			closeConnection(publisherConnection);
+			closeConnection(subscriberConnection);
+		} finally {
+			queueNameToChannel.clear();
+			publisherConnection = null;
+			subscriberConnection = null;
+		}
+	}
+	
+	
+	private void closeConnection(Connection connection) {
+		if (connection == null) {
+			logger.warn("Connection is null. Do not close it");
+		} else {
+			try {
+				connection.close();
+			} catch (Exception e) {
+				logger.warn("Fail to close connection: {}", e.getMessage(), e);
+			}
+		}
+	}
+	
+
+	private void closeChannel(Channel channel) {
+		if (channel == null) {
+			logger.warn("Channel is null. Do not close it");
+		} else {		
+			try {				
+				channel.close();
+			} catch (Exception e) {
+				logger.warn("Fail to close channel: {}", e.getMessage(), e);
+			}
+		}				
+	}
+	
+	
+
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Maps;
 import com.netflix.conductor.contribs.queue.amqp.config.AMQPEventQueueProperties;
 import com.netflix.conductor.contribs.queue.amqp.util.AMQPConstants;
 import com.netflix.conductor.contribs.queue.amqp.util.AMQPSettings;
+import com.netflix.conductor.contribs.queue.amqp.util.ConnectionType;
 import com.netflix.conductor.core.LifecycleAwareComponent;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
@@ -60,6 +61,7 @@ public class AMQPObservableQueue implements ObservableQueue {
     private final int batchSize;
     private final boolean useExchange;
     private int pollTimeInMS;
+    private AMQPConnection amqpConnection;
 
     private final ConnectionFactory factory;
     private Connection connection;
@@ -90,34 +92,10 @@ public class AMQPObservableQueue implements ObservableQueue {
         this.useExchange = useExchange;
         this.settings = settings;
         this.batchSize = batchSize;
+        this.amqpConnection = AMQPConnection.getInstance(factory, addresses);
         this.setPollTimeInMS(pollTimeInMS);
+        		
     }
-
-    private void connect() {
-        if (connection != null) {
-            return;
-        }
-        try {
-            connection = factory.newConnection(addresses);
-
-            if (connection == null || !connection.isOpen()) {
-                throw new RuntimeException("Failed to open connection");
-            }
-        } catch (final IOException e) {
-
-            final String error = "IO error while connecting to "
-                    + Arrays.stream(addresses).map(Address::toString).collect(Collectors.joining(","));
-            LOGGER.error(error, e);
-            throw new RuntimeException(error, e);
-        } catch (final TimeoutException e) {
-
-            final String error = "Timeout while connecting to "
-                    + Arrays.stream(addresses).map(Address::toString).collect(Collectors.joining(","));
-            LOGGER.error(error, e);
-            throw new RuntimeException(error, e);
-        }
-    }
-
     @Override
     public Observable<Message> observe() {
         receiveMessages();
@@ -176,7 +154,7 @@ public class AMQPObservableQueue implements ObservableQueue {
     }
 
     public Address[] getAddresses() {
-        return addresses;
+        return amqpConnection.getAddresses();
     }
 
     @Override
@@ -185,7 +163,7 @@ public class AMQPObservableQueue implements ObservableQueue {
         for (final Message message : messages) {
             try {
                 LOGGER.info("ACK message with delivery tag {}", message.getReceipt());
-                getOrCreateChannel().basicAck(Long.parseLong(message.getReceipt()), false);
+                amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER,getSettings().getQueueOrExchangeName()).basicAck(Long.parseLong(message.getReceipt()), false);
                 // Message ACKed
                 processedDeliveryTags.add(message.getReceipt());
             } catch (final IOException e) {
@@ -207,7 +185,7 @@ public class AMQPObservableQueue implements ObservableQueue {
     private void publishMessage(Message message, String exchange, String routingKey) {
         try {
             final String payload = message.getPayload();
-            getOrCreateChannel().basicPublish(exchange, routingKey, buildBasicProperties(message, settings),
+            amqpConnection.getOrCreateChannel(ConnectionType.PUBLISHER,getSettings().getQueueOrExchangeName()).basicPublish(exchange, routingKey, buildBasicProperties(message, settings),
                 payload.getBytes(settings.getContentEncoding()));
             LOGGER.info(String.format("Published message to %s: %s", exchange, payload));
         } catch (Exception ex) {
@@ -222,13 +200,13 @@ public class AMQPObservableQueue implements ObservableQueue {
             final String exchange, routingKey;
             if (useExchange) {
                 // Use exchange + routing key for publishing
-                getOrCreateExchange(settings.getQueueOrExchangeName(), settings.getExchangeType(), settings.isDurable(),
+                getOrCreateExchange(ConnectionType.PUBLISHER,settings.getQueueOrExchangeName(), settings.getExchangeType(), settings.isDurable(),
                     settings.autoDelete(), settings.getArguments());
                 exchange = settings.getQueueOrExchangeName();
                 routingKey = settings.getRoutingKey();
             } else {
                 // Use queue for publishing
-                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(settings.getQueueOrExchangeName(),
+                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(ConnectionType.PUBLISHER,settings.getQueueOrExchangeName(),
                     settings.isDurable(), settings.isExclusive(), settings.autoDelete(), settings.getArguments());
                 exchange = StringUtils.EMPTY; // Empty exchange name for queue
                 routingKey = declareOk.getQueue(); // Routing name is the name of queue
@@ -250,7 +228,7 @@ public class AMQPObservableQueue implements ObservableQueue {
     @Override
     public long size() {
         try {
-            return getOrCreateChannel().messageCount(settings.getQueueOrExchangeName());
+            return amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER,getSettings().getQueueOrExchangeName()).messageCount(settings.getQueueOrExchangeName());
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
@@ -258,8 +236,7 @@ public class AMQPObservableQueue implements ObservableQueue {
 
     @Override
     public void close() {
-        closeChannel();
-        closeConnection();
+        amqpConnection.close();
     }
 
     @Override
@@ -358,38 +335,13 @@ public class AMQPObservableQueue implements ObservableQueue {
         }
     }
 
-    private Channel getOrCreateChannel() throws IOException {
-        // Return the existing channel if it was created
-        if (channel != null) {
-            if (channel.isOpen()) {
-                return channel;
-            }
-            throw new IOException("Channel was created but is currently closed");
-        }
-        // Channel creation is required
-        try {
-            connect();
-            channel = connection.createChannel();
-            channel.addShutdownListener(cause -> {
-                LOGGER.error("Channel has been shutdown: {}", cause.getMessage(), cause);
-            });
-        } catch (final IOException e) {
-            throw new RuntimeException("Cannot open channel on "
-                + Arrays.stream(addresses).map(address -> address.toString()).collect(Collectors.joining(",")), e);
-        }
-
-        if (channel == null) {
-            throw new RuntimeException("Fail to open channel");
-        }
-        return channel;
-    }
-
-    private AMQP.Exchange.DeclareOk getOrCreateExchange() throws IOException {
-        return getOrCreateExchange(settings.getQueueOrExchangeName(), settings.getExchangeType(), settings.isDurable(),
+    
+    private AMQP.Exchange.DeclareOk getOrCreateExchange(ConnectionType connectionType) throws IOException {
+        return getOrCreateExchange(connectionType, settings.getQueueOrExchangeName(), settings.getExchangeType(), settings.isDurable(),
             settings.autoDelete(), settings.getArguments());
     }
 
-    private AMQP.Exchange.DeclareOk getOrCreateExchange(final String name, final String type, final boolean isDurable,
+    private AMQP.Exchange.DeclareOk getOrCreateExchange(ConnectionType connectionType, String name, final String type, final boolean isDurable,
         final boolean autoDelete, final Map<String, Object> arguments) throws IOException {
         if (StringUtils.isEmpty(name)) {
             throw new RuntimeException("Exchange name is undefined");
@@ -399,73 +351,29 @@ public class AMQPObservableQueue implements ObservableQueue {
         }
 
         try {
-            return getOrCreateChannel().exchangeDeclare(name, type, isDurable, autoDelete, arguments);
+            return amqpConnection.getOrCreateChannel(connectionType,getSettings().getQueueOrExchangeName()).exchangeDeclare(name, type, isDurable, autoDelete, arguments);
         } catch (final IOException e) {
             LOGGER.warn("Failed to create exchange {} of type {}", name, type, e);
             throw e;
         }
     }
 
-    private AMQP.Queue.DeclareOk getOrCreateQueue() throws IOException {
-        return getOrCreateQueue(settings.getQueueOrExchangeName(), settings.isDurable(), settings.isExclusive(),
+    private AMQP.Queue.DeclareOk getOrCreateQueue(ConnectionType connectionType) throws IOException {
+        return getOrCreateQueue(connectionType, settings.getQueueOrExchangeName(), settings.isDurable(), settings.isExclusive(),
             settings.autoDelete(), settings.getArguments());
     }
 
-    private AMQP.Queue.DeclareOk getOrCreateQueue(final String name, final boolean isDurable, final boolean isExclusive,
+    private AMQP.Queue.DeclareOk getOrCreateQueue(ConnectionType connectionType, final String name, final boolean isDurable, final boolean isExclusive,
         final boolean autoDelete, final Map<String, Object> arguments) throws IOException {
         if (StringUtils.isEmpty(name)) {
             throw new RuntimeException("Queue name is undefined");
         }
 
         try {
-            return  getOrCreateChannel().queueDeclare(name, isDurable, isExclusive, autoDelete, arguments);
+            return  amqpConnection.getOrCreateChannel(connectionType,getSettings().getQueueOrExchangeName()).queueDeclare(name, isDurable, isExclusive, autoDelete, arguments);
         } catch (final IOException e) {
              LOGGER.warn("Failed to create queue {}", name, e);
             throw e;
-        }
-    }
-
-    private void closeConnection() {
-        if (connection == null) {
-            LOGGER.warn("Connection is null. Do not close it");
-        } else {
-            try {
-                if (connection.isOpen()) {
-                    try {
-                        if (LOGGER.isInfoEnabled()) {
-                            LOGGER.info("Close AMQP connection");
-                        }
-                        connection.close();
-                    } catch (final IOException e) {
-                        LOGGER.warn("Fail to close connection: {}", e.getMessage(), e);
-                    }
-                }
-            } finally {
-                connection = null;
-            }
-        }
-    }
-
-    private void closeChannel() {
-        if (channel == null) {
-            LOGGER.warn("Channel is null. Do not close it");
-        } else {
-            try {
-                if (channel.isOpen()) {
-                    try {
-                        if (LOGGER.isInfoEnabled()) {
-                            LOGGER.info("Close AMQP channel");
-                        }
-                        channel.close();
-                    } catch (final TimeoutException e) {
-                        LOGGER.warn("Timeout while closing channel: {}", e.getMessage(), e);
-                    } catch (final IOException e) {
-                        LOGGER.warn("Fail to close channel: {}", e.getMessage(), e);
-                    }
-                }
-            } finally {
-                channel = null;
-            }
         }
     }
 
@@ -482,7 +390,7 @@ public class AMQPObservableQueue implements ObservableQueue {
 
     private void receiveMessagesFromQueue(String queueName) throws Exception {
         int nb = 0;
-        Consumer consumer = new DefaultConsumer(channel) {
+        Consumer consumer = new DefaultConsumer(amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER,getSettings().getQueueOrExchangeName())) {
 
             @Override
             public void handleDelivery(final String consumerTag, final Envelope envelope,
@@ -504,19 +412,24 @@ public class AMQPObservableQueue implements ObservableQueue {
                     //
                 }
             }
+            
+            
+            public void handleCancel(String consumerTag) throws IOException{
+            	LOGGER.error("Recieved a consumer cancel notification for subscriber. Will monitor and make changes");										
+			}
         };
 
-        getOrCreateChannel().basicConsume(queueName, false, consumer);
+        amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER,getSettings().getQueueOrExchangeName()).basicConsume(queueName, false, consumer);
         Monitors.recordEventQueueMessagesProcessed(getType(), queueName, messages.size());
     }
 
     protected void receiveMessages() {
         try {
-            getOrCreateChannel().basicQos(batchSize);
+        	amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER,getSettings().getQueueOrExchangeName()).basicQos(batchSize);
             String queueName;
             if (useExchange) {
                 // Consume messages from an exchange
-                getOrCreateExchange();
+            	getOrCreateExchange(ConnectionType.SUBSCRIBER);
                 /*
                  * Create queue if not present based on the settings provided in the queue URI or configuration properties.
                  * Sample URI format: amqp-exchange:myExchange?exchangeType=topic&routingKey=myRoutingKey&exclusive=false&autoDelete=false&durable=true
@@ -524,16 +437,16 @@ public class AMQPObservableQueue implements ObservableQueue {
                  * The same settings are currently used during creation of exchange as well as queue.
                  * TODO: This can be enhanced further to get the settings separately for exchange and queue from the URI
                  */
-                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(
+                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(ConnectionType.SUBSCRIBER,
                     String.format("bound_to_%s", settings.getQueueOrExchangeName()), settings.isDurable(),
                     settings.isExclusive(), settings.autoDelete(),
                     Maps.newHashMap());
                 // Bind the declared queue to exchange
                 queueName = declareOk.getQueue();
-                getOrCreateChannel().queueBind(queueName, settings.getQueueOrExchangeName(), settings.getRoutingKey());
+                amqpConnection.getOrCreateChannel(ConnectionType.SUBSCRIBER, getSettings().getQueueOrExchangeName()).queueBind(queueName, settings.getQueueOrExchangeName(), settings.getRoutingKey());
             } else {
                 // Consume messages from a queue
-                queueName = getOrCreateQueue().getQueue();
+                queueName = getOrCreateQueue(ConnectionType.SUBSCRIBER).getQueue();
             }
             // Consume messages
             LOGGER.info("Consuming from queue {}", queueName);

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -62,11 +62,7 @@ public class AMQPObservableQueue implements ObservableQueue {
     private final boolean useExchange;
     private int pollTimeInMS;
     private AMQPConnection amqpConnection;
-
-    private final ConnectionFactory factory;
-    private Connection connection;
-    private Channel channel;
-    private final Address[] addresses;
+    
     protected LinkedBlockingQueue<Message> messages = new LinkedBlockingQueue<>();
     private volatile boolean running;
 
@@ -87,8 +83,6 @@ public class AMQPObservableQueue implements ObservableQueue {
         if (pollTimeInMS <= 0) {
             throw new IllegalArgumentException("Poll time must be greater than 0 ms");
         }
-        this.factory = factory;
-        this.addresses = addresses;
         this.useExchange = useExchange;
         this.settings = settings;
         this.batchSize = batchSize;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/ConnectionType.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/ConnectionType.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.queue.amqp.util;
+
+public enum ConnectionType {
+	PUBLISHER,
+	SUBSCRIBER
+}


### PR DESCRIPTION
Pull Request type
----

- [X ] Bugfix

Changes in this PR
----
RabbitMQ Java Client has the inbuilt ability to recover in case of a connection and channel error. But the conductor code opens up a new channel instead of waiting for it to recover. This leads to acknowledgment of Messages in another channel.  The PR removes the code to recover the channel.

Conductor creates one connection per queue. This can be optimized to one connection for publishing and one connection for subscribing. We can create channels per queue.

Now the connections created by the conductor will have the name of the host. It helps to view the connection name in the RabbitMQ interface.

PR implements callbacks in case of channels getting blocked and consumer cancellations. This needs to be further enhanced.

What's tested:

RabbitMQ is restarted and verified if the conductor is able to send the messages once the connection is recovered by RabbitMQ java client

Issue #
