### PR TITLE
fix serverAndUI docker setup script.

### DIFF
--- a/docker/serverAndUI/bin/startup.sh
+++ b/docker/serverAndUI/bin/startup.sh
@@ -41,4 +41,4 @@ if [ -z "$CONFIG_PROP" ];
     export config_file=/app/config/$CONFIG_PROP
 fi
 
-nohup java -jar -DCONDUCTOR_CONFIG_FILE=$config_file conductor-server-*-all.jar 1>&2 > /app/logs/server.log
+nohup java -jar -DCONDUCTOR_CONFIG_FILE=$config_file conductor-server-*-boot.jar 1>&2 > /app/logs/server.log


### PR DESCRIPTION
The server jar file name was wrong and has been corrected.

Pull Request type
----

- [x] Bugfix
- [ ]  Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

In the [Dockerfile](https://github.com/Netflix/conductor/blob/main/docker/serverAndUI/Dockerfile), the jar file is retrieved as follows.

```
# Get Server Jar
&& mv ./server/build/libs/conductor-server-*-boot.jar /app/libs/ \
```

However, in the [shell script](https://github.com/Netflix/conductor/blob/main/docker/serverAndUI/bin/startup.sh), the server was started as follows.

```
nohup java -jar -DCONDUCTOR_CONFIG_FILE=$config_file conductor-server-*-all.jar 1>&2 > /app/logs/server.log
```

Therefore, I changed part of the file name from `all` to `boot`.



