### PR TITLE
Corrected the branch name in the document

### DIFF
--- a/docs/docs/gettingstarted/basicconcepts.md
+++ b/docs/docs/gettingstarted/basicconcepts.md
@@ -28,7 +28,7 @@ System tasks are executed within the JVM of the Conductor server and managed by 
 See [Systems tasks](../../configuration/systask) for list of available Task types, and instructions for using them.
 
 !!! Note
-	Conductor provides an API to create user defined tasks that are executed in the same JVM as the engine.	See [WorkflowSystemTask](https://github.com/Netflix/conductor/blob/dev/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java) interface for details.
+	Conductor provides an API to create user defined tasks that are executed in the same JVM as the engine.	See [WorkflowSystemTask](https://github.com/Netflix/conductor/blob/main/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java) interface for details.
 
 ## Worker Tasks
 Worker tasks are implemented by your application(s) and run in a separate environment from Conductor. The worker tasks can be implemented in any language.  These tasks talk to Conductor server via REST/gRPC to poll for tasks and update its status after execution.

--- a/docs/docs/gettingstarted/client.md
+++ b/docs/docs/gettingstarted/client.md
@@ -14,7 +14,7 @@ Conductor provides the following java clients to interact with the various APIs
 #### Worker
 Conductor provides an automated framework to poll for tasks, manage the execution thread and update the status of the execution back to the server.
 
-Implement the [Worker](https://github.com/Netflix/conductor/blob/dev/client/src/main/java/com/netflix/conductor/client/worker/Worker.java) interface to execute the task.
+Implement the [Worker](https://github.com/Netflix/conductor/blob/main/client/src/main/java/com/netflix/conductor/client/worker/Worker.java) interface to execute the task.
 
 #### TaskRunnerConfigurer  
 The TaskRunnerConfigurer can be used to register the worker(s) and initialize the polling loop.  
@@ -57,14 +57,14 @@ Further, these properties can be set either by Worker implementation or by setti
 
 **Examples**
 
-* [Sample Worker Implementation](https://github.com/Netflix/conductor/blob/dev/client/src/test/java/com/netflix/conductor/client/sample/SampleWorker.java)
-* [Example](https://github.com/Netflix/conductor/blob/dev/client/src/test/java/com/netflix/conductor/client/sample/Main.java)
+* [Sample Worker Implementation](https://github.com/Netflix/conductor/blob/main/client/src/test/java/com/netflix/conductor/client/sample/SampleWorker.java)
+* [Example](https://github.com/Netflix/conductor/blob/main/client/src/test/java/com/netflix/conductor/client/sample/Main.java)
 
 
 ## Python
-[https://github.com/Netflix/conductor/tree/dev/client/python](https://github.com/Netflix/conductor/tree/dev/client/python)
+[https://github.com/Netflix/conductor/tree/main/client/python](https://github.com/Netflix/conductor/tree/main/client/python)
 
-Follow the example as documented in the readme or take a look at [kitchensink_workers.py](https://github.com/Netflix/conductor/blob/dev/client/python/kitchensink_workers.py)
+Follow the example as documented in the readme or take a look at [kitchensink_workers.py](https://github.com/Netflix/conductor/blob/main/client/python/kitchensink_workers.py)
 
 !!!warning
 	Python client is a community contribution. We encourage you to test it out and let us know the feedback. Pull Requests with fixes or enhancements are welcomed!

--- a/docs/docs/gettingstarted/client.md
+++ b/docs/docs/gettingstarted/client.md
@@ -62,9 +62,9 @@ Further, these properties can be set either by Worker implementation or by setti
 
 
 ## Python
-[https://github.com/Netflix/conductor/tree/main/client/python](https://github.com/Netflix/conductor/tree/main/client/python)
+[https://github.com/Netflix/conductor/tree/main/polyglot-clients/python](https://github.com/Netflix/conductor/tree/main/polyglot-clients/python)
 
-Follow the example as documented in the readme or take a look at [kitchensink_workers.py](https://github.com/Netflix/conductor/blob/main/client/python/kitchensink_workers.py)
+Follow the example as documented in the readme or take a look at [kitchensink_workers.py](https://github.com/Netflix/conductor/blob/main/polyglot-clients/python/kitchensink_workers.py)
 
 !!!warning
 	Python client is a community contribution. We encourage you to test it out and let us know the feedback. Pull Requests with fixes or enhancements are welcomed!

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Conductor
 repo_url: https://github.com/Netflix/conductor
-edit_uri: edit/dev/docs/docs/
+edit_uri: edit/main/docs/docs/
 strict: true
 
 nav:


### PR DESCRIPTION
Changed the branch name from `dev` to `main` for links to files in the documentation.

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): fix document

Changes in this PR
----

Fixed a broken link to each GitHub file in the documentation due to a branch name change.
Changed the branch name from `dev` to `main`, and fixed the python client path.

Alternatives considered
----

The following command was executed to fix the problem. (macOS)

```shell
% find ./docs -type f | xargs grep '/dev/'
./docs/mkdocs.yml:edit_uri: edit/dev/docs/docs/
./docs/docs/gettingstarted/basicconcepts.md:	Conductor provides an API to create user defined tasks that are executed in the same JVM as the engine.	See [WorkflowSystemTask](https://github.com/Netflix/conductor/blob/dev/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java) interface for details.
./docs/docs/gettingstarted/client.md:Implement the [Worker](https://github.com/Netflix/conductor/blob/dev/client/src/main/java/com/netflix/conductor/client/worker/Worker.java) interface to execute the task.
./docs/docs/gettingstarted/client.md:* [Sample Worker Implementation](https://github.com/Netflix/conductor/blob/dev/client/src/test/java/com/netflix/conductor/client/sample/SampleWorker.java)
./docs/docs/gettingstarted/client.md:* [Example](https://github.com/Netflix/conductor/blob/dev/client/src/test/java/com/netflix/conductor/client/sample/Main.java)
./docs/docs/gettingstarted/client.md:[https://github.com/Netflix/conductor/tree/dev/client/python](https://github.com/Netflix/conductor/tree/dev/client/python)
./docs/docs/gettingstarted/client.md:Follow the example as documented in the readme or take a look at [kitchensink_workers.py](https://github.com/Netflix/conductor/blob/dev/client/python/kitchensink_workers.py)

% find ./docs -name "*.md" -type f | xargs sed -i '' 's|/dev/|/main/|g'
% find ./docs -name "*.yml" -type f | xargs sed -i '' 's|/dev/|/main/|g'

% find ./docs -name "*.md" -type f | xargs sed -i '' 's|client/python|polyglot-clients/python|g'
```
