### PR TITLE
feat: Add inputTemplate support to workflow metadata

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -302,9 +302,8 @@ public class WorkflowDef extends Auditable {
         return inputTemplate;
     }
 
-    public WorkflowDef setInputTemplate(Map<String, Object> inputTemplate) {
+    public void setInputTemplate(Map<String, Object> inputTemplate) {
         this.inputTemplate = inputTemplate;
-        return this;
     }
 
     public String key() {

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -93,6 +93,9 @@ public class WorkflowDef extends Auditable {
     @ProtoField(id = 14)
     private Map<String, Object> variables = new HashMap<>();
 
+    @ProtoField(id = 15)
+    private Map<String, Object> inputTemplate = new HashMap<>();
+
     /**
      * @return the name
      */
@@ -293,6 +296,15 @@ public class WorkflowDef extends Auditable {
      */
     public void setVariables(Map<String, Object> variables) {
         this.variables = variables;
+    }
+
+    public Map<String, Object> getInputTemplate() {
+        return inputTemplate;
+    }
+
+    public WorkflowDef setInputTemplate(Map<String, Object> inputTemplate) {
+        this.inputTemplate = inputTemplate;
+        return this;
     }
 
     public String key() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -404,7 +404,8 @@ public class WorkflowExecutor {
         workflow.setVariables(workflowDefinition.getVariables());
 
         if (workflowInput != null && !workflowInput.isEmpty()) {
-            workflow.setInput(workflowInput);
+            Map<String, Object> parsedInput = parametersUtils.getWorkflowInput(workflowDefinition, workflowInput);
+            workflow.setInput(parsedInput);
             deciderService.externalizeWorkflowData(workflow);
         } else {
             workflow.setExternalInputPayloadStoragePath(externalInputPayloadStoragePath);

--- a/core/src/main/java/com/netflix/conductor/core/utils/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ParametersUtils.java
@@ -21,6 +21,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.utils.EnvUtils;
 import com.netflix.conductor.common.utils.TaskUtils;
@@ -279,5 +280,12 @@ public class ParametersUtils {
             }
         });
         return input;
+    }
+
+    public Map<String, Object> getWorkflowInput (WorkflowDef workflowDef, Map<String, Object> inputParams) {
+        if (workflowDef != null && workflowDef.getInputTemplate() != null) {
+            clone(workflowDef.getInputTemplate()).forEach(inputParams::putIfAbsent);
+        }
+        return inputParams;
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
@@ -15,6 +15,7 @@ package com.netflix.conductor.core.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -279,5 +280,34 @@ public class ParametersUtilsTest {
         assertEquals("${someString}", inputList.get(0));
         assertEquals("${someNumber}", inputList.get(1));
         assertEquals("${someString} $${someNumber}", inputList.get(2));
+    }
+
+    @Test
+    public void getWorkflowInputHandlesNullInputTemplate () {
+        WorkflowDef workflowDef = new WorkflowDef();
+        Map<String, Object> inputParams = Map.of("key", "value");
+        Map<String, Object> workflowInput = parametersUtils.getWorkflowInput(workflowDef, inputParams);
+        assertEquals("value", workflowInput.get("key"));
+    }
+
+    @Test
+    public void getWorkflowInputFillsInTemplatedFields () {
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setInputTemplate(Map.of("other_key", "other_value"));
+        Map<String, Object> inputParams = new HashMap<>(Map.of("key", "value"));
+        Map<String, Object> workflowInput = parametersUtils.getWorkflowInput(workflowDef, inputParams);
+        assertEquals("value", workflowInput.get("key"));
+        assertEquals("other_value", workflowInput.get("other_key"));
+
+    }
+
+    @Test
+    public void getWorkflowInputPreservesExistingFieldsIfPopulated () {
+        WorkflowDef workflowDef = new WorkflowDef();
+        String keyName = "key";
+        workflowDef.setInputTemplate(Map.of(keyName, "templated_value"));
+        Map<String, Object> inputParams = new HashMap<>(Map.of(keyName, "supplied_value"));
+        Map<String, Object> workflowInput = parametersUtils.getWorkflowInput(workflowDef, inputParams);
+        assertEquals("supplied_value", workflowInput.get(keyName));
     }
 }

--- a/docs/docs/configuration/workflowdef.md
+++ b/docs/docs/configuration/workflowdef.md
@@ -42,6 +42,7 @@ Workflows are defined using a JSON based DSL.
 |version|Numeric field used to identify the version of the schema.  Use incrementing numbers|When starting a workflow execution, if not specified, the definition with highest version is used|
 |tasks|An array of task definitions as described below.||
 |inputParameters|List of input parameters. Used for documenting the required inputs to workflow|optional|
+|inputTemplate|Default input values. See [Using inputTemplate](#using-inputtemplate)|optional|
 |outputParameters|JSON template used to generate the output of the workflow|If not specified, the output is defined as the output of the _last_ executed task|
 |failureWorkflow|String; Workflow to be run on current Workflow failure. Useful for cleanup or post actions on failure.|optional|
 |schemaVersion|Current Conductor Schema version. schemaVersion 1 is discontinued.|Must be 2|
@@ -158,6 +159,19 @@ When scheduling the task, Conductor will merge the values from workflow input an
   }
 }
 ```
+
+#### Using inputTemplate
+
+* `inputTemplate` allows to define default values, which can be overridden by values provided in Workflow.
+* Eg: In your Workflow Definition, you can define your inputTemplate as:
+
+```json
+"inputTemplate": {
+    "url": "https://some_url:7004"
+}
+```
+
+And `url` would be `https://some_url:7004 if no `url` was provided as input to your workflow.
 
 ### Workflow notifications
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -76,7 +76,7 @@ public abstract class AbstractProtoMapper {
         to.setTaskName( from.getTaskName() );
         to.setWorkflowName( from.getWorkflowName() );
         to.setReferenceName( from.getReferenceName() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -136,7 +136,7 @@ public abstract class AbstractProtoMapper {
         to.setCreated( from.getCreated() );
         to.setStatus( fromProto( from.getStatus() ) );
         to.setAction( fromProto( from.getAction() ) );
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -226,7 +226,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCorrelationId( from.getCorrelationId() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -262,7 +262,7 @@ public abstract class AbstractProtoMapper {
         EventHandler.TaskDetails to = new EventHandler.TaskDetails();
         to.setWorkflowId( from.getWorkflowId() );
         to.setTaskRefName( from.getTaskRefName() );
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -377,13 +377,13 @@ public abstract class AbstractProtoMapper {
     public RerunWorkflowRequest fromProto(RerunWorkflowRequestPb.RerunWorkflowRequest from) {
         RerunWorkflowRequest to = new RerunWorkflowRequest();
         to.setReRunFromWorkflowId( from.getReRunFromWorkflowId() );
-        Map<String, Object> workflowInputMap = new HashMap<>();
+        Map<String, Object> workflowInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getWorkflowInputMap().entrySet()) {
             workflowInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setWorkflowInput(workflowInputMap);
         to.setReRunFromTaskId( from.getReRunFromTaskId() );
-        Map<String, Object> taskInputMap = new HashMap<>();
+        Map<String, Object> taskInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskInputMap().entrySet()) {
             taskInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -394,12 +394,12 @@ public abstract class AbstractProtoMapper {
 
     public SkipTaskRequest fromProto(SkipTaskRequestPb.SkipTaskRequest from) {
         SkipTaskRequest to = new SkipTaskRequest();
-        Map<String, Object> taskInputMap = new HashMap<>();
+        Map<String, Object> taskInputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskInputMap().entrySet()) {
             taskInputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setTaskInput(taskInputMap);
-        Map<String, Object> taskOutputMap = new HashMap<>();
+        Map<String, Object> taskOutputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getTaskOutputMap().entrySet()) {
             taskOutputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -445,7 +445,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCorrelationId( from.getCorrelationId() );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -578,7 +578,7 @@ public abstract class AbstractProtoMapper {
         Task to = new Task();
         to.setTaskType( from.getTaskType() );
         to.setStatus( fromProto( from.getStatus() ) );
-        Map<String, Object> inputDataMap = new HashMap<>();
+        Map<String, Object> inputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputDataMap().entrySet()) {
             inputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -605,7 +605,7 @@ public abstract class AbstractProtoMapper {
         to.setReasonForIncompletion( from.getReasonForIncompletion() );
         to.setCallbackAfterSeconds( from.getCallbackAfterSeconds() );
         to.setWorkerId( from.getWorkerId() );
-        Map<String, Object> outputDataMap = new HashMap<>();
+        Map<String, Object> outputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputDataMap().entrySet()) {
             outputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -727,7 +727,7 @@ public abstract class AbstractProtoMapper {
         to.setRetryDelaySeconds( from.getRetryDelaySeconds() );
         to.setResponseTimeoutSeconds( from.getResponseTimeoutSeconds() );
         to.setConcurrentExecLimit( from.getConcurrentExecLimit() );
-        Map<String, Object> inputTemplateMap = new HashMap<>();
+        Map<String, Object> inputTemplateMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputTemplateMap().entrySet()) {
             inputTemplateMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -838,7 +838,7 @@ public abstract class AbstractProtoMapper {
         to.setCallbackAfterSeconds( from.getCallbackAfterSeconds() );
         to.setWorkerId( from.getWorkerId() );
         to.setStatus( fromProto( from.getStatus() ) );
-        Map<String, Object> outputDataMap = new HashMap<>();
+        Map<String, Object> outputDataMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputDataMap().entrySet()) {
             outputDataMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1016,12 +1016,12 @@ public abstract class AbstractProtoMapper {
         to.setParentWorkflowId( from.getParentWorkflowId() );
         to.setParentWorkflowTaskId( from.getParentWorkflowTaskId() );
         to.setTasks( from.getTasksList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
-        Map<String, Object> inputMap = new HashMap<>();
+        Map<String, Object> inputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputMap().entrySet()) {
             inputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setInput(inputMap);
-        Map<String, Object> outputMap = new HashMap<>();
+        Map<String, Object> outputMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputMap().entrySet()) {
             outputMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1038,7 +1038,7 @@ public abstract class AbstractProtoMapper {
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         to.setPriority( from.getPriority() );
-        Map<String, Object> variablesMap = new HashMap<>();
+        Map<String, Object> variablesMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getVariablesMap().entrySet()) {
             variablesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1107,6 +1107,9 @@ public abstract class AbstractProtoMapper {
         for (Map.Entry<String, Object> pair : from.getVariables().entrySet()) {
             to.putVariables( pair.getKey(), toProto( pair.getValue() ) );
         }
+        for (Map.Entry<String, Object> pair : from.getInputTemplate().entrySet()) {
+            to.putInputTemplate( pair.getKey(), toProto( pair.getValue() ) );
+        }
         return to.build();
     }
 
@@ -1117,7 +1120,7 @@ public abstract class AbstractProtoMapper {
         to.setVersion( from.getVersion() );
         to.setTasks( from.getTasksList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
         to.setInputParameters( from.getInputParametersList().stream().collect(Collectors.toCollection(ArrayList::new)) );
-        Map<String, Object> outputParametersMap = new HashMap<>();
+        Map<String, Object> outputParametersMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getOutputParametersMap().entrySet()) {
             outputParametersMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1129,11 +1132,16 @@ public abstract class AbstractProtoMapper {
         to.setOwnerEmail( from.getOwnerEmail() );
         to.setTimeoutPolicy( fromProto( from.getTimeoutPolicy() ) );
         to.setTimeoutSeconds( from.getTimeoutSeconds() );
-        Map<String, Object> variablesMap = new HashMap<>();
+        Map<String, Object> variablesMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getVariablesMap().entrySet()) {
             variablesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setVariables(variablesMap);
+        Map<String, Object> inputTemplateMap = new HashMap<String, Object>();
+        for (Map.Entry<String, Value> pair : from.getInputTemplateMap().entrySet()) {
+            inputTemplateMap.put( pair.getKey(), fromProto( pair.getValue() ) );
+        }
+        to.setInputTemplate(inputTemplateMap);
         return to;
     }
 
@@ -1315,7 +1323,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setTaskReferenceName( from.getTaskReferenceName() );
         to.setDescription( from.getDescription() );
-        Map<String, Object> inputParametersMap = new HashMap<>();
+        Map<String, Object> inputParametersMap = new HashMap<String, Object>();
         for (Map.Entry<String, Value> pair : from.getInputParametersMap().entrySet()) {
             inputParametersMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
@@ -1325,7 +1333,7 @@ public abstract class AbstractProtoMapper {
         to.setCaseValueParam( from.getCaseValueParam() );
         to.setCaseExpression( from.getCaseExpression() );
         to.setScriptExpression( from.getScriptExpression() );
-        Map<String, List<WorkflowTask>> decisionCasesMap = new HashMap<>();
+        Map<String, List<WorkflowTask>> decisionCasesMap = new HashMap<String, List<WorkflowTask>>();
         for (Map.Entry<String, WorkflowTaskPb.WorkflowTask.WorkflowTaskList> pair : from.getDecisionCasesMap().entrySet()) {
             decisionCasesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }

--- a/grpc/src/main/proto/model/workflowdef.proto
+++ b/grpc/src/main/proto/model/workflowdef.proto
@@ -27,4 +27,5 @@ message WorkflowDef {
     WorkflowDef.TimeoutPolicy timeout_policy = 12;
     int64 timeout_seconds = 13;
     map<string, google.protobuf.Value> variables = 14;
+    map<string, google.protobuf.Value> input_template = 15;
 }

--- a/test-harness/src/test/resources/simple_workflow_1_input_template_integration_test.json
+++ b/test-harness/src/test/resources/simple_workflow_1_input_template_integration_test.json
@@ -1,0 +1,55 @@
+{
+  "name": "integration_test_template_wf",
+  "description": "Test a simple workflow with an input template",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "integration_task_1",
+      "taskReferenceName": "t1",
+      "inputParameters": {
+        "p1": "${workflow.input.param1}",
+        "p2": "${workflow.input.param2}",
+        "p3": "${CPEWF_TASK_ID}",
+        "someNullKey": null
+      },
+      "type": "SIMPLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [
+    "param1",
+    "param2",
+    "param3",
+    "param4"
+  ],
+  "inputTemplate": {
+    "param1": {
+      "nested_object": {
+        "nested_key": "nested_value"
+      }
+    },
+    "param2": ["list", "of", "strings"],
+    "param3": "string"
+  },
+  "outputParameters": {
+    "output": "${t1.output.op}",
+    "param1": "${workflow.input.param1}",
+    "param2": "${workflow.input.param2}",
+    "param3": "${workflow.input.param3}"
+  },
+  "failureWorkflow": "$workflow.input.failureWfName",
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This adds an `inputTemplate` configuration option to workflow definitions that functions similar to the [`inputTemplate` on task definitions ](https://netflix.github.io/conductor/configuration/taskdef/#using-inputtemplate). 

My current workaround is to define a `jq` task to do things like provide default variables but this does so more elegantly and maps to the current task modelling. 


Alternatives considered
----

- An entirely new field
  - I like the fact that `inputTemplate` is consistent across tasks and workflows, but a new field could have been used here if we wanted to separate the implementations


Questions
---

1. Are there any other places I should add tests? The workflow integration tests seem to be the most logical, but please let me know!
2. I've verified by running the tests locally, but i'm not sure if there's some additional testing/verification I should do manually.