### PR TITLE
Terminate when no dynamic tasks are returned

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -137,9 +137,29 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         List<String> joinOnTaskRefs = new LinkedList<>();
         //Add each dynamic task to the mapped tasks and also get the last dynamic task in the list,
         // which indicates that the following task after that needs to be a join task
-        for (WorkflowTask wft : dynForkTasks) {//TODO this is a cyclic dependency, break it out using function composition
+        for (WorkflowTask dynForkTask : dynForkTasks) {//TODO this is a cyclic dependency, break it out using function composition
             List<Task> forkedTasks = taskMapperContext.getDeciderService()
-                .getTasksToBeScheduled(workflowInstance, wft, retryCount);
+                .getTasksToBeScheduled(workflowInstance, dynForkTask, retryCount);
+
+            // It's an error state if no forkedTasks can be decided upon. In the cases where we've seen
+            // this happen is when a dynamic task is attempting to be created here, but a task with the
+            // same reference name has already been created in the Workflow.
+            if (forkedTasks == null || forkedTasks.isEmpty()) {
+                Optional<String> existingTaskRefName = workflowInstance.getTasks().stream()
+                        .filter(runningTask -> runningTask.getStatus().equals(Task.Status.IN_PROGRESS) || runningTask.getStatus().isTerminal())
+                        .map(Task::getReferenceTaskName)
+                        .filter(refTaskName -> refTaskName.equals(dynForkTask.getTaskReferenceName()))
+                        .findAny();
+
+                // Construct an informative error message
+                String terminateMessage = "No dynamic tasks could be created for the Workflow: " +
+                        workflowInstance + ", Dynamic Fork Task: " + dynForkTask;
+                if (existingTaskRefName.isPresent()) {
+                    terminateMessage += "Attempted to create a duplicate task reference name: " + existingTaskRefName.get();
+                }
+                throw new TerminateWorkflowException(terminateMessage);
+            }
+
             for (Task forkedTask : forkedTasks) {
                 Map<String, Object> forkedTaskInput = tasksInput.get(forkedTask.getReferenceTaskName());
                 forkedTask.getInputData().putAll(forkedTaskInput);

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.execution.mapper;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
@@ -387,5 +388,76 @@ public class ForkJoinDynamicTaskMapperTest {
         //when
         forkJoinDynamicTaskMapper
             .getDynamicForkTasksAndInput(dynamicForkJoinToSchedule, new Workflow(), "dynamicTasks");
+    }
+
+    @Test
+    public void testDynamicTaskDuplicateTaskRefName() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("DYNAMIC_FORK_JOIN_WF");
+        def.setDescription(def.getName());
+        def.setVersion(1);
+        def.setInputParameters(Arrays.asList("param1", "param2"));
+
+        Workflow  workflowInstance = new Workflow();
+        workflowInstance.setWorkflowDefinition(def);
+
+        WorkflowTask dynamicForkJoinToSchedule = new WorkflowTask();
+        dynamicForkJoinToSchedule.setType(TaskType.FORK_JOIN_DYNAMIC.name());
+        dynamicForkJoinToSchedule.setTaskReferenceName("dynamicfanouttask");
+        dynamicForkJoinToSchedule.setDynamicForkTasksParam("dynamicTasks");
+        dynamicForkJoinToSchedule.setDynamicForkTasksInputParamName("dynamicTasksInput");
+        dynamicForkJoinToSchedule.getInputParameters().put("dynamicTasks", "dt1.output.dynamicTasks");
+        dynamicForkJoinToSchedule.getInputParameters().put("dynamicTasksInput", "dt1.output.dynamicTasksInput");
+
+
+        WorkflowTask join = new WorkflowTask();
+        join.setType(TaskType.JOIN.name());
+        join.setTaskReferenceName("dynamictask_join");
+
+        def.getTasks().add(dynamicForkJoinToSchedule);
+        def.getTasks().add(join);
+
+        Map<String, Object> input1 = new HashMap<>();
+        input1.put("k1", "v1");
+        WorkflowTask wt2 = new WorkflowTask();
+        wt2.setName("junit_task_2");
+        wt2.setTaskReferenceName("xdt1");
+
+        Map<String, Object> input2 = new HashMap<>();
+        input2.put("k2", "v2");
+
+        WorkflowTask wt3 = new WorkflowTask();
+        wt3.setName("junit_task_3");
+        wt3.setTaskReferenceName("xdt2");
+
+        HashMap<String, Object> dynamicTasksInput = new HashMap<>();
+        dynamicTasksInput.put("xdt1", input1);
+        dynamicTasksInput.put("xdt2", input2);
+        dynamicTasksInput.put("dynamicTasks", Arrays.asList(wt2, wt3));
+        dynamicTasksInput.put("dynamicTasksInput", dynamicTasksInput);
+
+        // dynamic
+        when(parametersUtils.getTaskInput(anyMap(), any(Workflow.class), any(), any()))
+                .thenReturn(dynamicTasksInput);
+        when(objectMapper.convertValue(any(), any(TypeReference.class))).thenReturn(Arrays.asList(wt2, wt3));
+
+        Task simpleTask1 = new Task();
+        simpleTask1.setReferenceTaskName("xdt1");
+
+        // Empty list, this is a bad state, workflow should terminate
+        when(deciderService.getTasksToBeScheduled(workflowInstance, wt2, 0 )).thenReturn(Lists.newArrayList());
+
+        String taskId = IDGenerator.generate();
+        TaskMapperContext taskMapperContext = TaskMapperContext.newBuilder()
+                .withWorkflowDefinition(def)
+                .withWorkflowInstance(workflowInstance)
+                .withTaskToSchedule(dynamicForkJoinToSchedule)
+                .withRetryCount(0)
+                .withTaskId(taskId)
+                .withDeciderService(deciderService)
+                .build();
+
+        expectedException.expect(TerminateWorkflowException.class);
+        forkJoinDynamicTaskMapper.getMappedTasks(taskMapperContext);
     }
 }


### PR DESCRIPTION
Pull Request type: 
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
We started running into some ArrayIndexOutOfBounds exceptions during some Fork Dynamic tasks.

We have deployed this fix to our production server already, and it works as expected. How does this get back-ported to Conductor V2?

`
java.lang.ArrayIndexOutOfBoundsException: -1
\tat java.util.ArrayList.elementData(ArrayList.java:422)
\tat java.util.ArrayList.get(ArrayList.java:435)
\tat com.netflix.conductor.core.execution.mapper.ForkJoinDynamicTaskMapper.getMappedTasks(ForkJoinDynamicTaskMapper.java:146)
\tat com.netflix.conductor.core.execution.DeciderService.getTasksToBeScheduled(DeciderService.java:721)
\tat com.netflix.conductor.core.execution.DeciderService.getTasksToBeScheduled(DeciderService.java:684)
\tat com.netflix.conductor.core.execution.DeciderService.getNextTask(DeciderService.java:394)
\tat com.netflix.conductor.core.execution.DeciderService.decide(DeciderService.java:198)
\tat com.netflix.conductor.core.execution.DeciderService.decide(DeciderService.java:115)
\tat com.netflix.conductor.core.execution.WorkflowExecutor.decide(WorkflowExecutor.java:1047)
\tat com.netflix.conductor.core.execution.WorkflowSweeper.lambda$sweep$1(WorkflowSweeper.java:112)
\tat java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
\tat java.util.concurrent.FutureTask.run(FutureTask.java:266)
\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
\tat java.lang.Thread.run(Thread.java:748)","exception_class":"java.lang.ArrayIndexOutOfBoundsException
`

We figure out what the issue was. Workflows (correctly) must have task ref names unique across all tasks. Unfortunately, if you had static forks creating dynamic tasks in parallel branches, it's possible that you'd unknowingly *attempt* to create 2 tasks with the same ref name. If that happens, the Decider Service returns an empty list of tasks. 

This bug fix will now Terminate the workflow into a failed state and will also give some specific context about the error so you know what's happening:

![2021-09-02_12-42](https://user-images.githubusercontent.com/422315/131892670-f2349abf-701e-482b-90a4-6118ae16fd0f.png)
