### PR TITLE
Doc: Updates docker-compose commands to start Database container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,7 @@ Using compose (with Postgres):
 `ctrl+c` will exit docker compose.
 
 To ensure images are stopped do:
- - `docker-compose down`
+ - `docker-compose down --remove-orphans`
 
 ## Running in Interactive Mode
 In interactive mode the default startup script for the container do not run

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -49,11 +49,14 @@ gulp watch
 If you get an error message `ReferenceError: primordials is not defined`, you need to use an earlier version of Node (pre-12). See [this issue for more details](https://github.com/Netflix/conductor/issues/1232).
 
 #### Or Start all the services using [docker-compose](https://github.com/Netflix/conductor/blob/master/docker/docker-compose.yaml)
-
-```shell
-cd docker
-docker-compose up
-```
+- Using compose (with Dynomite):
+  ```shell
+  docker-compose -f docker-compose.yaml -f docker-compose-dynomite.yaml up
+  ```
+- Using compose (with Postgres):
+  ```shell
+  docker-compose -f docker-compose.yaml -f docker-compose-postgres.yaml up
+  ```
 
 If you ran it locally, launch UI at [http://localhost:3000/](http://localhost:3000/) OR if you ran it using docker-compose launch the UI at [http://localhost:5000/](http://localhost:5000/)
 

--- a/docs/docs/server.md
+++ b/docs/docs/server.md
@@ -4,7 +4,7 @@
 
 1. **Database**: [Dynomite](https://github.com/Netflix/dynomite)
 2. **Indexing Backend**: [Elasticsearch 5.x](https://www.elastic.co)
-2. **Servlet Container**: Tomcat, Jetty, or similar running JDK 1.8 or higher
+3. **Servlet Container**: Tomcat, Jetty, or similar running JDK 1.8 or higher
 
 There are 3 ways in which you can install Conductor:
 
@@ -33,11 +33,16 @@ docker-compose build
 ```
 
 After the docker images are built, run the following command to start the containers:
-```shell
-docker-compose up
-```
+- Using compose (with Dynomite):
+  ```shell
+  docker-compose -f docker-compose.yaml -f docker-compose-dynomite.yaml up
+  ```
+- Using compose (with Postgres):
+  ```shell
+  docker-compose -f docker-compose.yaml -f docker-compose-postgres.yaml up
+  ```
 
-This will create a docker container network that consists of the following images: conductor:server, conductor:ui, [elasticsearch:5.6.8](https://hub.docker.com/_/elasticsearch/), and dynomite.
+This will create a docker container network that consists of the following images: conductor:server, conductor:ui, [elasticsearch:5.6.8](https://hub.docker.com/_/elasticsearch/), and dynomite or postgres.
 
 To view the UI, navigate to [localhost:5000](http://localhost:5000/), to view the Swagger docs, navigate to [localhost:8080](http://localhost:8080/).
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Other (please describe): Update docs to fix docker-compose commands according to the new changes

Changes in this PR
----
The docker-compose command is updated with the `-f` flag to start the database container also, and adds the `--remove-orphans` flag to ensure all the containers are removed properly

Issue #2464