### PR TITLE
Remove ack from Go client + pass auth to go http client

### DIFF
--- a/polyglot-clients/go/conductorhttpclient.go
+++ b/polyglot-clients/go/conductorhttpclient.go
@@ -32,6 +32,22 @@ func NewConductorHttpClient(baseUrl string) *ConductorHttpClient {
     return conductorClient
 }
 
+type ConductorHttpClientConfig struct {
+    baseUrl string
+    bearerToken *string
+}
+
+func NewConductorHttpClientWithConfig(config ConductorHttpClientConfig) *ConductorHttpClient {
+    conductorClient := new(ConductorHttpClient)
+    headers := map[string]string{"Content-Type": "application/json", "Accept": "application/json"}
+    if bearerToken != nil {
+        headers["Authorization"] = *config.bearerToken
+    }
+    httpClient := httpclient.NewHttpClient(config.baseUrl, headers, true)
+    conductorClient.httpClient = httpClient
+    return conductorClient
+}
+
 
 /**********************/
 /* Metadata Functions */

--- a/polyglot-clients/go/conductorhttpclient.go
+++ b/polyglot-clients/go/conductorhttpclient.go
@@ -41,7 +41,7 @@ func NewConductorHttpClientWithConfig(config ConductorHttpClientConfig) *Conduct
     conductorClient := new(ConductorHttpClient)
     headers := map[string]string{"Content-Type": "application/json", "Accept": "application/json"}
     if bearerToken != nil {
-        headers["Authorization"] = *config.bearerToken
+        headers["Authorization"] = fmt.Sprintf("Bearer %s", *config.bearerToken)
     }
     httpClient := httpclient.NewHttpClient(config.baseUrl, headers, true)
     conductorClient.httpClient = httpClient

--- a/polyglot-clients/go/conductorhttpclient.go
+++ b/polyglot-clients/go/conductorhttpclient.go
@@ -40,7 +40,7 @@ type ConductorHttpClientConfig struct {
 func NewConductorHttpClientWithConfig(config ConductorHttpClientConfig) *ConductorHttpClient {
     conductorClient := new(ConductorHttpClient)
     headers := map[string]string{"Content-Type": "application/json", "Accept": "application/json"}
-    if bearerToken != nil {
+    if config.bearerToken != nil {
         headers["Authorization"] = fmt.Sprintf("Bearer %s", *config.bearerToken)
     }
     httpClient := httpclient.NewHttpClient(config.baseUrl, headers, true)

--- a/polyglot-clients/go/conductorworker.go
+++ b/polyglot-clients/go/conductorworker.go
@@ -88,13 +88,6 @@ func (c *ConductorWorker) PollAndExecute(taskType string, domain string, execute
 			continue
 		}
 
-		// Found a task, so we send an Ack
-		_, ackErr := c.ConductorHttpClient.AckTask(parsedTask.TaskId, hostname, domain)
-		if ackErr != nil {
-			log.Println("Error Acking task:", ackErr.Error())
-			continue
-		}
-
 		// Execute given function
 		c.Execute(parsedTask, executeFunction)
 	}


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): adapt go client to v3 

Changes in this PR
----
- Removed ack step for go client
- Added constructor for Httpclient to allow token based auth

_Describe the new behavior from this PR, and why it's needed_
Based on Issue # https://github.com/Netflix/conductor/issues/1659, v3 no longer requires workers to ack tasks. The ack step in the go client prevents the worker from executing the task, and was therefore removed.

Authentication was added due to my own setup, where workers need to auth to perform any action on the api. The existing http client only took url, and so would not allow any auth.