### PR TITLE
Add redis-lock dep

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':conductor-es6-persistence')
     implementation(project(path: ':conductor-es7-persistence', configuration: 'shadow'))
     implementation project(':conductor-grpc-server')
+    implementation project(':conductor-redis-lock')
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-validation'


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----

This PR adds redis-lock to server's dependencies. Our team is using distributed lock implemented by redis-lock on top of AWS Redis. Since redis-lock has not been listed in the dependencies we are patching upstream on every build. I believe you could add this PR to main branch since default configuration is:

```
conductor.app.workflow-execution-lock-enabled=false
conductor.workflow-execution-lock.type=noop_lock
```

Please review and let me know if anything else should be added or done differently to get this merged. 

Thanks in advance! 