### PR TITLE
Fix inconsistent workflow status caused by upload payload exception d…

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -837,7 +837,14 @@ public class WorkflowExecutor {
             if (workflow.getWorkflowDefinition() == null) {
                 workflow = metadataMapperService.populateWorkflowWithDefinitions(workflow);
             }
-            deciderService.updateWorkflowOutput(workflow, null);
+
+            try {
+                deciderService.updateWorkflowOutput(workflow, null);
+            } catch (Exception e) {
+                // catch any failure in this step and continue the execution of terminating workflow
+                LOGGER.error("Failed to update output data for workflow: {}", workflow.getWorkflowId(), e);
+                Monitors.error(CLASS_NAME, "terminateWorkflow");
+            }
 
             // update the failed reference task names
             workflow.getFailedReferenceTaskNames().addAll(workflow.getTasks().stream()

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
@@ -145,6 +146,7 @@ public class TestWorkflowExecutor {
     private QueueDAO queueDAO;
     private WorkflowStatusListener workflowStatusListener;
     private ExecutionLockService executionLockService;
+    private ExternalPayloadStorageUtils externalPayloadStorageUtils;
 
     @Configuration
     @ComponentScan(basePackageClasses = {Evaluator.class}) // load all Evaluator beans.
@@ -204,7 +206,7 @@ public class TestWorkflowExecutor {
         metadataDAO = mock(MetadataDAO.class);
         queueDAO = mock(QueueDAO.class);
         workflowStatusListener = mock(WorkflowStatusListener.class);
-        ExternalPayloadStorageUtils externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
+        externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         executionLockService = mock(ExecutionLockService.class);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
         Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
@@ -481,6 +483,51 @@ public class TestWorkflowExecutor {
         workflowExecutor.completeWorkflow(workflow);
         verify(workflowStatusListener, times(1)).onWorkflowCompletedIfEnabled(any(Workflow.class));
         verify(workflowStatusListener, times(1)).onWorkflowFinalizedIfEnabled(any(Workflow.class));
+    }
+
+    @Test
+    public void testUploadOutputFailuresDuringTerminateWorkflow() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("test");
+        def.setWorkflowStatusListenerEnabled(true);
+
+        Workflow workflow = new Workflow();
+        workflow.setWorkflowDefinition(def);
+        workflow.setWorkflowId("1");
+        workflow.setStatus(Workflow.WorkflowStatus.RUNNING);
+        workflow.setOwnerApp("junit_test");
+        workflow.setStartTime(10L);
+        workflow.setEndTime(100L);
+        workflow.setOutput(Collections.EMPTY_MAP);
+
+        List<Task> tasks = new LinkedList<>();
+
+        Task task = new Task();
+        task.setScheduledTime(1L);
+        task.setSeq(1);
+        task.setTaskId(UUID.randomUUID().toString());
+        task.setReferenceTaskName("t1");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setTaskDefName("task1");
+        task.setStatus(Status.IN_PROGRESS);
+
+        tasks.add(task);
+        workflow.setTasks(tasks);
+
+        when(executionDAOFacade.getWorkflowById(anyString(), anyBoolean())).thenReturn(workflow);
+
+        AtomicInteger updateWorkflowCalledCounter = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            updateWorkflowCalledCounter.incrementAndGet();
+            return null;
+        }).when(executionDAOFacade).updateWorkflow(any());
+
+        doThrow(new RuntimeException("any exception")).when(externalPayloadStorageUtils).verifyAndUpload(workflow, ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT);
+
+        workflowExecutor.terminateWorkflow(workflow.getWorkflowId(), "reason");
+        assertEquals(Workflow.WorkflowStatus.TERMINATED, workflow.getStatus());
+        assertEquals(1, updateWorkflowCalledCounter.get());
+        verify(workflowStatusListener, times(1)).onWorkflowTerminatedIfEnabled(any(Workflow.class));
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
@@ -192,4 +192,28 @@ public class ExternalPayloadStorageUtilsTest {
         assertNotNull(task);
         assertNull(task.getOutputData());
     }
+
+    @Test
+    public void testFailWorkflowWithInputPayload() {
+        Workflow workflow = new Workflow();
+        workflow.setInput(new HashMap<>());
+
+        expectedException.expect(TerminateWorkflowException.class);
+        externalPayloadStorageUtils.failWorkflow(workflow, ExternalPayloadStorage.PayloadType.TASK_INPUT, "error");
+        assertNotNull(workflow);
+        assertNull(workflow.getInput());
+        assertEquals(Workflow.WorkflowStatus.FAILED, workflow.getStatus());
+    }
+
+    @Test
+    public void testFailWorkflowWithOutputPayload() {
+        Workflow workflow = new Workflow();
+        workflow.setOutput(new HashMap<>());
+
+        expectedException.expect(TerminateWorkflowException.class);
+        externalPayloadStorageUtils.failWorkflow(workflow, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, "error");
+        assertNotNull(workflow);
+        assertNull(workflow.getOutput());
+        assertEquals(Workflow.WorkflowStatus.FAILED, workflow.getStatus());
+    }
 }


### PR DESCRIPTION
…uring workflow termination

Pull Request type
----

- [x ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Catch exception of external storage upload failures during workflow termination and continue the execution to persist workflow status, etc.
_Describe the new behavior from this PR, and why it's needed_
Issue #2343 https://github.com/Netflix/conductor/issues/2323

Alternatives considered
----

_Describe alternative implementation you have considered_
