### PR TITLE
Fix rerunWorkflow places synchronous system tasks in the queue

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/json/JsonJqTransform.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/json/JsonJqTransform.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +59,7 @@ public class JsonJqTransform extends WorkflowSystemTask {
     @Override
     public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
         final Map<String, Object> taskInput = task.getInputData();
-        final Map<String, Object> taskOutput = task.getOutputData();
+        final Map<String, Object> taskOutput = task.getOutputData() != null ? task.getOutputData(): new HashMap<>();
 
         final String queryExpression = (String) taskInput.get(QUERY_EXPRESSION_PARAMETER);
 
@@ -87,6 +88,7 @@ public class JsonJqTransform extends WorkflowSystemTask {
                 taskOutput.put(OUTPUT_RESULT, result.get(0));
                 taskOutput.put(OUTPUT_RESULT_LIST, result);
             }
+            task.setOutputData(taskOutput);
         } catch (final Exception e) {
             LOGGER.error("Error executing task: {} in workflow: {}", task.getTaskId(), workflow.getWorkflowId(), e);
             task.setStatus(Task.Status.FAILED);

--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/json/JsonJqTransform.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/json/JsonJqTransform.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +58,7 @@ public class JsonJqTransform extends WorkflowSystemTask {
     @Override
     public void start(Workflow workflow, Task task, WorkflowExecutor executor) {
         final Map<String, Object> taskInput = task.getInputData();
-        final Map<String, Object> taskOutput = task.getOutputData() != null ? task.getOutputData(): new HashMap<>();
+        final Map<String, Object> taskOutput = task.getOutputData();
 
         final String queryExpression = (String) taskInput.get(QUERY_EXPRESSION_PARAMETER);
 
@@ -88,7 +87,6 @@ public class JsonJqTransform extends WorkflowSystemTask {
                 taskOutput.put(OUTPUT_RESULT, result.get(0));
                 taskOutput.put(OUTPUT_RESULT_LIST, result);
             }
-            task.setOutputData(taskOutput);
         } catch (final Exception e) {
             LOGGER.error("Error executing task: {} in workflow: {}", task.getTaskId(), workflow.getWorkflowId(), e);
             task.setStatus(Task.Status.FAILED);

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1648,12 +1648,19 @@ public class WorkflowExecutor {
                 rerunFromTask.setStatus(IN_PROGRESS);
                 rerunFromTask.setStartTime(System.currentTimeMillis());
             } else {
-                // Set the task to rerun as SCHEDULED
-                rerunFromTask.setStatus(SCHEDULED);
                 if (taskInput != null) {
                     rerunFromTask.setInputData(taskInput);
                 }
-                addTaskToQueue(rerunFromTask);
+                if (systemTaskRegistry.isSystemTask(rerunFromTask.getTaskType()) &&
+                        !systemTaskRegistry.get(rerunFromTask.getTaskType()).isAsync()) {
+                    // Start the synchronized system task directly
+                    deciderService.populateTaskData(rerunFromTask);
+                    systemTaskRegistry.get(rerunFromTask.getTaskType()).start(workflow, rerunFromTask, this);
+                } else {
+                    // Set the task to rerun as SCHEDULED
+                    rerunFromTask.setStatus(SCHEDULED);
+                    addTaskToQueue(rerunFromTask);
+                }
             }
             executionDAOFacade.updateTask(rerunFromTask);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1639,7 +1639,7 @@ public class WorkflowExecutor {
             rerunFromTask.setStartTime(0);
             rerunFromTask.setUpdateTime(0);
             rerunFromTask.setEndTime(0);
-            rerunFromTask.setOutputData(null);
+            rerunFromTask.getOutputData().clear();
             rerunFromTask.setRetried(false);
             rerunFromTask.setExecuted(false);
             rerunFromTask.setExternalOutputPayloadStoragePath(null);

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
@@ -55,7 +55,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].outputData as String == "[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]"
+            tasks[0].outputData as String == '[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]'
         }
     }
 
@@ -82,7 +82,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.FAILED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].reasonForIncompletion as String == "Cannot index string with string \"array\""
+            tasks[0].reasonForIncompletion == 'Cannot index string with string \"array\"'
         }
     }
 
@@ -126,7 +126,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.FAILED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].reasonForIncompletion as String == "Cannot index string with string \"array\""
+            tasks[0].reasonForIncompletion == 'Cannot index string with string \"array\"'
         }
 
         when: "workflow which has the json jq transform task reran"
@@ -144,7 +144,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].outputData as String == "[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]"
+            tasks[0].outputData as String == '[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]'
         }
     }
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
@@ -13,6 +13,7 @@
 package com.netflix.conductor.test.integration
 
 import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.metadata.workflow.RerunWorkflowRequest
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.test.base.AbstractSpecification
 import spock.lang.Shared
@@ -82,6 +83,68 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks[0].status == Task.Status.FAILED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
             tasks[0].reasonForIncompletion as String == "Cannot index string with string \"array\""
+        }
+    }
+
+    /**
+     * Given the following invalid input JSON
+     *{*   "in1": "a",
+     *   "in2": "b"
+     *}* using the same query from the success test, jq will try to get in1['array']
+     * and fail since 'in1' is a string.
+     *
+     * Re-run failed system task with the following valid input JSON will fix the workflow
+     *{*   "in1": {*     "array": [ "a", "b" ]
+     *},
+     *   "in2": {*     "array": [ "c", "d" ]
+     *}*}* expect the workflow task to transform to following result:
+     *{*     out: [ "a", "b", "c", "d" ]
+     *}
+     */
+    def "Test rerun workflow with failed json jq transform task"() {
+        given: "workflow input"
+        def invalidInput = new HashMap()
+        invalidInput['in1'] = "a"
+        invalidInput['in2'] = "b"
+
+        def validInput = new HashMap()
+        def input = new HashMap()
+        input['in1'] = new HashMap()
+        input['in1']['array'] = ["a", "b"]
+        input['in2'] = new HashMap()
+        input['in2']['array'] = ["c", "d"]
+        validInput['input'] = input
+        validInput['queryExpression'] = '.input as $_ | { out: ($_.in1.array + $_.in2.array) }'
+
+        when: "workflow which has the json jq transform task started"
+        def workflowInstanceId = workflowExecutor.startWorkflow(JSON_JQ_TRANSFORM_WF, 1,
+                '', invalidInput, null, null, null)
+
+        then: "verify that the workflow and task failed with expected error"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 1
+            tasks[0].status == Task.Status.FAILED
+            tasks[0].taskType == 'JSON_JQ_TRANSFORM'
+            tasks[0].reasonForIncompletion as String == "Cannot index string with string \"array\""
+        }
+
+        when: "workflow which has the json jq transform task reran"
+        def reRunWorkflowRequest = new RerunWorkflowRequest()
+        reRunWorkflowRequest.reRunFromWorkflowId = workflowInstanceId
+        def reRunTaskId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).tasks[0].taskId
+        reRunWorkflowRequest.reRunFromTaskId = reRunTaskId
+        reRunWorkflowRequest.taskInput = validInput
+
+        workflowExecutor.rerun(reRunWorkflowRequest)
+
+        then: "verify that the workflow and task are completed with expected output"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            tasks.size() == 1
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'JSON_JQ_TRANSFORM'
+            tasks[0].outputData as String == "[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]"
         }
     }
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/JsonJQTransformSpec.groovy
@@ -55,7 +55,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].outputData as String == '[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]'
+            tasks[0].outputData.containsKey("result") && tasks[0].outputData.containsKey("resultList")
         }
     }
 
@@ -144,7 +144,7 @@ class JsonJQTransformSpec extends AbstractSpecification {
             tasks.size() == 1
             tasks[0].status == Task.Status.COMPLETED
             tasks[0].taskType == 'JSON_JQ_TRANSFORM'
-            tasks[0].outputData as String == '[result:[out:[a, b, c, d]], resultList:[[out:[a, b, c, d]]]]'
+            tasks[0].outputData.containsKey("result") && tasks[0].outputData.containsKey("resultList")
         }
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
When rerun from task, if it's a synchronous system task, don't put it in the queue, start directly instead.

_Describe the new behavior from this PR, and why it's needed_
Issue #MWI-3456: rerunWorkflow places synchronous system tasks in the queue

Alternatives considered
----

_Describe alternative implementation you have considered_
