### PR TITLE
Migrate conductor JAXB dependency from javax. to jakarta

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,9 +41,11 @@ dependencies {
 
     // JAXB is not bundled with Java 11, dependencies added explicitly
     // These are needed by Apache BVAL
-    implementation "javax.xml.bind:jaxb-api:${revJAXB}"
-    implementation "javax.activation:activation:${revActivation}"
-    implementation "org.glassfish.jaxb:jaxb-runtime:${revJAXB}"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:${revJAXB}"
+    implementation "jakarta.activation:jakarta.activation-api:${revActivation}"
+
+    // Only add it as a test dependency. The actual jaxb runtime provider is provided when building the server.
+    testImplementation "org.glassfish.jaxb:jaxb-runtime:${revJAXB}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation project(':conductor-common').sourceSets.test.output

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -38,11 +38,11 @@
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
         },
-        "javax.activation:activation": {
-            "locked": "1.1.1"
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.0.0"
         },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.0"
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "2.3.3"
         },
         "org.apache.bval:bval-jsr": {
             "locked": "2.0.5"
@@ -51,7 +51,7 @@
             "locked": "3.10"
         },
         "org.glassfish.jaxb:jaxb-runtime": {
-            "locked": "2.3.0"
+            "locked": "2.3.3"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
@@ -115,11 +115,11 @@
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
         },
-        "javax.activation:activation": {
-            "locked": "1.1.1"
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.0.0"
         },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.0"
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "2.3.3"
         },
         "org.apache.bval:bval-jsr": {
             "firstLevelTransitive": [
@@ -134,7 +134,7 @@
             "locked": "3.10"
         },
         "org.glassfish.jaxb:jaxb-runtime": {
-            "locked": "2.3.0"
+            "locked": "2.3.3"
         }
     },
     "testCompileClasspath": {
@@ -171,11 +171,11 @@
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
         },
-        "javax.activation:activation": {
-            "locked": "1.1.1"
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.0.0"
         },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.0"
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "2.3.3"
         },
         "org.apache.bval:bval-jsr": {
             "locked": "2.0.5"
@@ -187,7 +187,7 @@
             "locked": "2.5.13"
         },
         "org.glassfish.jaxb:jaxb-runtime": {
-            "locked": "2.3.0"
+            "locked": "2.3.3"
         },
         "org.spockframework:spock-core": {
             "locked": "1.3-groovy-2.5"
@@ -260,11 +260,11 @@
         "io.reactivex:rxjava": {
             "locked": "1.2.2"
         },
-        "javax.activation:activation": {
-            "locked": "1.1.1"
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.0.0"
         },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.0"
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "2.3.3"
         },
         "org.apache.bval:bval-jsr": {
             "firstLevelTransitive": [
@@ -282,7 +282,7 @@
             "locked": "2.5.13"
         },
         "org.glassfish.jaxb:jaxb-runtime": {
-            "locked": "2.3.0"
+            "locked": "2.3.3"
         },
         "org.spockframework:spock-core": {
             "locked": "1.3-groovy-2.5"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@
  * Common place to define all the version dependencies
  */
 ext {
-    revActivation = '1.1.1'
+    revActivation = '2.0.0'
     revAmqpClient = '5.13.0'
     revAwaitility = '3.1.6'
     revAwsSdk = '1.11.86'
@@ -37,7 +37,7 @@ ext {
     revGuavaRetrying = '2.0.0'
     revHamcrestAllMatchers = '1.8'
     revHealth = '1.1.+'
-    revJAXB = '2.3.0'
+    revJAXB = '2.3.3'
     revJedis = '3.3.0'
     revJersey = '1.19.4'
     revJsonPath = '2.4.0'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     runtimeOnly 'com.netflix.spectator:spectator-reg-micrometer'
 
+    runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${revJAXB}"
+
     testImplementation project(':conductor-rest')
     testImplementation project(':conductor-common')
     testImplementation "io.grpc:grpc-testing:${revGrpc}"


### PR DESCRIPTION
The conductor has JAXB dependency on javax.* which should be migrated
to jakarta.*.

Signed-off-by: Tao Jiang <taoj@vmware.com>

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
The conductor has JAXB dependency on javax.* which should be migrated to jakarta.* due to [some legal issues](https://eclipse-foundation.blog/2019/05/03/jakarta-ee-java-trademarks/). We, VMware, use and build the conductor as a library into our own service for internal CI/CD requirements.  This change will also avoid library clashes. 

_Describe the new behavior from this PR, and why it's needed_
Issue #2495

Alternatives considered
----
Deploy vanilla Conductor as standalone service. However, we have totally replaced the API layer with our own implementation in order to support using ASL (Amazon State Language) as DSL and security enhancement. It will be much less efficient to keep the conductor's API layer. 


_Describe alternative implementation you have considered_
