### PR TITLE
Add event handler operations to client

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
@@ -294,7 +294,7 @@ public abstract class ClientBase {
                 return;
             }
             String errorMessage = clientResponse.getEntity(String.class);
-            LOGGER.error(
+            LOGGER.warn(
                 "Unable to invoke Conductor API with uri: {}, unexpected response from server: statusCode={}, responseBody='{}'.",
                 uri, clientResponse.getStatus(), errorMessage);
             ErrorResponse errorResponse;

--- a/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
@@ -1,0 +1,108 @@
+package com.netflix.conductor.client.http;
+
+import com.google.common.base.Preconditions;
+import com.netflix.conductor.client.config.ConductorClientConfiguration;
+import com.netflix.conductor.client.config.DefaultConductorClientConfiguration;
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.sun.jersey.api.client.ClientHandler;
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.client.filter.ClientFilter;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.List;
+
+// Client class for all Event Handler operations
+public class EventClient extends ClientBase {
+    private static final GenericType<List<EventHandler>> eventHandlerList = new GenericType<List<EventHandler>>() {
+    };
+    /**
+     * Creates a default metadata client
+     */
+    public EventClient() {
+        this(new DefaultClientConfig(), new DefaultConductorClientConfiguration(), null);
+    }
+
+    /**
+     * @param clientConfig REST Client configuration
+     */
+    public EventClient(ClientConfig clientConfig) {
+        this(clientConfig, new DefaultConductorClientConfiguration(), null);
+    }
+
+    /**
+     * @param clientConfig  REST Client configuration
+     * @param clientHandler Jersey client handler. Useful when plugging in various http client interaction modules (e.g.
+     *                      ribbon)
+     */
+    public EventClient(ClientConfig clientConfig, ClientHandler clientHandler) {
+        this(clientConfig, new DefaultConductorClientConfiguration(), clientHandler);
+    }
+
+    /**
+     * @param config  config REST Client configuration
+     * @param handler handler Jersey client handler. Useful when plugging in various http client interaction modules
+     *                (e.g. ribbon)
+     * @param filters Chain of client side filters to be applied per request
+     */
+    public EventClient(ClientConfig config, ClientHandler handler, ClientFilter... filters) {
+        this(config, new DefaultConductorClientConfiguration(), handler, filters);
+    }
+
+    /**
+     * @param config              REST Client configuration
+     * @param clientConfiguration Specific properties configured for the client, see {@link ConductorClientConfiguration}
+     * @param handler             Jersey client handler. Useful when plugging in various http client interaction modules
+     *                            (e.g. ribbon)
+     * @param filters             Chain of client side filters to be applied per request
+     */
+    public EventClient(ClientConfig config, ConductorClientConfiguration clientConfiguration, ClientHandler handler,
+                          ClientFilter... filters) {
+        super(config, clientConfiguration, handler);
+        for (ClientFilter filter : filters) {
+            super.client.addFilter(filter);
+        }
+    }
+
+    /**
+     * Register an event handler with the server
+     *
+     * @param eventHandler the eventHandler definition
+     */
+    public void registerEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler, "Event Handler definition cannot be null");
+        postForEntityWithRequestOnly("event", eventHandler);
+    }
+
+    /**
+     * Updates an event handler with the server
+     *
+     * @param eventHandler the eventHandler definition
+     */
+    public void updateEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler, "Event Handler definition cannot be null");
+        put("event", null, eventHandler);
+    }
+
+    /**
+     * @param event name of the event
+     * @param activeOnly if true, returns only the active handlers
+     * @return Returns the list of all the event handlers for a given event
+     */
+    public List<EventHandler> getEventHandlers(String event, boolean activeOnly) {
+        Preconditions.checkArgument(org.apache.commons.lang3.StringUtils.isNotBlank(event), "Event cannot be blank");
+
+        return getForEntity("event/{event}", new Object[]{"activeOnly", activeOnly}, eventHandlerList, event);
+    }
+
+    /**
+     * Removes the event handler definition from the conductor server
+     *
+     * @param name the name of the event handler to be unregistered
+     */
+    public void unregisterEventHandler(String name) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(name), "Event handler name cannot be blank");
+        delete("event/{name}", name);
+    }
+}

--- a/client/src/test/java/com/netflix/conductor/client/http/EventClientTest.java
+++ b/client/src/test/java/com/netflix/conductor/client/http/EventClientTest.java
@@ -1,0 +1,76 @@
+package com.netflix.conductor.client.http;
+
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.sun.jersey.api.client.ClientHandler;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.net.URI;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(SpringRunner.class)
+public class EventClientTest {
+
+    @Mock
+    private ClientHandler clientHandler;
+
+    @Mock
+    private ClientConfig clientConfig;
+
+    private EventClient eventClient;
+
+    @Before
+    public void before() {
+        this.eventClient = new EventClient(clientConfig, clientHandler);
+        this.eventClient.setRootURI("http://myuri:8080/");
+    }
+
+    @Test
+    public void testRegisterEventHandler() {
+        EventHandler eventHandler = mock(EventHandler.class);
+        when(clientHandler.handle(argThat(argument ->
+                argument.getURI().equals(URI.create("http://myuri:8080/event")))))
+                .thenReturn(mock(ClientResponse.class));
+        eventClient.registerEventHandler(eventHandler);
+        verify(clientHandler).handle(any());
+    }
+
+    @Test
+    public void testUpdateEventHandler() {
+        EventHandler eventHandler = mock(EventHandler.class);
+        when(clientHandler.handle(argThat(argument ->
+                argument.getURI().equals(URI.create("http://myuri:8080/event")))))
+                .thenReturn(mock(ClientResponse.class));
+        eventClient.updateEventHandler(eventHandler);
+        verify(clientHandler).handle(any());
+    }
+
+    @Test
+    public void testGetEventHandlers() {
+        when(clientHandler.handle(argThat(argument ->
+                argument.getURI().equals(URI.create("http://myuri:8080/event/test?activeOnly=true")))))
+                .thenReturn(mock(ClientResponse.class));
+        eventClient.getEventHandlers("test", true);
+        verify(clientHandler).handle(any());
+    }
+
+    @Test
+    public void testUnregisterEventHandler() {
+        when(clientHandler.handle(argThat(argument ->
+                argument.getURI().equals(URI.create("http://myuri:8080/event/test")))))
+                .thenReturn(mock(ClientResponse.class));
+        eventClient.unregisterEventHandler("test");
+        verify(clientHandler).handle(any());
+    }
+}

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/EventClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/EventClient.java
@@ -1,0 +1,78 @@
+package com.netflix.conductor.client.grpc;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.netflix.conductor.grpc.EventServiceGrpc;
+import com.netflix.conductor.grpc.EventServicePb;
+import com.netflix.conductor.proto.EventHandlerPb;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Iterator;
+
+public class EventClient extends ClientBase {
+
+    private final EventServiceGrpc.EventServiceBlockingStub stub;
+
+    public EventClient(String address, int port) {
+        super(address, port);
+        this.stub = EventServiceGrpc.newBlockingStub(this.channel);
+    }
+
+    /**
+     * Register an event handler with the server
+     *
+     * @param eventHandler the event handler definition
+     */
+    public void registerEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler, "Event handler definition cannot be null");
+        stub.addEventHandler(
+                EventServicePb.AddEventHandlerRequest.newBuilder()
+                        .setHandler(protoMapper.toProto(eventHandler))
+                        .build()
+        );
+    }
+
+    /**
+     * Updates an existing event handler
+     *
+     * @param eventHandler the event handler to be updated
+     */
+    public void updateEventHandler(EventHandler eventHandler) {
+        Preconditions.checkNotNull(eventHandler, "Event handler definition cannot be null");
+        stub.updateEventHandler(
+                EventServicePb.UpdateEventHandlerRequest.newBuilder()
+                        .setHandler(protoMapper.toProto(eventHandler))
+                        .build()
+        );
+    }
+
+    /**
+     * @param event name of the event
+     * @param activeOnly if true, returns only the active handlers
+     * @return Returns the list of all the event handlers for a given event
+     */
+    public Iterator<EventHandler> getEventHandlers(String event, boolean activeOnly) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(event), "Event cannot be blank");
+
+        EventServicePb.GetEventHandlersForEventRequest.Builder request =
+                EventServicePb.GetEventHandlersForEventRequest.newBuilder()
+                        .setEvent(event)
+                        .setActiveOnly(activeOnly);
+        Iterator<EventHandlerPb.EventHandler> it = stub.getEventHandlersForEvent(request.build());
+        return Iterators.transform(it, protoMapper::fromProto);
+    }
+
+    /**
+     * Removes the event handler from the conductor server
+     *
+     * @param name the name of the event handler
+     */
+    public void unregisterEventHandler(String name) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(name), "Name cannot be blank");
+        stub.removeEventHandler(EventServicePb.RemoveEventHandlerRequest.newBuilder()
+                .setName(name)
+                .build()
+        );
+    }
+}

--- a/grpc-client/src/test/java/com/netflix/conductor/client/grpc/EventClientTest.java
+++ b/grpc-client/src/test/java/com/netflix/conductor/client/grpc/EventClientTest.java
@@ -1,0 +1,94 @@
+package com.netflix.conductor.client.grpc;
+
+import com.netflix.conductor.common.metadata.events.EventHandler;
+import com.netflix.conductor.grpc.EventServiceGrpc;
+import com.netflix.conductor.grpc.EventServicePb;
+import com.netflix.conductor.grpc.ProtoMapper;
+import com.netflix.conductor.proto.EventHandlerPb;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class EventClientTest {
+
+    @Mock
+    ProtoMapper mockedProtoMapper;
+
+    @Mock
+    EventServiceGrpc.EventServiceBlockingStub mockedStub;
+
+    EventClient eventClient;
+
+    @Before
+    public void init() {
+        eventClient = new EventClient("test", 0);
+        ReflectionTestUtils.setField(eventClient, "stub", mockedStub);
+        ReflectionTestUtils.setField(eventClient, "protoMapper", mockedProtoMapper);
+    }
+
+    @Test
+    public void testRegisterEventHandler() {
+        EventHandler eventHandler = mock(EventHandler.class);
+        EventHandlerPb.EventHandler eventHandlerPB = mock(EventHandlerPb.EventHandler.class);
+        when(mockedProtoMapper.toProto(eventHandler)).thenReturn(eventHandlerPB);
+
+        EventServicePb.AddEventHandlerRequest request = EventServicePb.AddEventHandlerRequest.newBuilder()
+                .setHandler(eventHandlerPB)
+                .build();
+        eventClient.registerEventHandler(eventHandler);
+        verify(mockedStub, times(1)).addEventHandler(request);
+    }
+
+    @Test
+    public void testUpdateEventHandler() {
+        EventHandler eventHandler = mock(EventHandler.class);
+        EventHandlerPb.EventHandler eventHandlerPB = mock(EventHandlerPb.EventHandler.class);
+        when(mockedProtoMapper.toProto(eventHandler)).thenReturn(eventHandlerPB);
+
+        EventServicePb.UpdateEventHandlerRequest request = EventServicePb.UpdateEventHandlerRequest.newBuilder()
+                .setHandler(eventHandlerPB)
+                .build();
+        eventClient.updateEventHandler(eventHandler);
+        verify(mockedStub, times(1)).updateEventHandler(request);
+    }
+
+    @Test
+    public void testGetEventHandlers() {
+        EventHandler eventHandler = mock(EventHandler.class);
+        EventHandlerPb.EventHandler eventHandlerPB = mock(EventHandlerPb.EventHandler.class);
+        when(mockedProtoMapper.fromProto(eventHandlerPB)).thenReturn(eventHandler);
+        EventServicePb.GetEventHandlersForEventRequest request = EventServicePb.GetEventHandlersForEventRequest.newBuilder()
+                .setEvent("test")
+                .setActiveOnly(true)
+                .build();
+        List<EventHandlerPb.EventHandler> result = new ArrayList<>();
+        result.add(eventHandlerPB);
+        when(mockedStub.getEventHandlersForEvent(request)).thenReturn(result.iterator());
+        Iterator<EventHandler> response = eventClient.getEventHandlers("test", true);
+        verify(mockedStub, times(1)).getEventHandlersForEvent(request);
+        assertEquals(response.next(), eventHandler);
+    }
+
+    @Test
+    public void testUnregisterEventHandler() {
+        EventServicePb.RemoveEventHandlerRequest request = EventServicePb.RemoveEventHandlerRequest.newBuilder()
+                .setName("test")
+                .build();
+        eventClient.unregisterEventHandler("test");
+        verify(mockedStub, times(1)).removeEventHandler(request);
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/AbstractEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/AbstractEndToEndTest.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.test.integration;
 
+import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -24,6 +25,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +37,15 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 
 @TestPropertySource(properties = {"conductor.indexing.enabled=true", "conductor.elasticsearch.version=6"})
 public abstract class AbstractEndToEndTest {
@@ -183,6 +188,79 @@ public abstract class AbstractEndToEndTest {
 
     }
 
+    @Test
+    @Ignore("This test needs a long run time")
+    public void testEventTaskAndEventHandler() throws Exception {
+        String workflowName = "test_workflow_for_eventHandler";
+        WorkflowDef workflowDefinition = createWorkflowDefinition(workflowName);
+
+        WorkflowTask eventTask = new WorkflowTask();
+        eventTask.setName("test_complete_task_event");
+        eventTask.setWorkflowTaskType(TaskType.EVENT);
+        eventTask.setTaskReferenceName("complete_task_with_event");
+        eventTask.setSink("conductor");
+
+        WorkflowTask waitTask = new WorkflowTask();
+        waitTask.setName("test_task_tobe_completed_by_eventHandler");
+        waitTask.setWorkflowTaskType(TaskType.WAIT);
+        waitTask.setTaskReferenceName("test_task_tobe_completed_by_eventHandler");
+
+        workflowDefinition.getTasks().add(eventTask);
+        workflowDefinition.getTasks().add(waitTask);
+        registerWorkflowDefinition(workflowDefinition);
+
+        String event = "conductor:test_workflow_for_eventHandler:complete_task_with_event";
+
+        String workflowId = startWorkflow(workflowName, workflowDefinition);
+        assertNotNull(workflowId);
+
+        Workflow workflow = getWorkflow(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals(Workflow.WorkflowStatus.RUNNING, workflow.getStatus());
+
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName("test_complete_task_event");
+        EventHandler.Action completeTaskAction = new EventHandler.Action();
+        completeTaskAction.setAction(EventHandler.Action.Type.complete_task);
+        completeTaskAction.setComplete_task(new EventHandler.TaskDetails());
+        completeTaskAction.getComplete_task().setTaskRefName(waitTask.getTaskReferenceName());
+        completeTaskAction.getComplete_task().setWorkflowId(workflowId);
+        completeTaskAction.getComplete_task().setOutput(new HashMap<>());
+        eventHandler.getActions().add(completeTaskAction);
+        eventHandler.setEvent(event);
+        eventHandler.setActive(true);
+        registerEventHandler(eventHandler);
+
+        // sleep for 100 seconds (need a really long wait time for the event to be processed)
+        Thread.sleep(100000L);
+
+        workflow = getWorkflow(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus());
+    }
+
+    @Test
+    public void testEventHandler() {
+        String eventName = "conductor:test_workflow:complete_task_with_event";
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName("test_complete_task_event");
+        EventHandler.Action completeTaskAction = new EventHandler.Action();
+        completeTaskAction.setAction(EventHandler.Action.Type.complete_task);
+        completeTaskAction.setComplete_task(new EventHandler.TaskDetails());
+        completeTaskAction.getComplete_task().setTaskRefName("test_task");
+        completeTaskAction.getComplete_task().setWorkflowId("test_id");
+        completeTaskAction.getComplete_task().setOutput(new HashMap<>());
+        eventHandler.getActions().add(completeTaskAction);
+        eventHandler.setEvent(eventName);
+        eventHandler.setActive(true);
+        registerEventHandler(eventHandler);
+
+        Iterator<EventHandler> it = getEventHandlers(eventName, true);
+        EventHandler result = it.next();
+        assertFalse(it.hasNext());
+        assertEquals(eventHandler.getName(), result.getName());
+    }
+
     protected WorkflowTask createWorkflowTask(String name) {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName(name);
@@ -238,4 +316,10 @@ public abstract class AbstractEndToEndTest {
     protected abstract TaskDef getTaskDefinition(String taskName);
 
     protected abstract void registerTaskDefinitions(List<TaskDef> taskDefinitionList);
+
+    protected abstract void registerWorkflowDefinition(WorkflowDef workflowDefinition);
+
+    protected abstract void registerEventHandler(EventHandler eventHandler);
+
+    protected abstract Iterator<EventHandler> getEventHandlers(String event, boolean activeOnly);
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/AbstractGrpcEndToEndTest.java
@@ -16,9 +16,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.conductor.client.grpc.EventClient;
 import com.netflix.conductor.client.grpc.MetadataClient;
 import com.netflix.conductor.client.grpc.TaskClient;
 import com.netflix.conductor.client.grpc.WorkflowClient;
+import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -33,6 +35,8 @@ import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.test.integration.AbstractEndToEndTest;
+
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import org.junit.Test;
@@ -52,6 +56,7 @@ public abstract class AbstractGrpcEndToEndTest extends AbstractEndToEndTest {
     protected static TaskClient taskClient;
     protected static WorkflowClient workflowClient;
     protected static MetadataClient metadataClient;
+    protected static EventClient eventClient;
 
     @Override
     protected String startWorkflow(String workflowExecutionName, WorkflowDef workflowDefinition) {
@@ -74,6 +79,21 @@ public abstract class AbstractGrpcEndToEndTest extends AbstractEndToEndTest {
     @Override
     protected void registerTaskDefinitions(List<TaskDef> taskDefinitionList) {
         metadataClient.registerTaskDefs(taskDefinitionList);
+    }
+
+    @Override
+    protected void registerWorkflowDefinition(WorkflowDef workflowDefinition) {
+        metadataClient.registerWorkflowDef(workflowDefinition);
+    }
+
+    @Override
+    protected void registerEventHandler(EventHandler eventHandler) {
+        eventClient.registerEventHandler(eventHandler);
+    }
+
+    @Override
+    protected Iterator<EventHandler> getEventHandlers(String event, boolean activeOnly) {
+        return eventClient.getEventHandlers(event, activeOnly);
     }
 
     @Test

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/GrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/GrpcEndToEndTest.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.test.integration.grpc;
 
+import com.netflix.conductor.client.grpc.EventClient;
 import com.netflix.conductor.client.grpc.MetadataClient;
 import com.netflix.conductor.client.grpc.TaskClient;
 import com.netflix.conductor.client.grpc.WorkflowClient;
@@ -24,5 +25,6 @@ public class GrpcEndToEndTest extends AbstractGrpcEndToEndTest {
         taskClient = new TaskClient("localhost", 8092);
         workflowClient = new WorkflowClient("localhost", 8092);
         metadataClient = new MetadataClient("localhost", 8092);
+        eventClient = new EventClient("localhost", 8092);
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/mysql/MySQLGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/mysql/MySQLGrpcEndToEndTest.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.test.integration.grpc.mysql;
 
+import com.netflix.conductor.client.grpc.EventClient;
 import com.netflix.conductor.client.grpc.MetadataClient;
 import com.netflix.conductor.client.grpc.TaskClient;
 import com.netflix.conductor.client.grpc.WorkflowClient;
@@ -38,5 +39,6 @@ public class MySQLGrpcEndToEndTest extends AbstractGrpcEndToEndTest {
         taskClient = new TaskClient("localhost", 8094);
         workflowClient = new WorkflowClient("localhost", 8094);
         metadataClient = new MetadataClient("localhost", 8094);
+        eventClient = new EventClient("localhost", 8094);
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/postgres/PostgresGrpcEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/grpc/postgres/PostgresGrpcEndToEndTest.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.test.integration.grpc.postgres;
 
+import com.netflix.conductor.client.grpc.EventClient;
 import com.netflix.conductor.client.grpc.MetadataClient;
 import com.netflix.conductor.client.grpc.TaskClient;
 import com.netflix.conductor.client.grpc.WorkflowClient;
@@ -38,5 +39,6 @@ public class PostgresGrpcEndToEndTest extends AbstractGrpcEndToEndTest {
         taskClient = new TaskClient("localhost", 8098);
         workflowClient = new WorkflowClient("localhost", 8098);
         metadataClient = new MetadataClient("localhost", 8098);
+        eventClient = new EventClient("localhost", 8098);
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/http/AbstractHttpEndToEndTest.java
@@ -18,9 +18,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
+import com.netflix.conductor.client.http.EventClient;
 import com.netflix.conductor.client.http.MetadataClient;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -38,6 +40,7 @@ import com.netflix.conductor.common.validation.ValidationError;
 import com.netflix.conductor.test.integration.AbstractEndToEndTest;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -61,6 +64,7 @@ public abstract class AbstractHttpEndToEndTest extends AbstractEndToEndTest {
     protected static TaskClient taskClient;
     protected static WorkflowClient workflowClient;
     protected static MetadataClient metadataClient;
+    protected static EventClient eventClient;
 
     @Override
     protected String startWorkflow(String workflowExecutionName, WorkflowDef workflowDefinition) {
@@ -84,6 +88,21 @@ public abstract class AbstractHttpEndToEndTest extends AbstractEndToEndTest {
     @Override
     protected void registerTaskDefinitions(List<TaskDef> taskDefinitionList) {
         metadataClient.registerTaskDefs(taskDefinitionList);
+    }
+
+    @Override
+    protected void registerWorkflowDefinition(WorkflowDef workflowDefinition) {
+        metadataClient.registerWorkflowDef(workflowDefinition);
+    }
+
+    @Override
+    protected void registerEventHandler(EventHandler eventHandler) {
+        eventClient.registerEventHandler(eventHandler);
+    }
+
+    @Override
+    protected Iterator<EventHandler> getEventHandlers(String event, boolean activeOnly) {
+        return eventClient.getEventHandlers(event, activeOnly).iterator();
     }
 
     @Test

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/http/HttpEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/http/HttpEndToEndTest.java
@@ -12,10 +12,14 @@
  */
 package com.netflix.conductor.test.integration.http;
 
+import com.netflix.conductor.client.http.EventClient;
 import com.netflix.conductor.client.http.MetadataClient;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.common.metadata.events.EventHandler;
 import org.junit.Before;
+
+import java.util.Iterator;
 
 public class HttpEndToEndTest extends AbstractHttpEndToEndTest {
 
@@ -31,5 +35,8 @@ public class HttpEndToEndTest extends AbstractHttpEndToEndTest {
 
         metadataClient = new MetadataClient();
         metadataClient.setRootURI(apiRoot);
+
+        eventClient = new EventClient();
+        eventClient.setRootURI(apiRoot);
     }
 }

--- a/test-harness/src/test/resources/application-integrationtest.properties
+++ b/test-harness/src/test/resources/application-integrationtest.properties
@@ -23,7 +23,7 @@ conductor.app.appId=conductor
 
 conductor.app.workflow-offset-timeout=30s
 
-conductor.system-task-workers.enabled=false
+conductor.system-task-workers.enabled=true
 conductor.app.system-task-worker-callback-duration=0
 
 conductor.app.event-message-indexing-enabled=true


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Added event handler CRUD operations for both http and grpc client.

_Describe the new behavior from this PR, and why it's needed_
Issue # MWI-3374, to support auto registration of event handlers in springboot-starter workflow client.

Alternatives considered
----

_Describe alternative implementation you have considered_
