### PR TITLE
Remove dependency on Netflix Servo

### DIFF
--- a/azureblob-storage/dependencies.lock
+++ b/azureblob-storage/dependencies.lock
@@ -57,6 +57,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -78,12 +84,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -192,6 +192,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -213,12 +219,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/cassandra-persistence/build.gradle
+++ b/cassandra-persistence/build.gradle
@@ -18,11 +18,17 @@ dependencies {
 
     implementation "com.datastax.cassandra:cassandra-driver-core:${revCassandra}"
     implementation "org.apache.commons:commons-lang3"
-
     implementation 'org.apache.logging.log4j:log4j-web'
 
     testImplementation("org.cassandraunit:cassandra-unit:${revCassandraUnit}") {
         exclude group: "com.datastax.cassandra", module: "cassandra-driver-core"
+    }
+
+    // Using higher guava version than the following causes test failure.
+    testImplementation ('com.google.guava:guava') {
+        version {
+            strictly '23.6.1-jre'
+        }
     }
 
     testImplementation project(':conductor-core').sourceSets.test.output

--- a/cassandra-persistence/dependencies.lock
+++ b/cassandra-persistence/dependencies.lock
@@ -60,6 +60,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -81,12 +87,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -146,6 +146,9 @@
         "com.datastax.cassandra:cassandra-driver-core": {
             "locked": "3.10.2"
         },
+        "com.google.guava:guava": {
+            "locked": "23.6.1-jre"
+        },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
@@ -204,6 +207,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "23.6.1-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -225,12 +234,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -100,6 +100,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -123,12 +126,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -313,6 +310,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -336,12 +336,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,7 +34,8 @@ dependencies {
 
     implementation "io.reactivex:rxjava:${revRxJava}"
 
-    implementation "com.netflix.servo:servo-core:${revServo}"
+    implementation "com.google.guava:guava:${revGuava}"
+
     implementation "com.netflix.spectator:spectator-api:${revSpectator}"
 
     implementation "org.apache.bval:bval-jsr:${revBval}"

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -14,6 +14,9 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.11.4"
         },
+        "com.google.guava:guava": {
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "locked": "3.13.0"
         },
@@ -22,9 +25,6 @@
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.122.0"
@@ -85,6 +85,9 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
@@ -96,9 +99,6 @@
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.122.0"
@@ -141,6 +141,9 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.11.4"
         },
+        "com.google.guava:guava": {
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "locked": "3.13.0"
         },
@@ -149,9 +152,6 @@
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.122.0"
@@ -227,6 +227,9 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
@@ -238,9 +241,6 @@
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.122.0"

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -15,8 +15,6 @@ package com.netflix.conductor.metrics;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
-import com.netflix.servo.monitor.BasicStopwatch;
-import com.netflix.servo.monitor.Stopwatch;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Gauge;
@@ -47,18 +45,6 @@ public class Monitors {
     public static final String classQualifier = "WorkflowMonitor";
 
     private Monitors() {
-    }
-
-    /**
-     * @param className  Name of the class
-     * @param methodName Method name
-     */
-    public static void error(String className, String methodName) {
-        getCounter(className, "workflow_server_error", "methodName", methodName).increment();
-    }
-
-    public static Stopwatch start(String className, String name, String... additionalTags) {
-        return start(getTimer(className, name, additionalTags));
     }
 
     /**
@@ -148,18 +134,13 @@ public class Monitors {
         return tags;
     }
 
-    private static Stopwatch start(Timer sm) {
 
-        Stopwatch sw = new BasicStopwatch() {
-            @Override
-            public void stop() {
-                super.stop();
-                long duration = getDuration(TimeUnit.MILLISECONDS);
-                sm.record(duration, TimeUnit.MILLISECONDS);
-            }
-        };
-        sw.start();
-        return sw;
+    /**
+     * @param className  Name of the class
+     * @param methodName Method name
+     */
+    public static void error(String className, String methodName) {
+        getCounter(className, "workflow_server_error", "methodName", methodName).increment();
     }
 
     public static void recordGauge(String name, long count, String... tags) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,7 +56,6 @@ ext {
     revRarefiedRedis = '0.0.17'
     revRedisson = '3.13.3'
     revRxJava = '1.2.2'
-    revServo = '0.13.0'
     revSpectator = '0.122.0'
     revSpock = '1.3-groovy-2.5'
     revSpotifyCompletableFutures = '0.3.3'

--- a/es6-persistence/dependencies.lock
+++ b/es6-persistence/dependencies.lock
@@ -67,6 +67,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -90,12 +93,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -229,6 +226,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -252,12 +252,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/es7-persistence/dependencies.lock
+++ b/es7-persistence/dependencies.lock
@@ -70,6 +70,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -93,12 +96,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -237,6 +234,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -260,12 +260,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/grpc-server/dependencies.lock
+++ b/grpc-server/dependencies.lock
@@ -60,6 +60,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -86,12 +92,6 @@
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -233,6 +233,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -259,12 +265,6 @@
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -70,6 +70,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -93,12 +96,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -232,6 +229,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -255,12 +255,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/postgres-persistence/dependencies.lock
+++ b/postgres-persistence/dependencies.lock
@@ -70,6 +70,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -93,12 +96,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -232,6 +229,9 @@
             "locked": "1.0.0"
         },
         "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
             "locked": "30.0-jre"
         },
         "com.google.protobuf:protobuf-java": {
@@ -255,12 +255,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/redis-lock/dependencies.lock
+++ b/redis-lock/dependencies.lock
@@ -54,6 +54,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -75,12 +81,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -195,6 +195,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -216,12 +222,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -57,6 +57,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -81,12 +87,6 @@
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -201,6 +201,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -225,12 +231,6 @@
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
             "locked": "2.0.20"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/rest/dependencies.lock
+++ b/rest/dependencies.lock
@@ -54,6 +54,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -78,12 +84,6 @@
         },
         "com.netflix.runtime:health-api": {
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -198,6 +198,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -222,12 +228,6 @@
         },
         "com.netflix.runtime:health-api": {
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -124,6 +124,7 @@
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -221,12 +222,6 @@
                 "com.netflix.conductor:conductor-rest"
             ],
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -531,6 +526,7 @@
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -628,12 +624,6 @@
                 "com.netflix.conductor:conductor-rest"
             ],
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -1018,6 +1008,7 @@
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
@@ -1115,12 +1106,6 @@
                 "com.netflix.conductor:conductor-rest"
             ],
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -179,6 +179,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-mysql-persistence",
@@ -327,12 +328,6 @@
                 "com.netflix.conductor:conductor-rest"
             ],
             "locked": "1.1.4"
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/zookeeper-lock/dependencies.lock
+++ b/zookeeper-lock/dependencies.lock
@@ -54,6 +54,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -75,12 +81,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -192,6 +192,12 @@
             ],
             "locked": "1.0.0"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "30.0-jre"
+        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
@@ -213,12 +219,6 @@
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.13.0"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Netflix Servo is a deprecated library. Conductor's dependency on Servo can
be simply removed due to code related to Servo Stopwatch is not used anywhere.

Also need to explicitly add Guava after removing servo dependency.

Build and test pass except for cassandraDaoTest during test teardown for cleanupData.

We will investigate more on explicitly adding guava dependency causing test
failure.

Signed-off-by: Tao Jiang <taoj@vmware.com>

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Removed Netflix Servo dependency because related code is unused. This is a small step for cleaning up dependencies.

_Describe the new behavior from this PR, and why it's needed_
Issue # 
https://github.com/Netflix/conductor/discussions/2501

Alternatives considered
----
Directly make Monitors from class to interface. 

_Describe alternative implementation you have considered

In order to make Monitors class to Interface need to create an almost identical amount to work already exists in spectator-api which may not worthwhile to do so. 
