### PR TITLE
[FEATURE] Add field to update task by reference name

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -61,6 +61,8 @@ public class TaskResult {
     @ProtoField(id = 8)
     private Any outputMessage;
 
+    private String taskReferenceName;
+
     private List<TaskExecLog> logs = new CopyOnWriteArrayList<>();
 
     private String externalOutputPayloadStoragePath;
@@ -76,6 +78,7 @@ public class TaskResult {
         this.outputData = task.getOutputData();
         this.externalOutputPayloadStoragePath = task.getExternalOutputPayloadStoragePath();
         this.subWorkflowId = task.getSubWorkflowId();
+        this.taskReferenceName = task.getReferenceTaskName();
         switch (task.getStatus()) {
             case CANCELED:
             case COMPLETED_WITH_ERRORS:
@@ -113,6 +116,12 @@ public class TaskResult {
 
     public void setTaskId(String taskId) {
         this.taskId = taskId;
+    }
+
+    public String getTaskReferenceName() { return this.taskReferenceName; }
+
+    public void setTaskReferenceName(String referenceName) {
+        this.taskReferenceName = referenceName;
     }
 
     public String getReasonForIncompletion() {
@@ -266,6 +275,7 @@ public class TaskResult {
             ", logs=" + logs +
             ", externalOutputPayloadStoragePath='" + externalOutputPayloadStoragePath + '\'' +
             ", subWorkflowId='" + subWorkflowId + '\'' +
+            ", taskReferenceName='" + taskReferenceName + '\'' +
             '}';
     }
 
@@ -310,6 +320,7 @@ public class TaskResult {
         taskResult.setOutputMessage(outputMessage);
         taskResult.setLogs(logs);
         taskResult.setSubWorkflowId(subWorkflowId);
+        taskResult.setTaskReferenceName(taskReferenceName);
         return taskResult;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -936,9 +936,17 @@ public class WorkflowExecutor {
             workflowInstance = metadataMapperService.populateWorkflowWithDefinitions(workflowInstance);
         }
 
-        Task task = Optional.ofNullable(executionDAOFacade.getTaskById(taskResult.getTaskId()))
-            .orElseThrow(() -> new ApplicationException(ApplicationException.Code.NOT_FOUND,
-                "No such task found by id: " + taskResult.getTaskId()));
+        Task task;
+
+        if (taskResult.getTaskReferenceName() != null && !taskResult.getTaskReferenceName().isEmpty()) {
+            task = Optional.ofNullable(workflowInstance.getTaskByRefName(taskResult.getTaskReferenceName()))
+                    .orElseThrow(() -> new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                            "No such task found by reference name: " + taskResult.getTaskReferenceName()));
+        } else {
+            task = Optional.ofNullable(executionDAOFacade.getTaskById(taskResult.getTaskId()))
+                    .orElseThrow(() -> new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                            "No such task found by id: " + taskResult.getTaskId()));
+        }
 
         LOGGER.debug("Task: {} belonging to Workflow {} being updated", task, workflowInstance);
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Adds a new field to update task by reference name.

Alternatives considered
----

The below case

![Untitled Diagram (2)](https://user-images.githubusercontent.com/33331415/137185826-04869849-90da-4b56-8faf-c80331edf982.jpg)

For now is impossible pass a task id to Kafka for it updates a WAIT task using `POST /api/tasks`. For solve it this PR adds a new field to enable update a task by reference name.

Notes:
- I'm using an external app with Kafka for avoid application polling
- There's the possibility to make a request to `GET /api/workflows/{id}` for retrieve all tasks, but it is expensive