### PR TITLE
Fix Security Vulnerability on xstream component

### DIFF
--- a/redis-persistence/build.gradle
+++ b/redis-persistence/build.gradle
@@ -18,6 +18,11 @@ dependencies {
 
     implementation "redis.clients:jedis:${revJedis}"
     implementation "com.netflix.dyno-queues:dyno-queues-redis:${revDynoQueues}"
+    constraints {
+        implementation('com.thoughtworks.xstream:xstream:1.4.18') {
+            because 'The version pulled from dyno-queues has security vulnerability'
+        }
+    }
 
     //In memory
     implementation "org.rarefiedredis.redis:redis-java:${revRarefiedRedis}"


### PR DESCRIPTION
Signed-off-by: Tao Jiang <taoj@vmware.com>

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

Some critical vulnerabilities exist in the XStream component used in Conductor.

Issue # 2505
https://github.com/Netflix/conductor/issues/2505

Alternatives considered
----
Deprecate and discontinue support for DynoQueues

_Describe alternative implementation you have considered

This approach inlines with the conductor's roadmap. https://github.com/Netflix/conductor/wiki/Roadmap but it may take a longer time to implement.
