### PR TITLE
fix issue that workflow not refetched when search with same query condition

### DIFF
--- a/ui/src/pages/executions/WorkflowSearch.jsx
+++ b/ui/src/pages/executions/WorkflowSearch.jsx
@@ -93,10 +93,10 @@ export default function WorkflowPanel() {
     const newQueryFT = buildQuery();
     setQueryFT(newQueryFT);
 
+    // Only force refetch if query didn't change. Else let react-query detect difference and refetch automatically
     if (_.isEqual(oldQueryFT, newQueryFT)) {
       refetch();
     }
-    // Only force refetch if query didn't change. Else let react-query detect difference and refetch automatically
   }
 
   const handlePage = (page) => {


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Correctly check old vs new query equality with `_.isEqual`, and refetch if query not changed 


Alternatives considered
----

_Describe alternative implementation you have considered_
