### PR TITLE
[FEATURE] Avro and Confluent Schema Registry integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ allprojects {
             url "https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates"
         }
 
+        maven {
+            url "https://packages.confluent.io/maven/"
+        }
+
         /**
          * This repository locates artifacts that don't exist in maven central but we had to backup from jcenter
          * The exclusiveContent

--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation "org.apache.kafka:kafka-clients:${revKafka}"
 
     implementation "io.confluent:kafka-avro-serializer:${revConfluent}"
-
     implementation "org.apache.avro:avro:${revAvro}"
+    implementation "tech.allegro.schema.json2avro:converter:${revAvroToJson}"
 
     implementation "com.rabbitmq:amqp-client:${revAmqpClient}"
 

--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -10,7 +10,6 @@
  *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  *  specific language governing permissions and limitations under the License.
  */
-
 dependencies {
     implementation project(':conductor-common')
     implementation project(':conductor-core')
@@ -29,6 +28,10 @@ dependencies {
     implementation "javax.ws.rs:jsr311-api:${revJsr311Api}"
 
     implementation "org.apache.kafka:kafka-clients:${revKafka}"
+
+    implementation "io.confluent:kafka-avro-serializer:${revConfluent}"
+
+    implementation "org.apache.avro:avro:${revAvro}"
 
     implementation "com.rabbitmq:amqp-client:${revAmqpClient}"
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaProducerManager.java
@@ -16,7 +16,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
-import java.time.Duration;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -98,7 +99,8 @@ public class KafkaProducerManager {
 
         configProperties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
         configProperties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs);
-        configProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, STRING_SERIALIZER);
+        configProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, input.getValueSerializer());
+        configProperties.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, input.getSchemaRegistryUrl());
         return configProperties;
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaPublishTask.java
@@ -50,8 +50,8 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 
     static final String REQUEST_PARAMETER_NAME = "kafka_request";
     private static final String MISSING_REQUEST =
-        "Missing Kafka request. Task input MUST have a '" + REQUEST_PARAMETER_NAME
-            + "' key with KafkaTask.Input as value. See documentation for KafkaTask for required input parameters";
+            "Missing Kafka request. Task input MUST have a '" + REQUEST_PARAMETER_NAME
+                    + "' key with KafkaTask.Input as value. See documentation for KafkaTask for required input parameters";
     private static final String MISSING_BOOT_STRAP_SERVERS = "No boot strap servers specified";
     private static final String MISSING_KAFKA_TOPIC = "Missing Kafka topic. See documentation for KafkaTask for required input parameters";
     private static final String MISSING_KAFKA_VALUE = "Missing Kafka value.  See documentation for KafkaTask for required input parameters";
@@ -144,10 +144,10 @@ public class KafkaPublishTask extends WorkflowSystemTask {
         Object key = getKey(input);
 
         Iterable<Header> headers = input.getHeaders().entrySet().stream()
-            .map(header -> new RecordHeader(header.getKey(), String.valueOf(header.getValue()).getBytes()))
-            .collect(Collectors.toList());
-        ProducerRecord rec = new ProducerRecord(input.getTopic(), null,
-            null, key, objectMapper.writeValueAsString(input.getValue()), headers);
+                .map(header -> new RecordHeader(header.getKey(), String.valueOf(header.getValue()).getBytes()))
+                .collect(Collectors.toList());
+        ProducerRecord<String, Object> rec = new ProducerRecord(input.getTopic(), null,
+                null, key, objectMapper.writeValueAsString(input.getValue()), headers);
 
         Future send = producer.send(rec);
 
@@ -198,6 +198,8 @@ public class KafkaPublishTask extends WorkflowSystemTask {
         private Integer maxBlockMs;
         private String topic;
         private String keySerializer = STRING_SERIALIZER;
+        private String valueSerializer = STRING_SERIALIZER;
+        private String schemaRegistryUrl;
 
         public Map<String, Object> getHeaders() {
             return headers;
@@ -263,18 +265,36 @@ public class KafkaPublishTask extends WorkflowSystemTask {
             this.maxBlockMs = maxBlockMs;
         }
 
+        public String getValueSerializer() {
+            return valueSerializer;
+        }
+
+        public void setValueSerializer(String valueSerializer) {
+            this.valueSerializer = valueSerializer;
+        }
+
+        public String getSchemaRegistryUrl() {
+            return schemaRegistryUrl;
+        }
+
+        public void setSchemaRegistryUrl(String schemaRegistryUrl) {
+            this.schemaRegistryUrl = schemaRegistryUrl;
+        }
+
         @Override
         public String toString() {
             return "Input{" +
-                "headers=" + headers +
-                ", bootStrapServers='" + bootStrapServers + '\'' +
-                ", key=" + key +
-                ", value=" + value +
-                ", requestTimeoutMs=" + requestTimeoutMs +
-                ", maxBlockMs=" + maxBlockMs +
-                ", topic='" + topic + '\'' +
-                ", keySerializer='" + keySerializer + '\'' +
-                '}';
+                    "headers=" + headers +
+                    ", bootStrapServers='" + bootStrapServers + '\'' +
+                    ", key=" + key +
+                    ", value=" + value +
+                    ", requestTimeoutMs=" + requestTimeoutMs +
+                    ", maxBlockMs=" + maxBlockMs +
+                    ", topic='" + topic + '\'' +
+                    ", keySerializer='" + keySerializer + '\'' +
+                    ", valueSerializer='" + valueSerializer + '\'' +
+                    ", schemaRegistryUrl='" + schemaRegistryUrl + '\'' +
+                    '}';
         }
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/kafka/KafkaPublishTask.java
@@ -220,7 +220,7 @@ public class KafkaPublishTask extends WorkflowSystemTask {
         private String topic;
         private String keySerializer = STRING_SERIALIZER;
         private String valueSerializer = STRING_SERIALIZER;
-        private String schemaRegistryUrl;
+        private String schemaRegistryUrl = "";
 
         public Map<String, Object> getHeaders() {
             return headers;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,4 +61,6 @@ ext {
     revSpock = '1.3-groovy-2.5'
     revSpotifyCompletableFutures = '0.3.3'
     revTestContainer = '1.15.3'
+    revConfluent = '5.3.0'
+    revAvro = '1.10.2'
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,4 +63,5 @@ ext {
     revTestContainer = '1.15.3'
     revConfluent = '5.3.0'
     revAvro = '1.10.2'
+    revAvroToJson = '0.2.10'
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Adds Avro and Schema Registry integration. Now, makes it easy to send decoded messages using Avro format.

Alternatives considered
----

That implementation adds a `if` to switch between default value serializer and kafka avro serializer to avoid over engineering, but we could implement a new code block to interface with other implementations/serializers.

Usage
------
```json
{
    "name": "task_a",
    "taskReferenceName": "task_a_ref",
    "inputParameters": {
        "kafka_request": {
            "maxBlockMs": 5000,
            "topic": "custom-topic",
            "value": {
                "workflow_id": "${workflow.workflowId}"
            },
            "bootStrapServers": "localhost:9092",
            "headers": {},
            "key": "${workflow.input.request_id}",
            "keySerializer": "org.apache.kafka.common.serialization.StringSerializer",
            "valueSerializer": "io.confluent.kafka.serializers.KafkaAvroSerializer",
            "schemaRegistryUrl": "http://localhost:8081"
        }
    },
    "type": "KAFKA_PUBLISH"
}
```