### PR TITLE
[FEATURE] Implement PSQL based object storage for Conductor

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -20,6 +20,11 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-s3:${revAwsSdk}"
     implementation "com.amazonaws:aws-java-sdk-sqs:${revAwsSdk}"
 
+    implementation "org.postgresql:postgresql"
+    implementation "org.springframework.boot:spring-boot-starter-jdbc"
+    implementation "org.flywaydb:flyway-core"
+    implementation "org.springdoc:springdoc-openapi-ui:${revOpenapi}"
+
     implementation "org.apache.commons:commons-lang3:"
 
     implementation "net.thisptr:jackson-jq:${revJq}"
@@ -44,6 +49,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation "org.testcontainers:mockserver:${revTestContainer}"
     testImplementation "org.mock-server:mockserver-client-java:${revMockServerClient}"
+    testImplementation "org.testcontainers:postgresql:${revTestContainer}"
 
     testImplementation project(':conductor-common').sourceSets.test.output
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadStorage.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadStorage.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres;
+
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.contribs.storage.postgres.config.PostgresPayloadProperties;
+import com.netflix.conductor.core.exception.ApplicationException;
+import com.netflix.conductor.core.utils.IDGenerator;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Store and pull the external payload which consists of key
+ * and stream of data in PostgreSQL database
+ */
+public class PostgresPayloadStorage implements ExternalPayloadStorage {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresPayloadStorage.class);
+
+    private final DataSource postgresDataSource;
+    private final String tableName;
+    private final String conductorUrl;
+
+    public PostgresPayloadStorage(PostgresPayloadProperties properties, DataSource dataSource) {
+        tableName = properties.getTableName();
+        conductorUrl = properties.getConductorUrl();
+        this.postgresDataSource = dataSource;
+        LOGGER.info("PostgreSQL Extenal Payload Storage initialized.");
+    }
+
+    /**
+     * @param operation   the type of {@link Operation} to be performed
+     * @param payloadType the {@link PayloadType} that is being accessed
+     * @return a {@link ExternalStorageLocation} object which contains the pre-signed URL
+     * and the PostgreSQL object key for the json payload
+     */
+    @Override
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path) {
+
+        ExternalStorageLocation externalStorageLocation = new ExternalStorageLocation();
+        String objectKey;
+        if (StringUtils.isNotBlank(path)) {
+            objectKey = path;
+        } else {
+            objectKey = IDGenerator.generate() + ".json";
+        }
+        String uri = conductorUrl + "/api/external/postgres/" + objectKey;
+        externalStorageLocation.setUri(uri);
+        externalStorageLocation.setPath(objectKey);
+        LOGGER.debug("External storage location URI: {}, location path: {}", uri, objectKey);
+        return externalStorageLocation;
+    }
+
+    /**
+     * Uploads the payload to the given PostgreSQL object key. It is expected that the caller retrieves the object key using
+     * {@link #getLocation(Operation, PayloadType, String)} before making this call.
+     *
+     * @param key         the PostgreSQL key of the object to be uploaded
+     * @param payload     an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     */
+    @Override
+    public void upload(String key, InputStream payload, long payloadSize) {
+        try (Connection conn = postgresDataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
+            stmt.setString(1, key);
+            stmt.setBinaryStream(2, payload, payloadSize);
+            stmt.executeUpdate();
+            LOGGER.debug("External PostgreSQL uploaded key: {}, payload size: {}", key, payloadSize);
+        } catch (SQLException e) {
+            String msg = "Error uploading data into External PostgreSQL";
+            LOGGER.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+    }
+
+    /**
+     * Downloads the payload stored in the PostgreSQL.
+     *
+     * @param key the PostgreSQL key of the object
+     * @return an input stream containing the contents of the object. Caller is expected to close the input stream.
+     */
+    @Override
+    public InputStream download(String key) {
+        InputStream inputStream;
+        try (Connection conn = postgresDataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("SELECT data FROM " + tableName + " WHERE id = ?")) {
+            stmt.setString(1, key);
+            ResultSet rs = stmt.executeQuery();
+            rs.next();
+            inputStream = rs.getBinaryStream(1);
+            rs.close();
+            LOGGER.debug("External PostgreSQL downloaded key: {}", key);
+        } catch (SQLException e) {
+            String msg = "Error downloading data from external PostgreSQL";
+            LOGGER.error(msg, e);
+            throw new ApplicationException(ApplicationException.Code.BACKEND_ERROR, msg, e);
+        }
+        return inputStream;
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/config/PostgresPayloadConfiguration.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/config/PostgresPayloadConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres.config;
+
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.contribs.storage.postgres.PostgresPayloadStorage;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration()
+@EnableConfigurationProperties(PostgresPayloadProperties.class)
+@ConditionalOnProperty(name = "conductor.external-payload-storage.type", havingValue = "postgres")
+public class PostgresPayloadConfiguration {
+
+    PostgresPayloadProperties properties;
+
+    public PostgresPayloadConfiguration(PostgresPayloadProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean(initMethod = "migrate")
+    @PostConstruct
+    public Flyway flywayForExternalDb() {
+        return Flyway.configure()
+            .locations("classpath:db/migration_external_postgres")
+            .schemas("external")
+            .baselineOnMigrate(true)
+            .placeholderReplacement(true)
+            .placeholders(Map.of("tableName", properties.getTableName(),
+                "maxDataRows", String.valueOf(properties.getMaxDataRows()),
+                "maxDataDays", "'" + properties.getMaxDataDays() + "'",
+                "maxDataMonths", "'" + properties.getMaxDataMonths() + "'",
+                "maxDataYears", "'" + properties.getMaxDataYears() + "'"))
+            .dataSource(DataSourceBuilder.create()
+                .driverClassName("org.postgresql.Driver")
+                .url(properties.getUrl())
+                .username(properties.getUsername())
+                .password(properties.getPassword())
+                .build())
+            .load();
+    }
+
+    @Bean
+    public ExternalPayloadStorage postgresExternalPayloadStorage(PostgresPayloadProperties properties) {
+        DataSource dataSource = DataSourceBuilder.create().driverClassName("org.postgresql.Driver")
+            .url(properties.getUrl()).username(properties.getUsername()).password(properties.getPassword()).build();
+        return new PostgresPayloadStorage(properties, dataSource);
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/config/PostgresPayloadProperties.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/config/PostgresPayloadProperties.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("conductor.external-payload-storage.postgres")
+public class PostgresPayloadProperties {
+
+    /**
+     * The PostgreSQL schema and table name where the payloads will be stored
+     */
+    private String tableName = "external.external_payload";
+
+    /**
+     * Username for connecting to PostgreSQL database
+     */
+    private String username;
+
+    /**
+     * Password for connecting to PostgreSQL database
+     */
+    private String password;
+
+    /**
+     * URL for connecting to PostgreSQL database
+     */
+    private String url;
+
+    /**
+     * Maximum count of data rows in PostgreSQL database.
+     * After overcoming this limit, the oldest data will be deleted.
+     */
+    private long maxDataRows = Long.MAX_VALUE;
+
+    /**
+     * Maximum count of days of data age in PostgreSQL database.
+     * After overcoming limit, the oldest data will be deleted.
+     */
+    private int maxDataDays = 0;
+
+    /**
+     * Maximum count of months of data age in PostgreSQL database.
+     * After overcoming limit, the oldest data will be deleted.
+     */
+    private int maxDataMonths = 0;
+
+    /**
+     * Maximum count of years of data age in PostgreSQL database.
+     * After overcoming limit, the oldest data will be deleted.
+     */
+    private int maxDataYears = 1;
+
+    /**
+     * URL, that can be used to pull the json configurations,
+     * that will be downloaded from PostgreSQL to the conductor server.
+     * For example: for local development it is "http://localhost:8080"
+     */
+    private String conductorUrl = "";
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getConductorUrl() {
+        return conductorUrl;
+    }
+
+    public long getMaxDataRows() {
+        return maxDataRows;
+    }
+
+    public int getMaxDataDays() {
+        return maxDataDays;
+    }
+
+    public int getMaxDataMonths() {
+        return maxDataMonths;
+    }
+
+    public int getMaxDataYears() {
+        return maxDataYears;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void setConductorUrl(String conductorUrl) {
+        this.conductorUrl = conductorUrl;
+    }
+
+    public void setMaxDataRows(long maxDataRows) {
+        this.maxDataRows = maxDataRows;
+    }
+
+    public void setMaxDataDays(int maxDataDays) {
+        this.maxDataDays = maxDataDays;
+    }
+
+    public void setMaxDataMonths(int maxDataMonths) {
+        this.maxDataMonths = maxDataMonths;
+    }
+
+    public void setMaxDataYears(int maxDataYears) {
+        this.maxDataYears = maxDataYears;
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/controller/ExternalPostgresPayloadResource.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/postgres/controller/ExternalPostgresPayloadResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres.controller;
+
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import io.swagger.v3.oas.annotations.Operation;
+import java.io.InputStream;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for pulling payload stream of data
+ * by key (externalPayloadPath) from PostgreSQL database
+ */
+@RestController
+@RequestMapping(value = "/api/external/postgres")
+@ConditionalOnProperty(name = "conductor.external-payload-storage.type", havingValue = "postgres")
+public class ExternalPostgresPayloadResource {
+
+    private final ExternalPayloadStorage postgresService;
+
+    public ExternalPostgresPayloadResource(@Qualifier("postgresExternalPayloadStorage")
+                                   ExternalPayloadStorage postgresService) {
+        this.postgresService = postgresService;
+    }
+
+    @GetMapping("/{externalPayloadPath}")
+    @Operation(summary = "Get task or workflow by externalPayloadPath from External PostgreSQL Storage")
+    public ResponseEntity<InputStreamResource> getExternalStorageData(@PathVariable("externalPayloadPath")
+                                                                        String externalPayloadPath) {
+        InputStream inputStream = postgresService.download(externalPayloadPath);
+        InputStreamResource outputStreamBody =  new InputStreamResource(inputStream);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(outputStreamBody);
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/S3PayloadStorage.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/S3PayloadStorage.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.contribs.storage;
+package com.netflix.conductor.contribs.storage.s3;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
@@ -23,7 +23,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
-import com.netflix.conductor.contribs.storage.config.S3Properties;
+import com.netflix.conductor.contribs.storage.s3.config.S3Properties;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.utils.IDGenerator;
 import java.io.InputStream;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/config/S3Configuration.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/config/S3Configuration.java
@@ -10,10 +10,10 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.contribs.storage.config;
+package com.netflix.conductor.contribs.storage.s3.config;
 
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
-import com.netflix.conductor.contribs.storage.S3PayloadStorage;
+import com.netflix.conductor.contribs.storage.s3.S3PayloadStorage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/config/S3Properties.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/s3/config/S3Properties.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.contribs.storage.config;
+package com.netflix.conductor.contribs.storage.s3.config;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;

--- a/contribs/src/main/resources/db/migration_external_postgres/R__initial_schema.sql
+++ b/contribs/src/main/resources/db/migration_external_postgres/R__initial_schema.sql
@@ -1,0 +1,56 @@
+--
+-- Copyright 2021 Netflix, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+-- --------------------------------------------------------------------------------------------------------------
+-- SCHEMA FOR EXTERNAL PAYLOAD POSTGRES STORAGE
+-- --------------------------------------------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS ${tableName}
+(
+    id   TEXT,
+    data bytea NOT NULL,
+    created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE ${tableName} ALTER COLUMN data SET STORAGE EXTERNAL;
+
+-- Delete trigger to delete the oldest external_payload rows,
+-- when there are too many or there are too old.
+
+DROP TRIGGER IF EXISTS tr_keep_row_number_steady ON ${tableName};
+
+CREATE OR REPLACE FUNCTION keep_row_number_steady()
+    RETURNS TRIGGER AS
+$body$
+DECLARE
+    time_interval interval := concat(${maxDataYears},' years ',${maxDataMonths},' mons ',${maxDataDays},' days' );
+BEGIN
+    WHILE ((SELECT count(id) FROM ${tableName}) > ${maxDataRows}) OR
+       ((SELECT min(created_on) FROM ${tableName}) < (CURRENT_TIMESTAMP - time_interval))
+    LOOP
+        DELETE FROM ${tableName}
+        WHERE created_on = (SELECT min(created_on) FROM ${tableName});
+    END LOOP;
+    RETURN NULL;
+END;
+$body$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER tr_keep_row_number_steady
+    AFTER INSERT ON ${tableName}
+    FOR EACH ROW EXECUTE PROCEDURE keep_row_number_steady();

--- a/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadStorageTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadStorageTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres;
+
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@ContextConfiguration(classes = {TestObjectMapperConfiguration.class})
+@RunWith(SpringRunner.class)
+public class PostgresPayloadStorageTest {
+
+    private PostgresPayloadTestUtil testPostgres;
+    private PostgresPayloadStorage executionPostgres;
+
+    public PostgreSQLContainer<?> postgreSQLContainer;
+
+    private final String inputString = "Lorem Ipsum is simply dummy text of the printing and typesetting industry."
+            + " Lorem Ipsum has been the industry's standard dummy text ever since the 1500s.";
+    private final InputStream inputData;
+    private final String key = "dummyKey.json";
+
+    public PostgresPayloadStorageTest() {
+        inputData = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Before
+    public void setup() {
+        postgreSQLContainer =
+                new PostgreSQLContainer<>(DockerImageName.parse("postgres")).withDatabaseName("conductor");
+        postgreSQLContainer.start();
+        testPostgres = new PostgresPayloadTestUtil(postgreSQLContainer);
+        executionPostgres = new PostgresPayloadStorage(testPostgres.getTestProperties(), testPostgres.getDataSource());
+    }
+
+    @Test
+    public void testWriteInputStreamToDb() throws IOException, SQLException {
+        executionPostgres.upload(key, inputData, inputData.available());
+
+        PreparedStatement stmt = testPostgres.getDataSource().getConnection()
+                .prepareStatement("SELECT data FROM external.external_payload WHERE id = 'dummyKey.json'");
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        assertEquals(inputString, new String(rs.getBinaryStream(1).readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testReadInputStreamFromDb() throws IOException, SQLException {
+        PreparedStatement stmt = testPostgres.getDataSource().getConnection()
+                .prepareStatement("INSERT INTO external.external_payload  VALUES (?, ?)");
+        stmt.setString(1, key);
+        stmt.setBinaryStream(2, inputData, inputData.available());
+        stmt.executeUpdate();
+
+        assertEquals(inputString,
+                new String(executionPostgres.download(key).readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testMaxRowInTable() throws IOException, SQLException {
+        executionPostgres.upload(key, inputData, inputData.available());
+        executionPostgres.upload("dummyKey2.json", inputData, inputData.available());
+        executionPostgres.upload("dummyKey3.json", inputData, inputData.available());
+        executionPostgres.upload("dummyKey4.json", inputData, inputData.available());
+        executionPostgres.upload("dummyKey5.json", inputData, inputData.available());
+        executionPostgres.upload("dummyKey6.json", inputData, inputData.available());
+        executionPostgres.upload("dummyKey7.json", inputData, inputData.available());
+
+        PreparedStatement stmt = testPostgres.getDataSource().getConnection()
+                .prepareStatement("SELECT count(id) FROM external.external_payload");
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        assertEquals(5, rs.getInt(1));
+        stmt.close();
+    }
+
+    @After
+    public void teardown() throws SQLException {
+        testPostgres.getDataSource().getConnection().close();
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadTestUtil.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/PostgresPayloadTestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres;
+
+import com.netflix.conductor.contribs.storage.postgres.config.PostgresPayloadProperties;
+import java.nio.file.Paths;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgresPayloadTestUtil {
+
+    private final DataSource dataSource;
+    private final PostgresPayloadProperties properties = new PostgresPayloadProperties();
+
+    public PostgresPayloadTestUtil(PostgreSQLContainer<?> postgreSQLContainer) {
+
+        this.dataSource = DataSourceBuilder.create()
+            .url(postgreSQLContainer.getJdbcUrl())
+            .username(postgreSQLContainer.getUsername())
+            .password(postgreSQLContainer.getPassword())
+            .build();
+        flywayMigrate(dataSource);
+    }
+
+    private void flywayMigrate(DataSource dataSource) {
+        FluentConfiguration fluentConfiguration = Flyway.configure()
+            .schemas("external")
+            .locations(Paths.get("db/migration_external_postgres").toString())
+            .dataSource(dataSource)
+            .placeholderReplacement(true)
+            .placeholders(Map.of("tableName", "external.external_payload",
+                "maxDataRows", "5",
+                "maxDataDays", "'1'",
+                "maxDataMonths", "'1'",
+                "maxDataYears", "'1'"));
+
+        Flyway flyway = fluentConfiguration.load();
+        flyway.migrate();
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    public PostgresPayloadProperties getTestProperties() {
+        return properties;
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/controller/ExternalPostgresPayloadResourceTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/storage/postgres/controller/ExternalPostgresPayloadResourceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.storage.postgres.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.conductor.contribs.storage.postgres.PostgresPayloadStorage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ResponseEntity;
+
+public class ExternalPostgresPayloadResourceTest {
+
+    private PostgresPayloadStorage mockPayloadStorage;
+    private ExternalPostgresPayloadResource postgresResource;
+
+    @Before
+    public void before() {
+        this.mockPayloadStorage = mock(PostgresPayloadStorage.class);
+        this.postgresResource = new ExternalPostgresPayloadResource(this.mockPayloadStorage);
+    }
+
+    @Test
+    public void testGetExternalStorageData() throws IOException {
+        String data = "Dummy data";
+        InputStream inputStreamData = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+        when(mockPayloadStorage.download(anyString())).thenReturn(inputStreamData);
+        ResponseEntity<InputStreamResource> response = postgresResource.getExternalStorageData("dummyKey.json");
+        assertNotNull(response.getBody());
+        assertEquals(data, new String(response.getBody().getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+    }
+}

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -107,6 +107,10 @@
         {
           "value": "s3",
           "description": "Use AWS S3 as the external payload storage."
+        },
+        {
+          "value": "postgres",
+          "description": "Use PostgreSQL as the external payload storage."
         }
       ]
     }

--- a/docs/docs/externalpayloadstorage.md
+++ b/docs/docs/externalpayloadstorage.md
@@ -84,3 +84,29 @@ Set the following properties to the desired values in the JVM system properties:
 | workflow.external.payload.storage.azure_blob.task_output_path | Path prefix where tasks output will be stored with an random UUID filename | task/output/ |
 
 The payloads will be stored as done in [Amazon S3](https://github.com/Netflix/conductor/blob/master/core/src/main/java/com/netflix/conductor/core/utils/S3PayloadStorage.java#L149-L167).
+
+### PostgreSQL Storage
+
+Frinx provides an implementation of [PostgreSQL Storage](https://www.postgresql.org/) used to externalize large payload storage.
+
+!!!note
+This implementation assumes that you have an [PostgreSQL database server with all required credentials](https://jdbc.postgresql.org/documentation/94/connect.html).
+
+Set the following properties to your application.properties:
+
+| Property | Description | default value |
+| --- | --- | --- |
+| conductor.external-payload-storage.postgres.conductor-url |  URL, that can be used to pull the json configurations, that will be downloaded from PostgreSQL to the conductor server. For example: for local development it is `http://localhost:8080` | `""`
+| conductor.external-payload-storage.postgres.url | PostgreSQL database connection URL. Required to connect to database. |
+| conductor.external-payload-storage.postgres.username | Username for connecting to PostgreSQL database. Required to connect to database. |
+| conductor.external-payload-storage.postgres.password | Password for connecting to PostgreSQL database. Required to connect to database. |
+| conductor.external-payload-storage.postgres.table-name | The PostgreSQL schema and table name where the payloads will be stored | `external.external_payload`
+| conductor.external-payload-storage.postgres.max-data-rows | Maximum count of data rows in PostgreSQL database. After overcoming this limit, the oldest data will be deleted. | Long.MAX_VALUE (9223372036854775807L)
+| conductor.external-payload-storage.postgres.max-data-days | Maximum count of days of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 0
+| conductor.external-payload-storage.postgres.max-data-months | Maximum count of months of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 0
+| conductor.external-payload-storage.postgres.max-data-years | Maximum count of years of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 1
+
+The maximum date age for fields in the database will be: `years + months + days`  
+The payloads will be stored in PostgreSQL database with key (externalPayloadPath) `UUID.json` and you can generate
+URI for this data using `external-postgres-payload-resource` rest controller.   
+To make this URI work correctly, you must correctly set the conductor-url property.

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -16,14 +16,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.postgres.dao.PostgresExecutionDAO;
 import com.netflix.conductor.postgres.dao.PostgresMetadataDAO;
 import com.netflix.conductor.postgres.dao.PostgresQueueDAO;
+import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
@@ -35,28 +35,35 @@ import org.springframework.context.annotation.Import;
 @Import(DataSourceAutoConfiguration.class)
 public class PostgresConfiguration {
 
-    @Bean
-    public FlywayConfigurationCustomizer flywayConfigurationCustomizer() {
-        // override the default location.
-        return configuration -> configuration.locations("classpath:db/migration_postgres");
+    DataSource dataSource;
+
+    public PostgresConfiguration(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Bean(initMethod = "migrate")
+    @PostConstruct
+    public Flyway flywayForPrimaryDb() {
+        return Flyway.configure()
+                .locations("classpath:db/migration_postgres")
+                .schemas("public")
+                .dataSource(dataSource)
+                .baselineOnMigrate(true)
+                .load();
     }
 
     @Bean
-    @DependsOn({"flyway", "flywayInitializer"})
-    public PostgresMetadataDAO postgresMetadataDAO(ObjectMapper objectMapper, DataSource dataSource,
-        PostgresProperties properties) {
+    public PostgresMetadataDAO postgresMetadataDAO(ObjectMapper objectMapper, PostgresProperties properties) {
         return new PostgresMetadataDAO(objectMapper, dataSource, properties);
     }
 
     @Bean
-    @DependsOn({"flyway", "flywayInitializer"})
-    public PostgresExecutionDAO postgresExecutionDAO(ObjectMapper objectMapper, DataSource dataSource) {
+    public PostgresExecutionDAO postgresExecutionDAO(ObjectMapper objectMapper) {
         return new PostgresExecutionDAO(objectMapper, dataSource);
     }
 
     @Bean
-    @DependsOn({"flyway", "flywayInitializer"})
-    public PostgresQueueDAO postgresQueueDAO(ObjectMapper objectMapper, DataSource dataSource) {
+    public PostgresQueueDAO postgresQueueDAO(ObjectMapper objectMapper) {
         return new PostgresQueueDAO(objectMapper, dataSource);
     }
 }


### PR DESCRIPTION
- Add PostgreSQL implementation for External Payload Storage and tests for its.
- Add second Flyway database initialize for PostgreSQL External Payload Storage 

Signed-off-by: Vasyl Klevlanyk <vklevlanyk@frinx.io>

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Adds PostgreSQL implementation for External Payload Storage. Now, makes it available to use PostgreSQL like primary database and external database.

Alternatives considered
---

This implementation adds the ability to use PostgreSQL as external payload storage. But we can also use Amazon S3 and Azure Blob Storage to implement this storage.

Usage
---
| Property | Description | default value |
| --- | --- | --- |
| conductor.external-payload-storage.postgres.conductor-url |  URL, that can be used to pull the json configurations, that will be downloaded from PostgreSQL to the conductor server. For example: for local development it is `http://localhost:8080` | `""`
| conductor.external-payload-storage.postgres.url | PostgreSQL database connection URL. Required to connect to database. |
| conductor.external-payload-storage.postgres.username | Username for connecting to PostgreSQL database. Required to connect to database. |
| conductor.external-payload-storage.postgres.password | Password for connecting to PostgreSQL database. Required to connect to database. |
| conductor.external-payload-storage.postgres.table-name | The PostgreSQL schema and table name where the payloads will be stored | `external.external_payload`
| conductor.external-payload-storage.postgres.max-data-rows | Maximum count of data rows in PostgreSQL database. After overcoming this limit, the oldest data will be deleted. | Long.MAX_VALUE (9223372036854775807L)
| conductor.external-payload-storage.postgres.max-data-days | Maximum count of days of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 0
| conductor.external-payload-storage.postgres.max-data-months | Maximum count of months of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 0
| conductor.external-payload-storage.postgres.max-data-years | Maximum count of years of data age in PostgreSQL database. After overcoming limit, the oldest data will be deleted. | 1




