### PR TITLE
Fixes #2528 - The UI was not supporting SWITCH task definitions or executions

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/evaluators/ValueParamEvaluator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/evaluators/ValueParamEvaluator.java
@@ -29,13 +29,13 @@ public class ValueParamEvaluator implements Evaluator {
 
    @Override
    public Object evaluate(String expression, Object input) {
-      LOGGER.debug("ValueParam evaluator -- Evaluating: {}", expression);
+      LOGGER.debug("ValueParam evaluator -- evaluating: {}", expression);
       if (input instanceof Map) {
          Object result = ((Map<String, Object>) input).get(expression);
          LOGGER.debug("ValueParam evaluator -- result: {}", result);
          return result;
       } else {
-         String errorMsg = String.format("Input must of a JSON object: %s", input.getClass());
+         String errorMsg = String.format("Input has to be a JSON object: %s", input.getClass());
          LOGGER.error(errorMsg);
          throw new TerminateWorkflowException(errorMsg);
       }

--- a/docs/docs/configuration/systask.md
+++ b/docs/docs/configuration/systask.md
@@ -3,9 +3,8 @@ A switch task is similar to ```case...switch``` statement in a programming langu
 The `switch` expression, however, is simply an input parameter (`value-param` evaluator) or a complex javascript 
 expression (`javascript` evaluator). Only two evaluators are supported by default in conductor. 
 
-**For Developers** Any type of custom evaluator can be implemented without having to touch the way `switch` task works.
-
-The task takes 2 parameters and even with growing number of evaluators, it always takes 2 parameters:
+**For Conductor Developers**: Custom evaluators can be implemented without having to change the way `SWITCH` task works.
+To implement and use the custom evaluators we can use the params `evaluatorType` and `expression`. 
 
 **Parameters:**
 
@@ -75,6 +74,16 @@ The task takes 2 parameters and even with growing number of evaluators, it alway
   }
 }
 ```
+
+### Decision (Deprecated)
+
+`DECISION` task type has been **deprecated** and replaced with the `SWITCH` task type. Switch task type is identical to how Decision tasks works except for the following differences:
+
+`DECISION` task type used to take two parameters 
+1. `caseExpression` : If present, this takes precedence and will be evaluated as a Javascript expression
+2. `caseValueParam` : If `caseExpression` param is null or empty, case value param will be used to determine the decision branch
+
+`SWITCH` works with the `evaluatorType` and `expression` params as a replacement to the above. For details refer to the `SWITCH` task documentation
 
 ## Event
 Event task provides ability to publish an event (message) to either Conductor or an external eventing system like SQS.  Event tasks are useful for creating event based dependencies for workflows and tasks.

--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -391,6 +391,7 @@ class WorkflowGraph extends React.PureComponent {
         this.barNodes.push(v.ref);
         break;
       case "DECISION":
+      case "SWITCH":
         retval.label = v.ref;
         retval.shape = "diamond";
         retval.height = 40;


### PR DESCRIPTION
The UI was not supporting SWITCH task definitions or executions display. With this change it will support both SWITCH and DECISION. Tested UI rendering manually screenshots attached to the issue.

Pull Request type
----

- [ X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Fix for rendering Switch Case flows which was previously not rendering


Issue #2528 

Alternatives considered
----
None


Validated rendering of both SWITCH and DECISION cases. Attaching screenshots.

Tested default branch, case branch, null branch value etc.


<img width="1357" alt="Screen Shot 2021-10-29 at 12 12 36 AM" src="https://user-images.githubusercontent.com/20978442/139395022-28f22eed-16d4-488f-95af-475b49616cdd.png">
<img width="1357" alt="Screen Shot 2021-10-29 at 12 12 02 AM" src="https://user-images.githubusercontent.com/20978442/139395032-30a294d1-f7ef-4be0-acb5-7cf115bae1dd.png">
<img width="1357" alt="Screen Shot 2021-10-29 at 12 08 45 AM" src="https://user-images.githubusercontent.com/20978442/139395036-323bf9ab-2e8d-464e-ad5c-a840334d5f46.png">
<img width="1360" alt="Screen Shot 2021-10-29 at 12 08 25 AM" src="https://user-images.githubusercontent.com/20978442/139395042-86b30ea7-dd96-46f8-87c0-32385ad84947.png">
<img width="1354" alt="Screen Shot 2021-10-29 at 12 07 56 AM" src="https://user-images.githubusercontent.com/20978442/139395046-a3713ce8-9ca1-4e3d-8ba7-8f36217d41c0.png">
