### PR TITLE
Fixes #2565 - Fix the broken inline task implementation. Added unit tests for Inline task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Inline.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Inline.java
@@ -94,7 +94,7 @@ public class Inline extends WorkflowSystemTask {
     }
 
     private void checkEvaluatorType(String evaluatorType) {
-        if (StringUtils.isNotBlank(evaluatorType)) {
+        if (StringUtils.isBlank(evaluatorType)) {
             LOGGER.error("Empty {} in Inline task. ", QUERY_EVALUATOR_TYPE);
             throw new TerminateWorkflowException("Empty '" + QUERY_EVALUATOR_TYPE
                   + "' in Inline task's input parameters. A non-empty String value must be provided.");
@@ -106,7 +106,7 @@ public class Inline extends WorkflowSystemTask {
     }
 
     private void checkExpression(String expression) {
-        if (StringUtils.isNotBlank(expression)) {
+        if (StringUtils.isBlank(expression)) {
             LOGGER.error("Empty {} in Inline task. ", QUERY_EXPRESSION_PARAMETER);
             throw new TerminateWorkflowException("Empty '" + QUERY_EXPRESSION_PARAMETER
                   + "' in Inline task's input parameters. A non-empty String value must be provided.");

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/InlineTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/InlineTest.java
@@ -1,0 +1,118 @@
+package com.netflix.conductor.core.execution.tasks;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.evaluators.Evaluator;
+import com.netflix.conductor.core.execution.evaluators.JavascriptEvaluator;
+import com.netflix.conductor.core.execution.evaluators.ValueParamEvaluator;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class InlineTest {
+
+    private final Workflow workflow = new Workflow();
+    private final WorkflowExecutor executor = mock(WorkflowExecutor.class);
+
+    @Test
+    public void testInlineTaskValidationFailures() {
+        Inline inline = new Inline(getStringEvaluatorMap());
+
+        Map<String, Object> inputObj = new HashMap<>();
+        inputObj.put("value", 1);
+        inputObj.put("expression", "");
+        inputObj.put("evaluatorType", "value-param");
+
+        Task task = new Task();
+        task.getInputData().putAll(inputObj);
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.FAILED, task.getStatus());
+        assertEquals("Empty 'expression' in Inline task's input parameters. A non-empty String value must be provided.", task.getReasonForIncompletion());
+
+        inputObj = new HashMap<>();
+        inputObj.put("value", 1);
+        inputObj.put("expression", "value");
+        inputObj.put("evaluatorType", "");
+
+        task = new Task();
+        task.getInputData().putAll(inputObj);
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.FAILED, task.getStatus());
+        assertEquals("Empty 'evaluatorType' in Inline task's input parameters. A non-empty String value must be provided.", task.getReasonForIncompletion());
+
+    }
+
+    @Test
+    public void testInlineValueParamExpression() {
+        Inline inline = new Inline(getStringEvaluatorMap());
+
+        Map<String, Object> inputObj = new HashMap<>();
+        inputObj.put("value", 101);
+        inputObj.put("expression", "value");
+        inputObj.put("evaluatorType", "value-param");
+
+        Task task = new Task();
+        task.getInputData().putAll(inputObj);
+
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.COMPLETED, task.getStatus());
+        assertNull(task.getReasonForIncompletion());
+        assertEquals(101, task.getOutputData().get("result"));
+
+        inputObj = new HashMap<>();
+        inputObj.put("value", "StringValue");
+        inputObj.put("expression", "value");
+        inputObj.put("evaluatorType", "value-param");
+
+        task = new Task();
+        task.getInputData().putAll(inputObj);
+
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.COMPLETED, task.getStatus());
+        assertNull(task.getReasonForIncompletion());
+        assertEquals("StringValue", task.getOutputData().get("result"));
+    }
+
+    @Test
+    public void testInlineJavascriptExpression() {
+        Inline inline = new Inline(getStringEvaluatorMap());
+
+        Map<String, Object> inputObj = new HashMap<>();
+        inputObj.put("value", 101);
+        inputObj.put("expression", "function e() { if ($.value == 101){return {\"evalResult\": true}} else { return {\"evalResult\": false}}} e();");
+        inputObj.put("evaluatorType", "javascript");
+
+        Task task = new Task();
+        task.getInputData().putAll(inputObj);
+
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.COMPLETED, task.getStatus());
+        assertNull(task.getReasonForIncompletion());
+        assertEquals(true, ((Map<String, Object>)task.getOutputData().get("result")).get("evalResult"));
+
+        inputObj = new HashMap<>();
+        inputObj.put("value", "StringValue");
+        inputObj.put("expression", "function e() { if ($.value == 'StringValue'){return {\"evalResult\": true}} else { return {\"evalResult\": false}}} e();");
+        inputObj.put("evaluatorType", "javascript");
+
+        task = new Task();
+        task.getInputData().putAll(inputObj);
+
+        inline.execute(workflow, task, executor);
+        assertEquals(Task.Status.COMPLETED, task.getStatus());
+        assertNull(task.getReasonForIncompletion());
+        assertEquals(true, ((Map<String, Object>)task.getOutputData().get("result")).get("evalResult"));
+    }
+
+    private Map<String, Evaluator> getStringEvaluatorMap() {
+        Map<String, Evaluator> evaluators = new HashMap<>();
+        evaluators.put(ValueParamEvaluator.NAME, new ValueParamEvaluator());
+        evaluators.put(JavascriptEvaluator.NAME, new JavascriptEvaluator());
+        return evaluators;
+    }
+}


### PR DESCRIPTION
Fix the broken inline task implementation. Added unit tests to validate for both value param and javascript evaluators

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Fixes the Inline task validation implementation. Without this fix, inline task won't work.

Issue #2565

Alternatives considered
----
None
