### PR TITLE
Fixing indexReplicaCount configuration for docker

### DIFF
--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -28,6 +28,7 @@ conductor.redis.queuesNonQuorumPort=22122
 # Elastic search instance indexing is disabled.
 conductor.indexing.enabled=true
 conductor.elasticsearch.url=http://es:9200
+conductor.elasticsearch.indexReplicasCount=0
 
 # Load sample kitchen sink workflow
 loadSample=true


### PR DESCRIPTION
Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Change to 0 the `conductor.elasticsearch.indexReplicasCount` since when using default docker images only one ES instance is used.

_Describe the new behavior from this PR, and why it's needed_
[Issue #2589](https://github.com/Netflix/conductor/issues/2589)

Alternatives considered
----
Another alternative to consider is using a ES cluster of 2 instances. But I consider this can be unnecessary due to the purpose of the docker alternative.
