### PR TITLE
Performance improvement by replacing StringBuffer with StringBuilder

### DIFF
--- a/annotations-processor/src/main/java/com/netflix/conductor/annotationsprocessor/protogen/Message.java
+++ b/annotations-processor/src/main/java/com/netflix/conductor/annotationsprocessor/protogen/Message.java
@@ -101,7 +101,7 @@ public class Message extends AbstractMessage {
         private static Pattern CAMEL_CASE_RE = Pattern.compile("(?<=[a-z])[A-Z]");
         private static String toUnderscoreCase(String input) {
             Matcher m = CAMEL_CASE_RE.matcher(input);
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             while (m.find()) {
                 m.appendReplacement(sb, "_" + m.group());
             }

--- a/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchBaseDAO.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchBaseDAO.java
@@ -38,7 +38,7 @@ abstract class ElasticSearchBaseDAO implements IndexDAO {
         String pattern = "\"template\": \"\\*(.*)\\*\"";
         Pattern r = Pattern.compile(pattern);
         Matcher m = r.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             m.appendReplacement(sb, m.group(0).replaceFirst(Pattern.quote(m.group(1)), indexPrefix + "_" + m.group(1)));
         }

--- a/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchBaseDAO.java
+++ b/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchBaseDAO.java
@@ -46,7 +46,7 @@ abstract class ElasticSearchBaseDAO implements IndexDAO {
                 ArrayList<String> patternsWithPrefix = new ArrayList<>();
                 indexPatternsNodeValue.forEach(v -> {
                     String patternText = v.asText();
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     if (patternText.startsWith("*")) {
                         sb.append("*").append(indexPrefix).append("_").append(patternText.substring(1));
                     } else {


### PR DESCRIPTION
Pull Request type

- [x ] Refactoring (no functional changes, no api changes)

Changes in this PR
----
Replacing StringBuffer objects used locally with StringBuilder.   StringBuilder does not synchronize and so will run faster.
This PR only improves performance
