### PR TITLE
Bug fixed: createTime was null when updating worflow definition

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraMetadataDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraMetadataDAO.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.netflix.conductor.annotations.Trace;
 import com.netflix.conductor.cassandra.config.CassandraProperties;
 import com.netflix.conductor.cassandra.util.Statements;
+import com.netflix.conductor.common.metadata.Auditable;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.exception.ApplicationException;
@@ -178,6 +179,8 @@ public class CassandraMetadataDAO extends CassandraBaseDAO implements MetadataDA
     @Override
     public void updateWorkflowDef(WorkflowDef workflowDef) {
         try {
+            workflowDef.setCreateTime(getWorkflowDef(workflowDef.getName(), workflowDef.getVersion()).map(Auditable::getCreateTime)
+                .orElse(System.currentTimeMillis()));
             String workflowDefinition = toJson(workflowDef);
             session.execute(updateWorkflowDefStatement.bind(workflowDefinition, workflowDef.getName(),
                 workflowDef.getVersion()));

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAO.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.mysql.dao;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import com.netflix.conductor.common.metadata.Auditable;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -361,8 +362,13 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO, Event
         final String INSERT_WORKFLOW_DEF_QUERY = "INSERT INTO meta_workflow_def (name, version, json_data) VALUES (?," +
             " ?, ?)";
 
+        Optional<WorkflowDef> optionalDef = getWorkflowDef(def.getName(), def.getVersion());
+        if (def.getCreateTime() == null) {
+            def.setCreateTime(optionalDef.map(Auditable::getCreateTime).orElse(System.currentTimeMillis()));
+        }
+
         Optional<Integer> version = getLatestVersion(tx, def.getName());
-        if (!workflowExists(tx, def)) {
+        if (optionalDef.isEmpty()) {
             execute(tx, INSERT_WORKFLOW_DEF_QUERY, q -> q.addParameter(def.getName())
                 .addParameter(def.getVersion())
                 .addJsonParameter(def)
@@ -374,7 +380,6 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO, Event
                     "SET json_data = ?, modified_on = CURRENT_TIMESTAMP " +
                     "WHERE name = ? AND version = ?";
             //@formatter:on
-
             execute(tx, UPDATE_WORKFLOW_DEF_QUERY, q -> q.addJsonParameter(def)
                 .addParameter(def.getName())
                 .addParameter(def.getVersion())

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -42,7 +42,9 @@ import static com.netflix.conductor.core.exception.ApplicationException.Code.CON
 import static com.netflix.conductor.core.exception.ApplicationException.Code.NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -102,7 +104,6 @@ public class PostgresMetadataDAOTest {
         def.setCreateTime(1L);
         def.setOwnerApp("ownerApp");
         def.setUpdatedBy("unit_test2");
-        def.setUpdateTime(2L);
 
         metadataDAO.createWorkflowDef(def);
 
@@ -114,26 +115,38 @@ public class PostgresMetadataDAOTest {
 
         WorkflowDef found = metadataDAO.getWorkflowDef("test", 1).get();
         assertTrue(EqualsBuilder.reflectionEquals(def, found));
+        assertNotNull(found.getCreateTime());
+        assertNull(found.getUpdateTime());
+        Long firstDefCreateTime = found.getCreateTime();
 
         def.setVersion(3);
+        def.setCreateTime(5L);
         metadataDAO.createWorkflowDef(def);
+
+        found = metadataDAO.getLatestWorkflowDef(def.getName()).get();
+        assertEquals(def.getName(), found.getName());
+        assertEquals(def.getVersion(), found.getVersion());
+        assertEquals(3, found.getVersion());
+        assertNotNull(found.getCreateTime());
+        assertNull(found.getUpdateTime());
+        Long secondDefCreateTime = found.getCreateTime();
+        assertNotEquals(firstDefCreateTime, secondDefCreateTime);
 
         all = metadataDAO.getAllWorkflowDefs();
         assertNotNull(all);
         assertEquals(2, all.size());
         assertEquals("test", all.get(0).getName());
         assertEquals(1, all.get(0).getVersion());
-
-        found = metadataDAO.getLatestWorkflowDef(def.getName()).get();
-        assertEquals(def.getName(), found.getName());
-        assertEquals(def.getVersion(), found.getVersion());
-        assertEquals(3, found.getVersion());
+        assertEquals(firstDefCreateTime, all.get(0).getCreateTime());
+        assertNull(all.get(0).getUpdateTime());
 
         all = metadataDAO.getAllLatest();
         assertNotNull(all);
         assertEquals(1, all.size());
         assertEquals("test", all.get(0).getName());
         assertEquals(3, all.get(0).getVersion());
+        assertEquals(secondDefCreateTime, all.get(0).getCreateTime());
+        assertNull(all.get(0).getUpdateTime());
 
         all = metadataDAO.getAllVersions(def.getName());
         assertNotNull(all);
@@ -142,11 +155,19 @@ public class PostgresMetadataDAOTest {
         assertEquals("test", all.get(1).getName());
         assertEquals(1, all.get(0).getVersion());
         assertEquals(3, all.get(1).getVersion());
+        assertEquals(firstDefCreateTime, all.get(0).getCreateTime());
+        assertNull(all.get(0).getUpdateTime());
+        assertEquals(secondDefCreateTime, all.get(1).getCreateTime());
+        assertNull(all.get(1).getUpdateTime());
 
         def.setDescription("updated");
+        Long updateTime = 6L;
+        def.setUpdateTime(updateTime);
         metadataDAO.updateWorkflowDef(def);
         found = metadataDAO.getWorkflowDef(def.getName(), def.getVersion()).get();
         assertEquals(def.getDescription(), found.getDescription());
+        assertEquals(secondDefCreateTime, found.getCreateTime());
+        assertEquals(updateTime, found.getUpdateTime());
 
         List<String> allnames = metadataDAO.findAll();
         assertNotNull(allnames);

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisMetadataDAO.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.redis.dao;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import com.netflix.conductor.common.metadata.Auditable;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.config.ConductorProperties;
@@ -156,6 +157,8 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 
     @Override
     public void updateWorkflowDef(WorkflowDef def) {
+        def.setCreateTime(getWorkflowDef(def.getName(), def.getVersion()).map(Auditable::getCreateTime)
+            .orElse(System.currentTimeMillis()));
         _createOrUpdate(def);
     }
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Now we are getting the `createTime` from:

- The workflow definition if we want to update it
- The system if the workflow definitions doesn't exists yet

Issue #2564 

Alternatives considered
----

It isn't necessary to pass neither the `createTime` nor the `updateTime` to the POST and PUT **/metadata/workflow** methods