### PR TITLE
fix for restart using Docker Compose: added local Docker volumes for …

### DIFF
--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -15,6 +15,8 @@ services:
     environment:
       - POSTGRES_USER=conductor
       - POSTGRES_PASSWORD=conductor
+    volumes:
+      - pgdata-conductor:/var/lib/postgresql/data
     networks:
       - internal
     ports:
@@ -29,6 +31,10 @@ services:
       options:
         max-size: "1k"
         max-file: "3"
+
+volumes:
+  pgdata-conductor:
+    driver: local
 
 networks:
   internal:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -50,6 +50,8 @@ services:
       - transport.host=0.0.0.0
       - discovery.type=single-node
       - xpack.security.enabled=false
+    volumes:
+      - esdata-conductor:/usr/share/elasticsearch/data
     networks:
       - internal
     ports:
@@ -65,6 +67,10 @@ services:
       options:
         max-size: "1k"
         max-file: "3"
+
+volumes:
+  esdata-conductor:
+    driver: local
 
 networks:
   internal:


### PR DESCRIPTION
…Elasticsearch and PostgreSQL

Pull Request type
----

- [X ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Added Docker volumes for PostgreSQL and ElasticSearch in the default Docker Compose templates.

_Describe the new behavior from this PR, and why it's needed_
Issue #2620
