### PR TITLE
[Fix] UI: fix fetching task logs uri

### DIFF
--- a/ui/src/pages/execution/TaskLogs.jsx
+++ b/ui/src/pages/execution/TaskLogs.jsx
@@ -4,7 +4,7 @@ import { DataTable, Text, LinearProgress } from "../../components";
 
 export default function TaskLogs({ task }) {
   const { taskId } = task;
-  const { data: log, isFetching } = useFetch(`/api/tasks/${taskId}/log`);
+  const { data: log, isFetching } = useFetch(`/tasks/${taskId}/log`);
 
   if (isFetching) {
     return <LinearProgress />;


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Issue: '/api' is already contained in root uri, UI can't fetch task logs right now.
Solution: remove '/api' from fetch task logs uri.

Alternatives considered
----
