### PR TITLE
Force log4j dep version to avoid 0-day exploit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,31 @@ allprojects {
     }
 
     dependencies {
+        implementation('org.apache.logging.log4j:log4j-core') {
+            version {
+                strictly '2.15.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-api') {
+            version {
+                strictly '2.15.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-slf4j-impl') {
+            version {
+                strictly '2.15.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-jul') {
+            version {
+                strictly '2.15.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-web') {
+            version {
+                strictly '2.15.0'
+            }
+        }
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
         testImplementation('org.springframework.boot:spring-boot-starter-test')
@@ -145,3 +170,4 @@ sonarqube {
         property "sonar.host.url", "https://sonarcloud.io"
     }
 }
+


### PR DESCRIPTION
Pull Request type
----

- [ X] Other (please describe):

Security. Log4j discovered vulnerability: 
- https://www.lunasec.io/docs/blog/log4j-zero-day/ 
- https://news.ycombinator.com/item?id=29504755

Changes in this PR
----

Forces to upgrade transitive dependencies versions to use patched ones.


