### PR TITLE
Fix bug in Task->Logs view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ buildscan.log
 # JS & UI Related
 node_modules
 /ui/build
+/ui/dist
 
 # publishing secrets
 secrets/signing-key

--- a/ui/src/pages/execution/TaskLogs.jsx
+++ b/ui/src/pages/execution/TaskLogs.jsx
@@ -4,7 +4,7 @@ import { DataTable, Text, LinearProgress } from "../../components";
 
 export default function TaskLogs({ task }) {
   const { taskId } = task;
-  const { data: log, isFetching } = useFetch(`/api/tasks/${taskId}/log`);
+  const { data: log, isFetching } = useFetch(`/tasks/${taskId}/log`);
 
   if (isFetching) {
     return <LinearProgress />;


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix

Changes in this PR
----

The Task->Logs view doesn't work, it tries to fetch resources from non existent URL. The problem was that it prefix the target endpoint with /api. Additionally, modified ignore to keep buildable artifacts out of configuration management.

With this fix:
![image](https://user-images.githubusercontent.com/73197513/146027639-075b5a85-52b6-445d-9e9d-770ae6f68f7e.png)
 

