### PR TITLE
Force log4j dep version to 2.16 to avoid a second exploit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,27 +97,27 @@ allprojects {
     dependencies {
         implementation('org.apache.logging.log4j:log4j-core') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-api') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-slf4j-impl') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-jul') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-web') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Other (please describe):

Changes in this PR
----

Update the version of log4j from 2.15 to 2.16 because the 2.15 contains a new vulnerability
sources: [here](https://www.techzine.eu/news/security/69795/log4j-2-15-is-not-foolproof-apache-publishes-second-emergency-patch/) or [on apache log4j project](https://logging.apache.org/log4j/2.x/index.html)

Alternatives considered
----
