### PR TITLE
Address CVE-2021-45046 (log4j again)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,27 +97,27 @@ allprojects {
     dependencies {
         implementation('org.apache.logging.log4j:log4j-core') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-api') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-slf4j-impl') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-jul') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-web') {
             version {
-                strictly '2.15.0'
+                strictly '2.16.0'
             }
         }
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
Pull Request type
----

- [X] Other: Dependency upgrade to address critical [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) 

Changes in this PR
----

Updatting log4j to address the brand new CVE that affects 2.15.0.  This is the recommended way of fixing this CVE

Alternatives considered
----

None
