### PR TITLE
Force the upgrade to log4j2 in 2.31 branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,31 @@ configure(javaProjects) {
     targetCompatibility = 1.8
 
     dependencies {
+        implementation('org.apache.logging.log4j:log4j-core') {
+            version {
+                strictly '2.16.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-api') {
+            version {
+                strictly '2.16.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-slf4j-impl') {
+            version {
+                strictly '2.16.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-jul') {
+            version {
+                strictly '2.16.0'
+            }
+        }
+        implementation('org.apache.logging.log4j:log4j-web') {
+            version {
+                strictly '2.16.0'
+            }
+        }
         testCompile "junit:junit:${revJUnit}"
         testCompile("org.mockito:mockito-core:${revMockito}") {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Looks like v3 got updated, but 2.31 did not. This forces log4j2 to be version 2.16.0 (which y'all should probably upgrade v3 to as well, since 2.15.0 isn't perfect (https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/)

