### PR TITLE
Fix for #2642: Bump Redisson dependency as current version has issue with schema resolution

### DIFF
--- a/cassandra-persistence/dependencies.lock
+++ b/cassandra-persistence/dependencies.lock
@@ -1,4545 +1,590 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.dropwizard.metrics:metrics-core"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.dropwizard.metrics:metrics-core"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.dropwizard.metrics:metrics-core"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.dropwizard.metrics:metrics-core"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.dropwizard.metrics:metrics-core"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.addthis.metrics:reporter-config-base": {
-            "locked": "3.0.3",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3"
-            ]
-        },
-        "com.addthis.metrics:reporter-config3": {
-            "locked": "3.0.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.boundary:high-scale-lib": {
-            "locked": "1.0.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.clearspring.analytics:stream": {
-            "locked": "2.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.2.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jbellis:jamm": {
-            "locked": "0.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "21.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru": {
-            "locked": "1.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.lmax:disruptor": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.thinkaurelius.thrift:thrift-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.ning:compress-lzf": {
-            "locked": "0.8.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.thinkaurelius.thrift:thrift-server": {
-            "locked": "0.3.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-jvm": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "it.unimi.dsi:fastutil": {
-            "locked": "6.5.7",
-            "transitive": [
-                "com.clearspring.analytics:stream"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.java.dev.jna:jna": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.jpountz.lz4:lz4": {
-            "locked": "1.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:ST4": {
-            "locked": "4.0.8",
-            "transitive": [
-                "org.antlr:antlr"
-            ]
-        },
-        "org.antlr:antlr": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.antlr:ST4",
-                "org.antlr:antlr",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.7.0",
-            "transitive": [
-                "de.jflex:jflex"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.7.0",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.cassandra:cassandra-all": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.4",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.commons:commons-math3": {
-            "locked": "3.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.caffinitas.ohc:ohc-core": {
-            "locked": "0.4.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.cassandraunit:cassandra-unit": {
-            "locked": "3.5.0.1",
-            "requested": "3.5.0.1"
-        },
-        "org.codehaus.jackson:jackson-core-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.codehaus.jackson:jackson-mapper-asl"
-            ]
-        },
-        "org.codehaus.jackson:jackson-mapper-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.fusesource:sigar": {
-            "locked": "1.6.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.cassandraunit:cassandra-unit",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.jctools:jctools-core": {
-            "locked": "1.2.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mindrot:jbcrypt": {
-            "locked": "0.3m",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.apache.cassandra:cassandra-all",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.thinkaurelius.thrift:thrift-server",
-                "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit",
-                "org.slf4j:jcl-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.addthis.metrics:reporter-config-base": {
-            "locked": "3.0.3",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3"
-            ]
-        },
-        "com.addthis.metrics:reporter-config3": {
-            "locked": "3.0.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.boundary:high-scale-lib": {
-            "locked": "1.0.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.clearspring.analytics:stream": {
-            "locked": "2.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.2.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jbellis:jamm": {
-            "locked": "0.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "21.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru": {
-            "locked": "1.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.lmax:disruptor": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.thinkaurelius.thrift:thrift-server"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.ning:compress-lzf": {
-            "locked": "0.8.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "com.thinkaurelius.thrift:thrift-server": {
-            "locked": "0.3.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-jvm": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "it.unimi.dsi:fastutil": {
-            "locked": "6.5.7",
-            "transitive": [
-                "com.clearspring.analytics:stream"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.java.dev.jna:jna": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.jpountz.lz4:lz4": {
-            "locked": "1.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:ST4": {
-            "locked": "4.0.8",
-            "transitive": [
-                "org.antlr:antlr"
-            ]
-        },
-        "org.antlr:antlr": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.antlr:ST4",
-                "org.antlr:antlr",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.7.0",
-            "transitive": [
-                "de.jflex:jflex"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.7.0",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.cassandra:cassandra-all": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.4",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.commons:commons-math3": {
-            "locked": "3.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.caffinitas.ohc:ohc-core": {
-            "locked": "0.4.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.4"
         },
         "org.cassandraunit:cassandra-unit": {
-            "locked": "3.5.0.1",
-            "requested": "3.5.0.1"
-        },
-        "org.codehaus.jackson:jackson-core-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.codehaus.jackson:jackson-mapper-asl"
-            ]
-        },
-        "org.codehaus.jackson:jackson-mapper-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.fusesource:sigar": {
-            "locked": "1.6.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            "locked": "3.5.0.1"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.cassandraunit:cassandra-unit",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.jctools:jctools-core": {
-            "locked": "1.2.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mindrot:jbcrypt": {
-            "locked": "0.3m",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.apache.cassandra:cassandra-all",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.thinkaurelius.thrift:thrift-server",
-                "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit",
-                "org.slf4j:jcl-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.addthis.metrics:reporter-config-base": {
-            "locked": "3.0.3",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3"
-            ]
-        },
-        "com.addthis.metrics:reporter-config3": {
-            "locked": "3.0.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.boundary:high-scale-lib": {
-            "locked": "1.0.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.clearspring.analytics:stream": {
-            "locked": "2.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.2.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jbellis:jamm": {
-            "locked": "0.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "21.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru": {
-            "locked": "1.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.lmax:disruptor": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.thinkaurelius.thrift:thrift-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.ning:compress-lzf": {
-            "locked": "0.8.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.thinkaurelius.thrift:thrift-server": {
-            "locked": "0.3.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-jvm": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "it.unimi.dsi:fastutil": {
-            "locked": "6.5.7",
-            "transitive": [
-                "com.clearspring.analytics:stream"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.java.dev.jna:jna": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.jpountz.lz4:lz4": {
-            "locked": "1.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:ST4": {
-            "locked": "4.0.8",
-            "transitive": [
-                "org.antlr:antlr"
-            ]
-        },
-        "org.antlr:antlr": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.antlr:ST4",
-                "org.antlr:antlr",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.7.0",
-            "transitive": [
-                "de.jflex:jflex"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.7.0",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.cassandra:cassandra-all": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.4",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.commons:commons-math3": {
-            "locked": "3.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.caffinitas.ohc:ohc-core": {
-            "locked": "0.4.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.cassandraunit:cassandra-unit": {
-            "locked": "3.5.0.1",
-            "requested": "3.5.0.1"
-        },
-        "org.codehaus.jackson:jackson-core-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.codehaus.jackson:jackson-mapper-asl"
-            ]
-        },
-        "org.codehaus.jackson:jackson-mapper-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.fusesource:sigar": {
-            "locked": "1.6.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.cassandraunit:cassandra-unit",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.jctools:jctools-core": {
-            "locked": "1.2.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mindrot:jbcrypt": {
-            "locked": "0.3m",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.apache.cassandra:cassandra-all",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.thinkaurelius.thrift:thrift-server",
-                "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit",
-                "org.slf4j:jcl-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.addthis.metrics:reporter-config-base": {
-            "locked": "3.0.3",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3"
-            ]
-        },
-        "com.addthis.metrics:reporter-config3": {
-            "locked": "3.0.3",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.boundary:high-scale-lib": {
-            "locked": "1.0.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.clearspring.analytics:stream": {
-            "locked": "2.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "requested": "3.6.0"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.2.6",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jbellis:jamm": {
-            "locked": "0.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "21.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru": {
-            "locked": "1.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.lmax:disruptor": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.thinkaurelius.thrift:thrift-server"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.ning:compress-lzf": {
-            "locked": "0.8.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "com.thinkaurelius.thrift:thrift-server": {
-            "locked": "0.3.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-jvm": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.56.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "it.unimi.dsi:fastutil": {
-            "locked": "6.5.7",
-            "transitive": [
-                "com.clearspring.analytics:stream"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.java.dev.jna:jna": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "net.jpountz.lz4:lz4": {
-            "locked": "1.3.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:ST4": {
-            "locked": "4.0.8",
-            "transitive": [
-                "org.antlr:antlr"
-            ]
-        },
-        "org.antlr:antlr": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.5.2",
-            "transitive": [
-                "org.antlr:ST4",
-                "org.antlr:antlr",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.7.0",
-            "transitive": [
-                "de.jflex:jflex"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.7.0",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.cassandra:cassandra-all": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.11.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.4",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.apache.commons:commons-math3": {
-            "locked": "3.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.caffinitas.ohc:ohc-core": {
-            "locked": "0.4.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.cassandraunit:cassandra-unit": {
-            "locked": "3.5.0.1",
-            "requested": "3.5.0.1"
-        },
-        "org.codehaus.jackson:jackson-core-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.codehaus.jackson:jackson-mapper-asl"
-            ]
-        },
-        "org.codehaus.jackson:jackson-mapper-asl": {
-            "locked": "1.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.fusesource:sigar": {
-            "locked": "1.6.4",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.4"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.cassandraunit:cassandra-unit",
-                "org.hamcrest:hamcrest-library"
-            ]
+        "org.cassandraunit:cassandra-unit": {
+            "locked": "3.5.0.1"
         },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.cassandraunit:cassandra-unit"
-            ]
-        },
-        "org.jctools:jctools-core": {
-            "locked": "1.2.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.mindrot:jbcrypt": {
-            "locked": "0.3m",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.apache.cassandra:cassandra-all",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.thinkaurelius.thrift:thrift-server",
-                "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard.metrics:metrics-jvm",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.caffinitas.ohc:ohc-core",
-                "org.cassandraunit:cassandra-unit",
-                "org.slf4j:jcl-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.addthis.metrics:reporter-config-base",
-                "com.addthis.metrics:reporter-config3",
-                "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     }
 }

--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -1,4077 +1,461 @@
 {
-    "compile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
     "compileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "0.7.5"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
+            "locked": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            "locked": "1.19.4"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "default": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "findbugs": {
-        "com.apple:AppleJavaExtensions": {
-            "locked": "1.4",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "com.google.code.findbugs:bcel-findbugs": {
-            "locked": "6.0",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "com.google.code.findbugs:findbugs": {
-            "locked": "3.0.1"
-        },
-        "com.google.code.findbugs:jFormatString": {
-            "locked": "2.0.1",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.1",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "dom4j:dom4j": {
-            "locked": "1.6.1",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "jaxen:jaxen": {
-            "locked": "1.1.6",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "net.jcip:jcip-annotations": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.2",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "org.ow2.asm:asm-debug-all": {
-            "locked": "5.0.2",
-            "transitive": [
-                "com.google.code.findbugs:findbugs"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.ow2.asm:asm-commons"
-            ]
-        },
-        "xml-apis:xml-apis": {
-            "locked": "1.0.b2",
-            "transitive": [
-                "dom4j:dom4j"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
+            "locked": "0.8.6"
         }
     },
-    "runtime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+    "pmd": {
+        "net.sourceforge.pmd:pmd-java": {
+            "locked": "6.26.0"
         }
     },
     "runtimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "0.7.5"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
+            "locked": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            "locked": "1.19.4"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
-    "testCompile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.27.0-GA",
-            "transitive": [
-                "org.powermock:powermock-core"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.3.3",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.powermock:powermock-api-mockito2": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-api-support": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.powermock:powermock-core": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.powermock:powermock-module-junit4": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-module-junit4-common": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-module-junit4"
-            ]
-        },
-        "org.powermock:powermock-reflect": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+    "spotbugs": {
+        "com.github.spotbugs:spotbugs": {
+            "locked": "4.2.1"
+        }
+    },
+    "spotbugsSlf4j": {
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.8.0-beta4"
         }
     },
     "testCompileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "0.7.5"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
+            "locked": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            "locked": "1.19.4"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.27.0-GA",
-            "transitive": [
-                "org.powermock:powermock-core"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.3.3",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-reflect"
-            ]
+            "locked": "3.3.3"
         },
         "org.powermock:powermock-api-mockito2": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-api-support": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.powermock:powermock-core": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-module-junit4-common"
-            ]
+            "locked": "2.0.9"
         },
         "org.powermock:powermock-module-junit4": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-module-junit4-common": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-module-junit4"
-            ]
-        },
-        "org.powermock:powermock-reflect": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-module-junit4-common"
-            ]
+            "locked": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testRuntime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.27.0-GA",
-            "transitive": [
-                "org.powermock:powermock-core"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.3.3",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.powermock:powermock-api-mockito2": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-api-support": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.powermock:powermock-core": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.powermock:powermock-module-junit4": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-module-junit4-common": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-module-junit4"
-            ]
-        },
-        "org.powermock:powermock-reflect": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.1",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.5",
-            "requested": "0.7.5",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "0.7.5"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "requested": "1.8.7"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-internal": {
-            "locked": "0.10.1",
-            "transitive": [
-                "com.netflix.servo:servo-core"
-            ]
+            "locked": "1.8.7"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            "locked": "0.68.0"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            "locked": "1.19.4"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "requested": "2.6"
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.10.14",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-reflect"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.powermock:powermock-module-junit4",
-                "org.powermock:powermock-module-junit4-common"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.27.0-GA",
-            "transitive": [
-                "org.powermock:powermock-core"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.3.3",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.powermock:powermock-reflect"
-            ]
+            "locked": "3.3.3"
         },
         "org.powermock:powermock-api-mockito2": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-api-support": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-mockito2"
-            ]
-        },
-        "org.powermock:powermock-core": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-module-junit4-common"
-            ]
+            "locked": "2.0.9"
         },
         "org.powermock:powermock-module-junit4": {
-            "locked": "2.0.9",
-            "requested": "2.0.9"
-        },
-        "org.powermock:powermock-module-junit4-common": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-module-junit4"
-            ]
-        },
-        "org.powermock:powermock-reflect": {
-            "locked": "2.0.9",
-            "transitive": [
-                "org.powermock:powermock-api-support",
-                "org.powermock:powermock-core",
-                "org.powermock:powermock-module-junit4-common"
-            ]
+            "locked": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.servo:servo-internal",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/common/dependencies.lock
+++ b/common/dependencies.lock
@@ -1,1075 +1,176 @@
 {
-    "compile": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
-        }
-    },
     "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
+            "locked": "3.5.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
-        }
-    },
-    "default": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
+            "locked": "3.5.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
-        }
-    },
-    "testCompile": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
+            "locked": "3.5.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
-        }
-    },
-    "testRuntime": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
+            "locked": "1.7.25"
         }
     },
     "testRuntimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0"
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "requested": "2.0.0"
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "requested": "1.0.0"
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.4",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:failureaccess": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:listenablefuture": {
-            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
+            "locked": "3.5.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "requested": "1"
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final"
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3"
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.5.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "requested": "1.7.25"
+            "locked": "1.7.25"
         }
     }
 }

--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -1,4511 +1,701 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            "locked": "1.12.129"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.12.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.3"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.1.1"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
+            "locked": "2.2.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "compileOnly": {
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1"
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.29"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            "locked": "1.12.129"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.12.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.3"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
+            "locked": "2.2.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.29"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            "locked": "1.12.129"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.12.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.3"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.13.1"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
+            "locked": "2.2.0"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "requested": "latest.release"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            "locked": "1.12.129"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.12.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.3"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "requested": "5.8.0"
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
+            "locked": "1.19.4"
         },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.1.2",
-            "transitive": [
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "requested": "0.5.0"
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.13.1"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "requested": "0.0.12"
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.2.1"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+        "org.apache.kafka:kafka-clients": {
+            "locked": "2.2.0"
         },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.kafka:kafka-clients",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -1,2280 +1,434 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "requested": "1.11.86"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "requested": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "requested": "4.1.0"
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "requested": "2.2.0"
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "requested": "0.12.17"
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "requested": "0.68.0"
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "requested": "0.3.1"
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "requested": "1.2.2"
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "requested": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "requested": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,65 +1,12 @@
 {
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
+            "locked": "0.8.6"
         }
     }
 }

--- a/es5-persistence/dependencies.lock
+++ b/es5-persistence/dependencies.lock
@@ -1,5474 +1,668 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
+    "compileClasspath": {
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.11.1",
-            "requested": "2.11.1",
-            "transitive": [
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "2.11.1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.11.1",
-            "requested": "2.11.1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "2.11.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "5.6.8"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "5.6.8"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "5.6.8"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.13.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "5.6.8"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.15",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/es6-persistence/dependencies.lock
+++ b/es6-persistence/dependencies.lock
@@ -1,4782 +1,670 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
+    "compileClasspath": {
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.11.1",
-            "requested": "2.11.1",
-            "transitive": [
-                "org.apache.logging.log4j:log4j-core"
-            ]
+            "locked": "2.11.1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.11.1",
-            "requested": "2.11.1"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "2.11.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "6.8.12"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "compileOnly": {
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
     "shadow": {
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "6.8.12"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "6.8.12"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.11",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.8.11",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-cli"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.0"
         },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "7.7.3",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
+            "locked": "6.8.12"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "6.8.12",
-            "requested": "6.8.12"
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:rank-eval-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            "locked": "6.8.12"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "6.8.12",
-            "requested": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-cli": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-core": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch",
-                "org.elasticsearch:elasticsearch-cli",
-                "org.elasticsearch:elasticsearch-ssl-config",
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-secure-sm": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-ssl-config": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch:elasticsearch-x-content": {
-            "locked": "6.8.12",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "5.5.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "6.8.12"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.17",
-            "transitive": [
-                "org.elasticsearch:elasticsearch-x-content"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/es7-persistence/dependencies.lock
+++ b/es7-persistence/dependencies.lock
@@ -1,5 +1,5 @@
 {
-    "compile": {
+    "compileClasspath": {
         "com.amazonaws:aws-java-sdk-s3": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -11,7 +11,7 @@
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "2.10.0"
+            "locked": "2.10.4"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
@@ -84,8 +84,13 @@
             "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
+        },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -121,316 +126,22 @@
             "locked": "3.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.11.1",
-            "requested": "2.11.1"
+            "locked": "2.11.1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.11.1",
-            "requested": "2.11.1"
-        },
-        "org.glassfish:javax.el": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
-        }
-    },
-    "compileClasspath": {
-        "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
-        },
-        "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
-        },
-        "javax.validation:validation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            "locked": "2.11.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.glassfish:javax.el": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
-        }
-    },
-    "compileOnly": {
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        }
-    },
-    "default": {
-        "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
-        },
-        "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
-        },
-        "javax.validation:validation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
+            "locked": "7.10.1"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -448,149 +159,12 @@
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "requested": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1",
-            "requested": "0.8.1"
-        }
-    },
-    "runtime": {
-        "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
-        },
-        "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
-        },
-        "javax.validation:validation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.1.Final"
-        },
-        "org.apache.bval:bval-jsr": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
-        },
-        "org.glassfish:javax.el": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.7.25"
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
@@ -678,8 +252,13 @@
             "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
+        },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -713,6 +292,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -730,187 +315,16 @@
     },
     "shadow": {
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        }
-    },
-    "testCompile": {
-        "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
-        },
-        "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
-        },
-        "javax.validation:validation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.1.Final"
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.glassfish:javax.el": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0.0"
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.8.0-alpha1"
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
+            "locked": "7.10.1"
         }
     },
     "testCompileClasspath": {
@@ -925,7 +339,7 @@
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "2.10.0"
+            "locked": "2.10.4"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
@@ -998,8 +412,13 @@
             "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
+        },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1021,8 +440,7 @@
             "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
             "firstLevelTransitive": [
@@ -1038,25 +456,26 @@
             ],
             "locked": "3.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
+        },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1066,8 +485,7 @@
             "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1076,175 +494,7 @@
             "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        }
-    },
-    "testRuntime": {
-        "com.amazonaws:aws-java-sdk-s3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.11.86"
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.10.0"
-        },
-        "com.github.rholder:guava-retrying": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.0.0"
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.inject:guice": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "4.1.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "3.5.1"
-        },
-        "com.jayway.jsonpath:json-path": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.2.0"
-        },
-        "com.netflix.conductor:conductor-common": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.12.17"
-        },
-        "com.netflix.spectator:spectator-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.68.0"
-        },
-        "com.spotify:completable-futures": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "0.3.1"
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "1.2.2"
-        },
-        "javax.inject:javax.inject": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1"
-        },
-        "javax.validation:validation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.1.Final"
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "org.apache.bval:bval-jsr": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "2.0.3"
-        },
-        "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0"
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
-        },
-        "org.glassfish:javax.el": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ],
-            "locked": "3.0.0"
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
             "locked": "1.8.0-alpha1"
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
@@ -1259,7 +509,7 @@
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
             ],
-            "locked": "2.10.0"
+            "locked": "2.10.4"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
@@ -1332,8 +582,13 @@
             "locked": "0.3.1"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
+        },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1355,8 +610,7 @@
             "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
             "firstLevelTransitive": [
@@ -1372,25 +626,26 @@
             ],
             "locked": "3.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.11.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.11.1"
+        },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "7.9.2",
-            "requested": "7.10.1"
+            "locked": "7.10.1"
         },
         "org.glassfish:javax.el": {
             "firstLevelTransitive": [
@@ -1400,8 +655,7 @@
             "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1410,8 +664,7 @@
             "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/grpc-client/dependencies.lock
+++ b/grpc-client/dependencies.lock
@@ -1,3847 +1,720 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     }
 }

--- a/grpc-server/dependencies.lock
+++ b/grpc-server/dependencies.lock
@@ -1,4563 +1,750 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-testing": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub",
-                "io.grpc:grpc-testing"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services",
-                "io.grpc:grpc-testing"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-testing": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
+            "locked": "4.12"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-testing": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "com.google.protobuf:protobuf-java-util",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub",
-                "io.grpc:grpc-testing"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services",
-                "io.grpc:grpc-testing"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-testing": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
+            "locked": "4.12"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "requested": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.2.17"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     }
 }

--- a/grpc/dependencies.lock
+++ b/grpc/dependencies.lock
@@ -1,3309 +1,934 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
+    "compileProtoPath": {
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "protobuf": {
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.auth:google-auth-library-credentials": {
-            "locked": "0.9.0",
-            "transitive": [
-                "io.grpc:grpc-auth"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-protobuf-nano"
-            ]
-        },
-        "com.google.protobuf.nano:protobuf-javanano": {
-            "locked": "3.0.0-alpha-5",
-            "transitive": [
-                "io.grpc:grpc-protobuf-nano"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.chaossystems.grpc:grpc-healthcheck",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.squareup.okhttp:okhttp": {
-            "locked": "2.5.0",
-            "transitive": [
-                "io.grpc:grpc-okhttp"
-            ]
-        },
-        "com.squareup.okio:okio": {
-            "locked": "1.13.0",
-            "transitive": [
-                "com.squareup.okhttp:okhttp",
-                "io.grpc:grpc-okhttp"
-            ]
-        },
-        "io.chaossystems.grpc:grpc-healthcheck": {
-            "locked": "1.0.1",
-            "requested": "1.0.+"
-        },
-        "io.grpc:grpc-all": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.chaossystems.grpc:grpc-healthcheck"
-            ]
-        },
-        "io.grpc:grpc-auth": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all",
-                "io.grpc:grpc-auth",
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-okhttp",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-protobuf-nano",
-                "io.grpc:grpc-stub",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.grpc:grpc-okhttp": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-protobuf-nano": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all",
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "io.grpc:grpc-testing": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-all"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-resolver"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "1.9.5",
-            "transitive": [
-                "io.grpc:grpc-testing"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "1.0",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "protobufToolsLocator_grpc": {
         "io.grpc:protoc-gen-grpc-java": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
+            "locked": "1.14.0"
         }
     },
     "protobufToolsLocator_protoc": {
         "com.google.protobuf:protoc": {
-            "locked": "3.5.1",
-            "requested": "3.5.1"
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "3.5.1"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
+    "testCompileProtoPath": {
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "requested": "1.0.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.7",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite"
-            ]
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "requested": "1.14.+"
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
+            "locked": "1.14.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     }
 }

--- a/jersey/dependencies.lock
+++ b/jersey/dependencies.lock
@@ -1,3587 +1,623 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
+            "locked": "1.19.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.1.1"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "compileOnly": {
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
+            "locked": "1.19.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "1.1.1"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
+            "locked": "1.19.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
+            "locked": "1.1.1"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.2.1"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.4.5",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.reflections:reflections"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "requested": "1.19.1"
+            "locked": "1.19.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "requested": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "requested": "1.1.1",
-            "transitive": [
-                "com.sun.jersey:jersey-bundle",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-            ]
+            "locked": "1.1.1"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "requested": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.2.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.2.1"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.12",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         }
     }
 }

--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -1,3087 +1,632 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "8.0.11"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "8.0.11"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "locked": "4.12"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "8.0.11"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "mysql:mysql-connector-java"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "locked": "4.12"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "requested": "8.0.11"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "8.0.11"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     }
 }

--- a/postgres-persistence/dependencies.lock
+++ b/postgres-persistence/dependencies.lock
@@ -1,3078 +1,632 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
+            "locked": "42.2.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
+            "locked": "42.2.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
+            "locked": "42.2.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice",
-                "org.springframework:spring-aop"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.collections:google-collections": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "requested": "3.2.0"
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "requested": "2.4"
+            "locked": "2.4"
         },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
-                "org.springframework:spring-core"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.persistence:persistence-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "requested": "7.5.2"
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.hamcrest:hamcrest-library",
-                "org.testinfected.hamcrest-matchers:core-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers",
-                "org.testinfected.hamcrest-matchers:spring-matchers",
-                "org.testinfected.hamcrest-matchers:validation-matchers"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "requested": "42.2.6"
+            "locked": "42.2.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.zaxxer:HikariCP",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.springframework:spring-aop": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-asm": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context",
-                "org.springframework:spring-core"
-            ]
-        },
-        "org.springframework:spring-beans": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-context"
-            ]
-        },
-        "org.springframework:spring-context": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:spring-matchers"
-            ]
-        },
-        "org.springframework:spring-core": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-aop",
-                "org.springframework:spring-beans",
-                "org.springframework:spring-context",
-                "org.springframework:spring-expression"
-            ]
-        },
-        "org.springframework:spring-expression": {
-            "locked": "3.0.2.RELEASE",
-            "transitive": [
-                "org.springframework:spring-context"
-            ]
+            "locked": "1.8.0-alpha1"
         },
         "org.testinfected.hamcrest-matchers:all-matchers": {
-            "locked": "1.8",
-            "requested": "1.8"
-        },
-        "org.testinfected.hamcrest-matchers:core-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers",
-                "org.testinfected.hamcrest-matchers:dom-matchers",
-                "org.testinfected.hamcrest-matchers:jpa-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:dom-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:jpa-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:spring-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "org.testinfected.hamcrest-matchers:validation-matchers": {
-            "locked": "1.8",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:all-matchers"
-            ]
-        },
-        "se.fishtank:css-selectors": {
-            "locked": "1.0.5",
-            "transitive": [
-                "org.testinfected.hamcrest-matchers:dom-matchers"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8"
         }
     }
 }

--- a/redis-lock/dependencies.lock
+++ b/redis-lock/dependencies.lock
@@ -1,3814 +1,596 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.30"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "com.github.kstyrc:embedded-redis": {
-            "locked": "0.6",
-            "requested": "0.6"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.30"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.github.kstyrc:embedded-redis": {
-            "locked": "0.6",
-            "requested": "0.6"
+            "locked": "0.6"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.13.1"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            "locked": "3.1.0"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "com.github.kstyrc:embedded-redis": {
-            "locked": "0.6",
-            "requested": "0.6"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "de.ruedigermoeller:fst",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.12.5"
         },
         "com.github.kstyrc:embedded-redis": {
-            "locked": "0.6",
-            "requested": "0.6"
+            "locked": "0.6"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.github.kstyrc:embedded-redis"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.13.1"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            "locked": "3.1.0"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "requested": "3.11.4"
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1"
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }

--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -1,5485 +1,608 @@
 {
-    "compile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
     "compileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "2.0.13"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
+            "locked": "0.0.17"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "default": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "3.0.1"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "2.0.13"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
+            "locked": "0.0.17"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testCompile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "3.0.1"
         }
     },
     "testCompileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "2.0.13"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            "locked": "3.1.0"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
+            "locked": "0.0.17"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testRuntime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "3.0.1"
         }
     },
     "testRuntimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "requested": "2.0.13"
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "2.0.13"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-client"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-core"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.6"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            "locked": "3.1.0"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17"
+            "locked": "0.0.17"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.25"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "requested": "3.0.+",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "3.0.1"
         }
     }
 }

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -1,430 +1,104 @@
 {
-    "compile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
+    "compileClasspath": {
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -437,7 +111,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -446,10 +121,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -472,5227 +147,401 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+        "javax.ws.rs:jsr311-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
+        },
+        "log4j:log4j": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
+        },
+        "mysql:mysql-connector-java": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence"
+            ],
+            "locked": "8.0.11"
+        },
+        "net.thisptr:jackson-jq": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "0.0.12"
+        },
+        "org.apache.bval:bval-jsr": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.3"
         },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "2.4.0"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.11.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.11.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
+            ],
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "compileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "default": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            ],
+            "locked": "3.0.1"
         }
     },
     "grettyProductRuntime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -5705,7 +554,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -5714,10 +564,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -5740,4519 +590,461 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+        "javax.ws.rs:jsr311-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
+        },
+        "log4j:log4j": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
+        },
+        "mysql:mysql-connector-java": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence"
+            ],
+            "locked": "8.0.11"
+        },
+        "net.thisptr:jackson-jq": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "0.0.12"
+        },
+        "org.apache.bval:bval-jsr": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.3"
         },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.6"
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.curator:curator-recipes": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-zookeeper-lock"
+            ],
+            "locked": "2.4.0"
         },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
+        "org.apache.kafka:kafka-clients": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "2.2.0"
         },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+        "org.eclipse.jetty:jetty-jmx": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+        "org.elasticsearch.client:transport": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+        "org.elasticsearch:elasticsearch": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
+        "org.flywaydb:flyway-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "7.5.2"
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "3.0.1"
         }
     },
     "grettyProvidedCompile": {
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
+            "locked": "3.1.0"
         }
     },
     "grettyRunnerJetty7": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner-jetty": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7"
-            ]
-        },
         "org.akhikhl.gretty:gretty-runner-jetty7": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "org.eclipse.jetty.orbit:com.sun.el": {
-            "locked": "1.0.0.v201105211818",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.activation": {
-            "locked": "1.1.0.v201105071233",
-            "transitive": [
-                "org.eclipse.jetty.orbit:javax.mail.glassfish"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.el": {
-            "locked": "2.1.0.v201105211819",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.mail.glassfish": {
-            "locked": "1.4.1.v201005082020",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jndi"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.servlet.jsp": {
-            "locked": "2.1.0.v201105211820",
-            "transitive": [
-                "org.eclipse.jetty.orbit:javax.servlet.jsp.jstl",
-                "org.eclipse.jetty.orbit:org.apache.jasper.glassfish",
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.servlet.jsp.jstl": {
-            "locked": "1.2.0.v201105211821",
-            "transitive": [
-                "org.eclipse.jetty.orbit:org.apache.taglibs.standard.glassfish",
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.transaction": {
-            "locked": "1.1.1.v201105210645",
-            "transitive": [
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.apache.jasper.glassfish": {
-            "locked": "2.1.0.v201110031002",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.apache.taglibs.standard.glassfish": {
-            "locked": "1.2.0.v201112081803",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.eclipse.jdt.core": {
-            "locked": "3.7.1",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty:jetty-continuation": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jndi": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jsp": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7"
-            ]
-        },
-        "org.eclipse.jetty:jetty-plus": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7",
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7",
-                "org.eclipse.jetty:jetty-jndi",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7",
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-webapp": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty7",
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-xml": {
-            "locked": "7.6.16.v20140903",
-            "transitive": [
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.7",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
+            "locked": "1.2.4"
         }
     },
     "grettyRunnerJetty8": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner-jetty": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8"
-            ]
-        },
         "org.akhikhl.gretty:gretty-runner-jetty8": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "org.eclipse.jetty.orbit:com.sun.el": {
-            "locked": "2.2.0.v201108011116",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.activation": {
-            "locked": "1.1.0.v201105071233",
-            "transitive": [
-                "org.eclipse.jetty.orbit:javax.mail.glassfish"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.annotation": {
-            "locked": "1.1.0.v201108011116",
-            "transitive": [
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.el": {
-            "locked": "2.2.0.v201108011116",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.mail.glassfish": {
-            "locked": "1.4.1.v201005082020",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jndi"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.servlet.jsp": {
-            "locked": "2.2.0.v201112011158",
-            "transitive": [
-                "org.eclipse.jetty.orbit:javax.servlet.jsp.jstl",
-                "org.eclipse.jetty.orbit:org.apache.jasper.glassfish",
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.servlet.jsp.jstl": {
-            "locked": "1.2.0.v201105211821",
-            "transitive": [
-                "org.eclipse.jetty.orbit:org.apache.taglibs.standard.glassfish",
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.transaction": {
-            "locked": "1.1.1.v201105210645",
-            "transitive": [
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.apache.jasper.glassfish": {
-            "locked": "2.2.2.v201112011158",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.apache.taglibs.standard.glassfish": {
-            "locked": "1.2.0.v201112081803",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.eclipse.jdt.core": {
-            "locked": "3.7.1",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.objectweb.asm": {
-            "locked": "3.1.0.v200803061910",
-            "transitive": [
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "org.eclipse.jetty:jetty-annotations": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8"
-            ]
-        },
-        "org.eclipse.jetty:jetty-continuation": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jndi": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jsp": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8"
-            ]
-        },
-        "org.eclipse.jetty:jetty-plus": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8",
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8",
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8",
-                "org.eclipse.jetty:jetty-jndi",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8",
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-webapp": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty8",
-                "org.eclipse.jetty:jetty-annotations",
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-xml": {
-            "locked": "8.1.8.v20121106",
-            "transitive": [
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.7",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
+            "locked": "1.2.4"
         }
     },
     "grettyRunnerJetty9": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "javax.servlet.jsp:javax.servlet.jsp-api": {
-            "locked": "2.3.1",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp",
-                "org.glassfish.web:javax.servlet.jsp"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty.websocket:websocket-servlet",
-                "org.eclipse.jetty:jetty-jsp",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.websocket:javax.websocket-api": {
-            "locked": "1.0",
-            "transitive": [
-                "org.eclipse.jetty.websocket:javax-websocket-client-impl",
-                "org.eclipse.jetty.websocket:javax-websocket-server-impl"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner-jetty": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9"
-            ]
-        },
         "org.akhikhl.gretty:gretty-runner-jetty9": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "org.eclipse.jetty.orbit:javax.servlet.jsp.jstl": {
-            "locked": "1.2.0.v201105211821",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.orbit:org.eclipse.jdt.core": {
-            "locked": "3.8.2.v20130121",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.toolchain:jetty-schemas": {
-            "locked": "3.1.M0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.eclipse.jetty.websocket:javax-websocket-client-impl": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:javax-websocket-server-impl"
-            ]
-        },
-        "org.eclipse.jetty.websocket:javax-websocket-server-impl": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9"
-            ]
-        },
-        "org.eclipse.jetty.websocket:websocket-api": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-common",
-                "org.eclipse.jetty.websocket:websocket-servlet"
-            ]
-        },
-        "org.eclipse.jetty.websocket:websocket-client": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:javax-websocket-client-impl",
-                "org.eclipse.jetty.websocket:websocket-server"
-            ]
-        },
-        "org.eclipse.jetty.websocket:websocket-common": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-client",
-                "org.eclipse.jetty.websocket:websocket-server"
-            ]
-        },
-        "org.eclipse.jetty.websocket:websocket-server": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:javax-websocket-server-impl"
-            ]
-        },
-        "org.eclipse.jetty.websocket:websocket-servlet": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-annotations": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty.websocket:javax-websocket-server-impl"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-server",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-client",
-                "org.eclipse.jetty.websocket:websocket-common",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jndi": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jsp": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9"
-            ]
-        },
-        "org.eclipse.jetty:jetty-plus": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty.websocket:websocket-server",
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty.websocket:websocket-client",
-                "org.eclipse.jetty.websocket:websocket-common",
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jndi",
-                "org.eclipse.jetty:jetty-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-webapp": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-annotations",
-                "org.eclipse.jetty:jetty-plus"
-            ]
-        },
-        "org.eclipse.jetty:jetty-xml": {
-            "locked": "9.2.10.v20150310",
-            "transitive": [
-                "org.eclipse.jetty:jetty-webapp"
-            ]
-        },
-        "org.glassfish.web:javax.servlet.jsp": {
-            "locked": "2.3.2",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.glassfish.web:javax.servlet.jsp.jstl": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-jsp",
-                "org.glassfish.web:javax.servlet.jsp"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-annotations",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-jetty9",
-                "org.eclipse.jetty:jetty-annotations"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "org.ow2.asm:asm-commons"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.7",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
+            "locked": "1.2.4"
         }
     },
     "grettyRunnerTomcat7": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.0.1",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner-tomcat": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat7"
-            ]
-        },
         "org.akhikhl.gretty:gretty-runner-tomcat7": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "7.0.62",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat",
-                "org.apache.tomcat.embed:tomcat-embed-jasper",
-                "org.apache.tomcat.embed:tomcat-embed-websocket"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "7.0.62",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat7",
-                "org.apache.tomcat.embed:tomcat-embed-jasper"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-jasper": {
-            "locked": "7.0.62",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat7"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-logging-log4j": {
-            "locked": "7.0.62",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "7.0.62",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat7"
-            ]
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.tomcat.embed:tomcat-embed-jasper"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.12",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.12",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.slf4j:log4j-over-slf4j"
-            ]
+            "locked": "1.2.4"
         }
     },
     "grettyRunnerTomcat8": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat8"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-runner-tomcat": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat8"
-            ]
-        },
         "org.akhikhl.gretty:gretty-runner-tomcat8": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "8.0.23",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat",
-                "org.akhikhl.gretty:gretty-runner-tomcat8",
-                "org.apache.tomcat.embed:tomcat-embed-jasper",
-                "org.apache.tomcat.embed:tomcat-embed-websocket"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "8.0.23",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat8",
-                "org.apache.tomcat.embed:tomcat-embed-jasper"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-jasper": {
-            "locked": "8.0.23",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat8"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-logging-log4j": {
-            "locked": "8.0.23",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat",
-                "org.akhikhl.gretty:gretty-runner-tomcat8"
-            ]
-        },
-        "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "8.0.23",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner-tomcat8"
-            ]
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-runner"
-            ]
-        },
-        "org.eclipse.jdt.core.compiler:ecj": {
-            "locked": "4.4.2",
-            "transitive": [
-                "org.apache.tomcat.embed:tomcat-embed-jasper"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.7",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
+            "locked": "1.2.4"
         }
     },
     "grettySpringLoaded": {
         "org.springframework:springloaded": {
-            "locked": "1.2.3.RELEASE",
-            "requested": "1.2.3.RELEASE"
+            "locked": "1.2.3.RELEASE"
         }
     },
     "grettyStarter": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.1.3",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.1.3",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.1.1",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "org.akhikhl.gretty:gretty-core": {
-            "locked": "1.2.4",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-starter"
-            ]
-        },
         "org.akhikhl.gretty:gretty-starter": {
-            "locked": "1.2.4",
-            "requested": "1.2.4"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.3.2",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "org.bouncycastle:bcprov-jdk16": {
-            "locked": "1.46",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.3.10",
-            "transitive": [
-                "org.akhikhl.gretty:gretty-core"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.7",
-            "transitive": [
-                "ch.qos.logback:logback-classic"
-            ]
+            "locked": "1.2.4"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "providedCompile": {
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
+            "locked": "3.1.0"
         }
     },
     "providedRuntime": {
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        }
-    },
-    "runtime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "3.1.0"
         }
     },
     "runtimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -10265,7 +1057,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -10274,10 +1067,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -10300,1705 +1093,401 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+        "javax.ws.rs:jsr311-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
+        },
+        "log4j:log4j": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
+        },
+        "mysql:mysql-connector-java": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence"
+            ],
+            "locked": "8.0.11"
+        },
+        "net.thisptr:jackson-jq": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "0.0.12"
+        },
+        "org.apache.bval:bval-jsr": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.3"
         },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.6"
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.curator:curator-recipes": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-zookeeper-lock"
+            ],
+            "locked": "2.4.0"
         },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
+        "org.apache.kafka:kafka-clients": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "2.2.0"
         },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+        "org.eclipse.jetty:jetty-jmx": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+        "org.elasticsearch.client:transport": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+        "org.elasticsearch:elasticsearch": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
+        "org.flywaydb:flyway-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "7.5.2"
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "3.0.1"
         }
     },
     "springBoot": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -12011,7 +1500,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -12020,10 +1510,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -12046,3440 +1536,392 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "8.0.11"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "2.4.0"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "2.2.0"
         },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "project": true,
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "project": true,
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "project": true,
-            "requested": "9.4.22.v20191022"
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
+            ],
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.5.1",
-            "transitive": [
-                "de.ruedigermoeller:fst"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testCompile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            ],
+            "locked": "3.0.1"
         }
     },
     "testCompileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -15492,7 +1934,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -15501,10 +1944,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -15527,3495 +1970,407 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.13.1"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "8.0.11"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "2.4.0"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "2.2.0"
         },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
+            "locked": "9.4.22.v20191022"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
+            ],
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testRuntime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            ],
+            "locked": "3.0.1"
         }
     },
     "testRuntimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-grpc",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
             "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -19028,7 +2383,8 @@
                 "com.netflix.conductor:conductor-redis-lock",
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
             "project": true
@@ -19037,10 +2393,10 @@
             "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
             "project": true
@@ -19063,1299 +2419,305 @@
         "com.netflix.conductor:conductor-zookeeper-lock": {
             "project": true
         },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.6",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.15.7",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "requested": "1.1.+"
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4"
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.4"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.9"
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+        "javax.ws.rs:jsr311-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
+        },
+        "junit:junit": {
+            "locked": "4.13.1"
+        },
+        "log4j:log4j": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
+        },
+        "mysql:mysql-connector-java": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence"
+            ],
+            "locked": "8.0.11"
+        },
+        "net.thisptr:jackson-jq": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "0.0.12"
+        },
+        "org.apache.bval:bval-jsr": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.3"
         },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022"
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.6"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+        "org.apache.curator:curator-recipes": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-zookeeper-lock"
+            ],
+            "locked": "2.4.0"
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.kafka:kafka-clients": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "2.2.0"
         },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "org.eclipse.jetty:jetty-jmx": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "org.elasticsearch.client:transport": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+        "org.elasticsearch:elasticsearch": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+        "org.flywaydb:flyway-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "7.5.2"
+        },
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "3.0.1"
         }
     }
 }

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -1,2513 +1,135 @@
 {
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "testCompile": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "cglib:cglib-nodep": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs",
-                "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.cyrusinnovation:mockito-groovy-support": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.archaius:archaius2-test",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-test": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-client": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-client": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-core",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.governator:governator-test": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.netflix.governator:governator-test-spock": {
-            "locked": "1.17.11",
-            "requested": "latest.release"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "1.3.5",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.activation:javax.activation-api": {
-            "locked": "1.2.0",
-            "transitive": [
-                "javax.xml.bind:jaxb-api"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.1",
-            "transitive": [
-                "com.netflix.governator:governator"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.spockframework:spock-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.governator:governator-test",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.15",
-            "requested": "2.4.15",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support",
-                "org.spockframework:spock-core",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-all": {
-            "locked": "1.9.5",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.spockframework:spock-core": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.spockframework:spock-guice": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "locked": "0.8.6"
         }
     },
     "testCompileClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "cglib:cglib-nodep": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.cyrusinnovation:mockito-groovy-support": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
                 "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.archaius:archaius2-test",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-test": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "0.7.6"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-client": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
@@ -2515,17 +137,17 @@
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -2540,3956 +162,550 @@
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-server",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-client": {
             "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-jersey": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-server": {
             "project": true
         },
         "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-core",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.governator:governator-test": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "1.8.7"
         },
         "com.netflix.governator:governator-test-spock": {
-            "locked": "1.17.11",
-            "requested": "latest.release"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "1.17.12"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "1.19.4"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "1.3.5",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.activation:javax.activation-api": {
-            "locked": "1.2.0",
-            "transitive": [
-                "javax.xml.bind:jaxb-api"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.1.Final"
         },
         "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.1",
-            "transitive": [
-                "com.netflix.governator:governator"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.spockframework:spock-core"
-            ]
+            "locked": "4.13.1"
         },
         "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
         },
         "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            ],
+            "locked": "8.0.11"
         },
         "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
+            ],
+            "locked": "0.0.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.governator:governator-test",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.6"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
+            ],
+            "locked": "2.4.0"
         },
         "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.9.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.9.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
         "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
+            "locked": "3.1.2"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.15",
-            "requested": "2.4.15",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support",
-                "org.spockframework:spock-core",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
+            "locked": "2.4.15"
         },
         "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
+            ],
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-security"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "9.4.22.v20191022"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
+            ],
+            "locked": "9.4.22.v20191022"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
+            ],
+            "locked": "5.6.8"
         },
         "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
         "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
+            ],
+            "locked": "7.5.2"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-all": {
-            "locked": "1.9.5",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "org.spockframework:spock-core": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock",
-                "org.spockframework:spock-guice"
-            ]
+            "locked": "1.3-groovy-2.4"
         },
         "org.spockframework:spock-guice": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "1.3-groovy-2.4"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        }
-    },
-    "testRuntime": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "cglib:cglib-nodep": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs",
-                "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.cyrusinnovation:mockito-groovy-support": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.archaius:archaius2-test",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-test": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-client": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.netflix.conductor:conductor-contribs": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-cassandra-persistence",
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.conductor:conductor-redis-lock",
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-grpc-client": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-grpc-server": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-jersey": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-redis-lock": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.conductor:conductor-server": {
-            "project": true
-        },
-        "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-core",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.governator:governator-test": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
-        "com.netflix.governator:governator-test-spock": {
-            "locked": "1.17.11",
-            "requested": "latest.release"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
-        },
-        "commons-io:commons-io": {
-            "locked": "2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
-        },
-        "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-server"
-            ]
-        },
-        "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "1.3.5",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.activation:javax.activation-api": {
-            "locked": "1.2.0",
-            "transitive": [
-                "javax.xml.bind:jaxb-api"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
-        },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.1",
-            "transitive": [
-                "com.netflix.governator:governator"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.spockframework:spock-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.governator:governator-test",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.15",
-            "requested": "2.4.15",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support",
-                "org.spockframework:spock-core",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
-        },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
-        },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
-        },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
-        },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.mockito:mockito-all": {
-            "locked": "1.9.5",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
-        },
-        "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
-        },
-        "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.spockframework:spock-core": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.spockframework:spock-guice": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            ],
+            "locked": "3.0.1"
         }
     },
     "testRuntimeClasspath": {
-        "antlr:antlr": {
-            "locked": "2.7.7",
-            "transitive": [
-                "org.antlr:antlr-runtime",
-                "org.antlr:stringtemplate"
-            ]
-        },
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "cglib:cglib-nodep": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.amazonaws:aws-java-sdk-sqs": {
-            "locked": "1.11.951",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.951",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3",
-                "com.amazonaws:aws-java-sdk-sqs"
-            ]
-        },
-        "com.carrotsearch:hppc": {
-            "locked": "0.7.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.cyrusinnovation:mockito-groovy-support": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
+            ],
+            "locked": "1.12.129"
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.6.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence"
-            ]
-        },
-        "com.ecwid.consul:consul-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.eureka:eureka-client",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models"
-            ]
+            ],
+            "locked": "3.6.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.eureka:eureka-client",
-                "de.ruedigermoeller:fst",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "com.netflix.archaius:archaius-core",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator",
-                "io.swagger:swagger-core",
-                "net.thisptr:jackson-jq",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.8.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-smile": {
-            "locked": "2.8.6",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
-            "locked": "2.9.10",
-            "transitive": [
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.elasticsearch:elasticsearch",
-                "org.redisson:redisson"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
-            "locked": "2.4.5",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.10.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
-            ]
-        },
-        "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
+            ],
+            "locked": "2.12.5"
         },
         "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
-            ]
-        },
-        "com.github.andrewoma.dexx:dexx-collections": {
-            "locked": "0.2",
-            "transitive": [
-                "com.github.vlsi.compactmap:compactmap"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.16",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.9",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.1.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.44",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.luben:zstd-jni": {
-            "locked": "1.3.8-1",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.spullara.mustache.java:compiler": {
-            "locked": "0.9.3",
-            "transitive": [
-                "org.elasticsearch.plugin:lang-mustache-client"
-            ]
-        },
-        "com.github.vlsi.compactmap:compactmap": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.api.grpc:proto-google-common-protos": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.code.findbugs:annotations": {
-            "locked": "2.0.1",
-            "transitive": [
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.code.gson:gson": {
-            "locked": "2.8.5",
-            "transitive": [
-                "com.ecwid.consul:consul-api",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.2",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "20.0",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "io.grpc:grpc-core",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.reflections:reflections"
-            ]
-        },
-        "com.google.inject.extensions:guice-assistedinject": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher"
-            ]
-        },
-        "com.google.inject.extensions:guice-grapher": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-grapher",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.governator:governator-core"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject.extensions:guice-servlet": {
-            "locked": "4.1.0",
-            "requested": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-assistedinject",
-                "com.google.inject.extensions:guice-grapher",
-                "com.google.inject.extensions:guice-multibindings",
-                "com.google.inject.extensions:guice-servlet",
-                "com.netflix.archaius:archaius2-guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence",
                 "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.conductor:conductor-server",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.governator:governator-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.google.api.grpc:proto-google-common-protos",
-                "com.google.protobuf:protobuf-java-util",
-                "com.netflix.conductor:conductor-common",
-                "io.grpc:grpc-protobuf",
-                "mysql:mysql-connector-java"
-            ]
-        },
-        "com.google.protobuf:protobuf-java-util": {
-            "locked": "3.5.1",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.google.re2j:re2j": {
-            "locked": "1.2",
-            "transitive": [
-                "io.grpc:grpc-services"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.archaius:archaius-core": {
-            "locked": "0.7.6",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "com.netflix.archaius:archaius2-api": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-core": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.archaius:archaius2-test",
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.archaius:archaius2-test": {
-            "locked": "2.1.10",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "0.7.6"
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-client": {
             "project": true
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-core",
@@ -6497,17 +713,17 @@
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-contribs": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-cassandra-persistence",
                 "com.netflix.conductor:conductor-contribs",
                 "com.netflix.conductor:conductor-es5-persistence",
@@ -6522,1508 +738,427 @@
                 "com.netflix.conductor:conductor-redis-persistence",
                 "com.netflix.conductor:conductor-server",
                 "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es5-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-es6-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-grpc-client": {
             "project": true
         },
         "com.netflix.conductor:conductor-grpc-server": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-jersey": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-mysql-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-postgres-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-redis-lock": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-redis-persistence": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-server": {
             "project": true
         },
         "com.netflix.conductor:conductor-zookeeper-lock": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.netflix.dyno-queues:dyno-queues-core": {
-            "locked": "2.0.13",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.dyno-queues:dyno-queues-redis": {
-            "locked": "2.0.13",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "com.netflix.dyno:dyno-contrib": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache"
-            ]
-        },
-        "com.netflix.dyno:dyno-core": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-demo": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis"
-            ]
-        },
-        "com.netflix.dyno:dyno-jedis": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-recipes"
-            ]
-        },
-        "com.netflix.dyno:dyno-memcache": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "com.netflix.dyno:dyno-recipes": {
-            "locked": "1.7.2-rc2",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
+            ],
+            "locked": "2.0.13"
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.8.7",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib"
-            ]
-        },
-        "com.netflix.governator:governator": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "com.netflix.governator:governator-api": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-core",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.governator:governator-core": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator",
-                "com.netflix.governator:governator-test",
-                "com.netflix.runtime:health-guice"
-            ]
-        },
-        "com.netflix.governator:governator-test": {
-            "locked": "1.17.11",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "1.8.7"
         },
         "com.netflix.governator:governator-test-spock": {
-            "locked": "1.17.11",
-            "requested": "latest.release"
-        },
-        "com.netflix.netflix-commons:netflix-eventbus": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.netflix.netflix-commons:netflix-infix": {
-            "locked": "0.3.0",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "locked": "1.17.12"
         },
         "com.netflix.runtime:health-api": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc",
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.runtime:health-core"
-            ]
-        },
-        "com.netflix.runtime:health-core": {
-            "locked": "1.1.4",
-            "transitive": [
-                "com.netflix.runtime:health-guice"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.runtime:health-guice": {
-            "locked": "1.1.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
+            ],
+            "locked": "1.1.4"
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno-queues:dyno-queues-redis",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.eureka:eureka-client",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.runtime:health-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "0.68.0"
         },
         "com.netflix.spectator:spectator-reg-metrics3": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.rabbitmq:amqp-client": {
-            "locked": "5.8.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "5.8.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-client": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs.jersey-oauth:oauth-signature": {
-            "locked": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-apache-client4": {
-            "locked": "1.19.1",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey.contribs:jersey-guice": {
-            "locked": "1.19.4",
-            "requested": "1.19.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "com.sun.jersey.contribs:jersey-multipart": {
-            "locked": "1.13",
-            "transitive": [
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+            ],
+            "locked": "1.19.4"
         },
         "com.sun.jersey:jersey-bundle": {
-            "locked": "1.19.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "1.19.1"
         },
         "com.sun.jersey:jersey-client": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.conductor:conductor-client",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-core": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs.jersey-oauth:oauth-signature",
-                "com.sun.jersey.contribs:jersey-multipart",
-                "com.sun.jersey:jersey-client",
-                "com.sun.jersey:jersey-server",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-server": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey:jersey-servlet",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.sun.jersey:jersey-servlet": {
-            "locked": "1.19.4",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-guice",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
-        },
-        "com.tdunning:t-digest": {
-            "locked": "3.0",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "com.thoughtworks.xstream:xstream": {
-            "locked": "1.4.10",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "com.vividsolutions:jts": {
-            "locked": "1.13",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-client"
+            ],
+            "locked": "1.19.4"
         },
         "com.zaxxer:HikariCP": {
-            "locked": "3.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-mysql-persistence",
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "commons-cli:commons-cli": {
-            "locked": "1.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-demo"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.11",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "commons-configuration:commons-configuration": {
-            "locked": "1.8",
-            "transitive": [
-                "com.netflix.archaius:archaius-core"
-            ]
+            ],
+            "locked": "3.2.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
                 "com.netflix.conductor:conductor-es5-persistence",
                 "com.netflix.conductor:conductor-es6-persistence",
                 "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence",
-                "com.netflix.dyno:dyno-core"
-            ]
-        },
-        "commons-jxpath:commons-jxpath": {
-            "locked": "1.3",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "2.6"
         },
         "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "commons-configuration:commons-configuration"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "commons-configuration:commons-configuration",
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "de.ruedigermoeller:fst": {
-            "locked": "2.57",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.netflix.spectator:spectator-reg-metrics3"
-            ]
-        },
-        "io.grpc:grpc-context": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.grpc:grpc-core": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-netty",
-                "io.grpc:grpc-protobuf",
-                "io.grpc:grpc-protobuf-lite",
-                "io.grpc:grpc-stub"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.grpc:grpc-netty": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-client",
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-protobuf": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
-        },
-        "io.grpc:grpc-protobuf-lite": {
-            "locked": "1.14.0",
-            "transitive": [
-                "io.grpc:grpc-protobuf"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-services": {
-            "locked": "1.14.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-grpc-server"
-            ]
+            ],
+            "locked": "1.14.0"
         },
         "io.grpc:grpc-stub": {
-            "locked": "1.14.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc",
-                "io.grpc:grpc-services"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "1.14.0"
         },
         "io.nats:java-nats-streaming": {
-            "locked": "0.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "io.netty:netty": {
-            "locked": "3.10.6.Final",
-            "transitive": [
-                "org.elasticsearch.plugin:transport-netty3-client"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-codec-http",
-                "io.netty:netty-codec-socks",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-codec-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns"
-            ]
-        },
-        "io.netty:netty-codec-http": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-codec-http2",
-                "io.netty:netty-handler-proxy",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-codec-http2": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-codec-socks": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.netty:netty-handler-proxy"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-buffer",
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-resolver",
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "io.netty:netty-codec-http2",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-handler-proxy": {
-            "locked": "4.1.27.Final",
-            "transitive": [
-                "io.grpc:grpc-netty"
-            ]
-        },
-        "io.netty:netty-resolver": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "io.netty:netty-resolver-dns": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.1.41.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-codec-dns",
-                "io.netty:netty-handler",
-                "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.redisson:redisson"
-            ]
-        },
-        "io.opencensus:opencensus-api": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core",
-                "io.opencensus:opencensus-contrib-grpc-metrics"
-            ]
-        },
-        "io.opencensus:opencensus-contrib-grpc-metrics": {
-            "locked": "0.12.3",
-            "transitive": [
-                "io.grpc:grpc-core"
-            ]
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.2.6.RELEASE",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
-        },
-        "io.reactivex.rxjava2:rxjava": {
-            "locked": "2.2.7",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "0.5.0"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "io.swagger:swagger-annotations": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-models"
-            ]
-        },
-        "io.swagger:swagger-core": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "io.swagger:swagger-jaxrs": {
-            "locked": "1.5.9",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-jersey-jaxrs"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.5.9"
         },
         "io.swagger:swagger-jersey-jaxrs": {
-            "locked": "1.5.9",
-            "requested": "1.5.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "io.swagger:swagger-models": {
-            "locked": "1.5.9",
-            "transitive": [
-                "io.swagger:swagger-core"
-            ]
-        },
-        "jakarta.activation:jakarta.activation-api": {
-            "locked": "1.2.1",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
-                "jakarta.xml.bind:jakarta.xml.bind-api"
-            ]
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "1.3.5",
-            "transitive": [
-                "com.netflix.governator:governator-core"
-            ]
-        },
-        "jakarta.xml.bind:jakarta.xml.bind-api": {
-            "locked": "2.3.2",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
-            ]
-        },
-        "javax.activation:javax.activation-api": {
-            "locked": "1.2.0",
-            "transitive": [
-                "javax.xml.bind:jaxb-api"
-            ]
-        },
-        "javax.cache:cache-api": {
-            "locked": "1.0.0",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+            ],
+            "locked": "1.5.9"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.archaius:archaius2-api",
-                "com.netflix.archaius:archaius2-guice",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core",
-                "com.netflix.runtime:health-core",
-                "com.sun.jersey.contribs:jersey-guice"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1"
         },
         "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "javax.servlet:servlet-api": {
-            "locked": "2.5",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "3.1.0"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core",
-                "com.netflix.conductor:conductor-jersey",
-                "io.swagger:swagger-core"
-            ]
-        },
-        "javax.ws.rs:jsr311-api": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-jersey",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey:jersey-bundle",
-                "com.sun.jersey:jersey-core",
-                "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "javax.xml.bind:jaxb-api": {
-            "locked": "2.3.1",
-            "transitive": [
-                "com.netflix.governator:governator"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.9.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.netflix-commons:netflix-infix",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12",
-            "transitive": [
-                "org.spockframework:spock-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-grpc-client",
-                "com.netflix.conductor:conductor-grpc-server",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "mysql:mysql-connector-java": {
-            "locked": "8.0.11",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.16",
-            "transitive": [
-                "org.mockito:mockito-core",
-                "org.redisson:redisson"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "net.sf.jopt-simple:jopt-simple": {
-            "locked": "5.0.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "net.thisptr:jackson-jq": {
-            "locked": "0.0.12",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.antlr:antlr-runtime": {
-            "locked": "3.4",
-            "transitive": [
-                "com.netflix.netflix-commons:netflix-infix"
-            ]
-        },
-        "org.antlr:stringtemplate": {
-            "locked": "3.2.1",
-            "transitive": [
-                "org.antlr:antlr-runtime"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
                 "com.netflix.conductor:conductor-jersey"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.6",
-            "transitive": [
-                "com.netflix.archaius:archaius2-core",
+        "javax.ws.rs:jsr311-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "1.1.1"
+        },
+        "junit:junit": {
+            "locked": "4.13.1"
+        },
+        "log4j:log4j": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server"
+            ],
+            "locked": "1.2.17"
+        },
+        "mysql:mysql-connector-java": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence"
+            ],
+            "locked": "8.0.11"
+        },
+        "net.thisptr:jackson-jq": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "0.0.12"
+        },
+        "org.apache.bval:bval-jsr": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.governator:governator-test",
-                "io.swagger:swagger-core"
-            ]
+                "com.netflix.conductor:conductor-jersey"
+            ],
+            "locked": "2.0.3"
         },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.netflix-commons:netflix-eventbus"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.3",
-            "transitive": [
-                "redis.clients:jedis"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-zookeeper-lock"
-            ]
-        },
-        "org.apache.httpcomponents:httpasyncclient": {
-            "locked": "4.1.2",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.13",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.eureka:eureka-client",
-                "com.sun.jersey.contribs:jersey-apache-client4",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.13",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore-nio": {
-            "locked": "4.4.5",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-client"
-            ]
-        },
-        "org.apache.kafka:kafka-clients": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-contribs"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.apache.logging.log4j:log4j-core",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.9.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "com.netflix.conductor:conductor-es6-persistence",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.apache.lucene:lucene-analyzers-common": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-backward-codecs": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-core": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-grouping": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-highlighter": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-join": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-memory": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-misc": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queries": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-queryparser": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-sandbox": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial-extras": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-spatial3d": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.lucene:lucene-suggest": {
-            "locked": "6.6.1",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.awaitility:awaitility": {
-            "locked": "3.1.2",
-            "requested": "3.1.2"
-        },
-        "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.15",
-            "requested": "2.4.15",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support",
-                "org.spockframework:spock-core",
-                "org.spockframework:spock-guice"
-            ]
-        },
-        "org.codehaus.jettison:jettison": {
-            "locked": "1.3.7",
-            "transitive": [
-                "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.woodstox:stax2-api": {
-            "locked": "3.1.4",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-            ]
-        },
-        "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-jmx": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-servlet"
-            ]
-        },
-        "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server",
-                "org.eclipse.jetty:jetty-security"
-            ]
-        },
-        "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.22.v20191022",
-            "requested": "9.4.22.v20191022",
-            "transitive": [
-                "com.netflix.conductor:conductor-server"
-            ]
-        },
-        "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.22.v20191022",
-            "transitive": [
-                "org.eclipse.jetty:jetty-http",
-                "org.eclipse.jetty:jetty-io",
-                "org.eclipse.jetty:jetty-jmx"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.plugin:reindex-client"
-            ]
-        },
-        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.client:transport": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence"
-            ]
-        },
-        "org.elasticsearch.plugin:aggs-matrix-stats-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client"
-            ]
-        },
-        "org.elasticsearch.plugin:lang-mustache-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:parent-join-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:percolator-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:reindex-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty3-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch.plugin:transport-netty4-client": {
-            "locked": "5.6.8",
-            "transitive": [
-                "org.elasticsearch.client:transport"
-            ]
-        },
-        "org.elasticsearch:elasticsearch": {
-            "locked": "5.6.8",
-            "requested": "5.6.8",
-            "transitive": [
-                "com.netflix.conductor:conductor-es5-persistence",
-                "org.elasticsearch.client:elasticsearch-rest-high-level-client",
-                "org.elasticsearch.client:transport",
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
-        },
-        "org.elasticsearch:jna": {
-            "locked": "4.4.0-1",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client",
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.elasticsearch:securesm": {
-            "locked": "1.2",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
-        },
-        "org.flywaydb:flyway-core": {
-            "locked": "7.5.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-mysql-persistence",
-                "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "3.6"
         },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit",
-                "org.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
+        "org.apache.curator:curator-recipes": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-zookeeper-lock"
+            ],
+            "locked": "2.4.0"
         },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "org.awaitility:awaitility"
-            ]
+        "org.apache.kafka:kafka-clients": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-contribs"
+            ],
+            "locked": "2.2.0"
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "org.elasticsearch:elasticsearch"
-            ]
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.javassist:javassist": {
-            "locked": "3.21.0-GA",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.reflections:reflections"
-            ]
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence",
+                "com.netflix.conductor:conductor-es6-persistence"
+            ],
+            "locked": "2.11.1"
         },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+        "org.awaitility:awaitility": {
+            "locked": "3.1.2"
         },
-        "org.jodd:jodd-bean": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.redisson:redisson"
-            ]
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.15"
         },
-        "org.jodd:jodd-core": {
-            "locked": "5.0.13",
-            "transitive": [
-                "org.jodd:jodd-bean"
-            ]
+        "org.eclipse.jetty:jetty-jmx": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.jcodings:jcodings": {
-            "locked": "1.0.43",
-            "transitive": [
-                "org.jruby.joni:joni"
-            ]
+        "org.eclipse.jetty:jetty-server": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "9.4.22.v20191022"
         },
-        "org.jruby.joni:joni": {
-            "locked": "2.1.27",
-            "transitive": [
-                "net.thisptr:jackson-jq"
-            ]
+        "org.eclipse.jetty:jetty-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "9.4.22.v20191022"
         },
-        "org.jvnet:mimepull": {
-            "locked": "1.6",
-            "transitive": [
-                "com.sun.jersey.contribs:jersey-multipart"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.locationtech.spatial4j:spatial4j": {
-            "locked": "0.6",
-            "transitive": [
-                "org.elasticsearch.plugin:aggs-matrix-stats-client",
-                "org.elasticsearch.plugin:lang-mustache-client",
-                "org.elasticsearch.plugin:parent-join-client",
-                "org.elasticsearch.plugin:percolator-client",
-                "org.elasticsearch.plugin:reindex-client",
-                "org.elasticsearch.plugin:transport-netty3-client",
-                "org.elasticsearch.plugin:transport-netty4-client"
-            ]
+        "org.elasticsearch.client:elasticsearch-rest-high-level-client": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.luaj:luaj-jse": {
-            "locked": "3.0",
-            "transitive": [
-                "org.rarefiedredis.redis:redis-java"
-            ]
+        "org.elasticsearch.client:transport": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.lz4:lz4-java": {
-            "locked": "1.5.0",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
+        "org.elasticsearch:elasticsearch": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-es5-persistence"
+            ],
+            "locked": "5.6.8"
         },
-        "org.mockito:mockito-all": {
-            "locked": "1.9.5",
-            "transitive": [
-                "com.cyrusinnovation:mockito-groovy-support"
-            ]
+        "org.flywaydb:flyway-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence"
+            ],
+            "locked": "7.5.2"
+        },
+        "org.glassfish:javax.el": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0",
-            "transitive": [
-                "com.netflix.governator:governator-test"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "de.ruedigermoeller:fst",
-                "org.awaitility:awaitility",
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "net.minidev:accessors-smart",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
+            "locked": "3.1.0"
         },
         "org.postgresql:postgresql": {
-            "locked": "42.2.6",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-postgres-persistence"
-            ]
-        },
-        "org.projectlombok:lombok": {
-            "locked": "1.18.4",
-            "transitive": [
-                "com.netflix.dyno:dyno-jedis"
-            ]
+            ],
+            "locked": "42.2.6"
         },
         "org.rarefiedredis.redis:redis-java": {
-            "locked": "0.0.17",
-            "requested": "0.0.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-persistence"
-            ]
-        },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.2",
-            "transitive": [
-                "io.projectreactor:reactor-core",
-                "io.reactivex.rxjava2:rxjava"
-            ]
+            ],
+            "locked": "0.0.17"
         },
         "org.redisson:redisson": {
-            "locked": "3.11.4",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
-            ]
-        },
-        "org.reflections:reflections": {
-            "locked": "0.9.10",
-            "transitive": [
-                "io.swagger:swagger-jaxrs"
-            ]
+            ],
+            "locked": "3.16.6"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.29",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.archaius:archaius-core",
-                "com.netflix.archaius:archaius2-core",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "com.netflix.governator:governator-core",
-                "com.netflix.netflix-commons:netflix-eventbus",
-                "com.netflix.netflix-commons:netflix-infix",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "com.netflix.spectator:spectator-reg-metrics3",
-                "com.rabbitmq:amqp-client",
-                "com.zaxxer:HikariCP",
-                "io.dropwizard.metrics:metrics-core",
-                "io.swagger:swagger-core",
-                "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.kafka:kafka-clients",
-                "org.apache.zookeeper:zookeeper",
-                "org.redisson:redisson",
-                "org.slf4j:slf4j-log4j12",
-                "redis.clients:jedis"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.21",
-            "transitive": [
-                "com.netflix.dyno:dyno-contrib",
-                "com.netflix.dyno:dyno-core",
-                "com.netflix.dyno:dyno-demo",
-                "com.netflix.dyno:dyno-jedis",
-                "com.netflix.dyno:dyno-memcache",
-                "com.netflix.dyno:dyno-recipes",
-                "org.apache.zookeeper:zookeeper"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.7.30"
         },
         "org.spockframework:spock-core": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4",
-            "transitive": [
-                "com.netflix.governator:governator-test-spock",
-                "org.spockframework:spock-guice"
-            ]
+            "locked": "1.3-groovy-2.4"
         },
         "org.spockframework:spock-guice": {
-            "locked": "1.3-groovy-2.4",
-            "requested": "1.3-groovy-2.4"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.7.2",
-            "transitive": [
-                "org.apache.kafka:kafka-clients"
-            ]
-        },
-        "org.yaml:snakeyaml": {
-            "locked": "1.23",
-            "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-                "org.elasticsearch:elasticsearch"
-            ]
+            "locked": "1.3-groovy-2.4"
         },
         "redis.clients:jedis": {
-            "locked": "3.0.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-redis-persistence",
-                "com.netflix.dyno:dyno-jedis",
-                "org.rarefiedredis.redis:redis-java"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "stax:stax-api": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.codehaus.jettison:jettison"
-            ]
-        },
-        "xmlpull:xmlpull": {
-            "locked": "1.1.3.1",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
-        },
-        "xpp3:xpp3_min": {
-            "locked": "1.1.4c",
-            "transitive": [
-                "com.thoughtworks.xstream:xstream"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-redis-persistence"
+            ],
+            "locked": "3.0.1"
         }
     }
 }

--- a/ui/dependencies.lock
+++ b/ui/dependencies.lock
@@ -1,201 +1,28 @@
 {
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "testCompile": {
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "testCompileClasspath": {
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            "locked": "4.12"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "3.1.0"
         }
     },
     "testRuntimeClasspath": {
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
+            "locked": "4.12"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
+            "locked": "3.1.0"
         }
     }
 }

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -62,7 +62,7 @@ ext {
     revSlf4j = '1.7.25'
     revSlf4jlog4j = '1.8.0-alpha1'
     revSpectator = '0.68.0'
-    revRedisson = '3.11.4'
+    revRedisson = '3.16.6'
     revEmbeddedRedis = '0.6'
     revCuratorRecipes = '2.4.0'
     revCuratorTest = '2.4.0'

--- a/zookeeper-lock/dependencies.lock
+++ b/zookeeper-lock/dependencies.lock
@@ -1,2987 +1,596 @@
 {
-    "compile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.16",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.6.1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
     "compileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.16",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
+            "locked": "2.4.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.6.1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "default": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.16",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.6.1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1"
+            "locked": "0.8.6"
         }
     },
     "jacocoAnt": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.1"
-        },
-        "org.jacoco:org.jacoco.core": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant",
-                "org.jacoco:org.jacoco.report"
-            ]
-        },
-        "org.jacoco:org.jacoco.report": {
-            "locked": "0.8.1",
-            "transitive": [
-                "org.jacoco:org.jacoco.ant"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "6.0",
-            "transitive": [
-                "org.jacoco:org.jacoco.core"
-            ]
-        }
-    },
-    "runtime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.16",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.6.1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "0.8.6"
         }
     },
     "runtimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "log4j:log4j": {
-            "locked": "1.2.16",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes"
-            ]
+            "locked": "2.4.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.6.1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testCompile": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.curator:curator-test": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.15.0-GA",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "1.7.25"
         }
     },
     "testCompileClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
+            "locked": "2.4.0"
         },
         "org.apache.curator:curator-test": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
+            "locked": "2.4.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.15.0-GA",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        }
-    },
-    "testRuntime": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.conductor:conductor-core": {
-            "project": true
-        },
-        "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
-                "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.curator:curator-test": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.15.0-GA",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     },
     "testRuntimeClasspath": {
-        "aopalliance:aopalliance": {
-            "locked": "1.0",
-            "transitive": [
-                "com.google.inject:guice"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-kms": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
         "com.amazonaws:aws-java-sdk-s3": {
-            "locked": "1.11.86",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.86",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-kms",
-                "com.amazonaws:aws-java-sdk-s3"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
+            ],
+            "locked": "1.11.86"
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.10.0",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.6",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.10.0"
         },
         "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "2.0.0"
         },
         "com.github.vmg.protogen:protogen-annotations": {
-            "locked": "1.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
-        },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "2.0.2",
-            "transitive": [
-                "com.github.rholder:guava-retrying"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "19.0",
-            "transitive": [
-                "com.github.rholder:guava-retrying",
-                "com.google.inject:guice",
-                "com.netflix.servo:servo-core",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
+            ],
+            "locked": "1.0.0"
         },
         "com.google.inject.extensions:guice-multibindings": {
-            "locked": "4.1.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.inject:guice": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.google.inject.extensions:guice-multibindings",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "4.1.0"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.5.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "3.5.1"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.2.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.2.0"
         },
         "com.netflix.conductor:conductor-common": {
-            "project": true,
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-core": {
             "project": true
         },
         "com.netflix.servo:servo-core": {
-            "locked": "0.12.17",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.12.17"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.68.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.68.0"
         },
         "com.spotify:completable-futures": {
-            "locked": "0.3.1",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "0.3.1"
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "commons-logging:commons-logging": {
-            "locked": "1.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient"
-            ]
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.6"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.2.2",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "1.2.2"
         },
         "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "com.google.inject:guice",
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
-            ]
+            ],
+            "locked": "1"
         },
         "javax.validation:validation-api": {
-            "locked": "2.0.1.Final",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "jline:jline": {
-            "locked": "0.9.94",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            ],
+            "locked": "2.0.1.Final"
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
-        },
-        "log4j:log4j": {
-            "locked": "1.2.17",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
-        },
-        "net.bytebuddy:byte-buddy": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.9.10",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "net.minidev:accessors-smart": {
-            "locked": "1.1",
-            "transitive": [
-                "net.minidev:json-smart"
-            ]
-        },
-        "net.minidev:json-smart": {
-            "locked": "2.2.1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path"
-            ]
+            "locked": "4.12"
         },
         "org.apache.bval:bval-jsr": {
-            "locked": "2.0.3",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
+            ],
+            "locked": "2.0.3"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.apache.commons:commons-math": {
-            "locked": "2.2",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
+            ],
+            "locked": "3.0"
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
+            "locked": "2.4.0"
         },
         "org.apache.curator:curator-test": {
-            "locked": "2.4.0",
-            "requested": "2.4.0"
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.4.5",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.curator:curator-test"
-            ]
+            "locked": "2.4.0"
         },
         "org.glassfish:javax.el": {
-            "locked": "3.0.0",
-            "transitive": [
+            "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common",
                 "com.netflix.conductor:conductor-core"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.15.0-GA",
-            "transitive": [
-                "org.apache.curator:curator-test"
-            ]
-        },
-        "org.jboss.netty:netty": {
-            "locked": "3.2.2.Final",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
+            ],
+            "locked": "3.0.0"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.1.0",
-            "requested": "3.1.0"
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.6",
-            "transitive": [
-                "org.mockito:mockito-core"
-            ]
-        },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.3",
-            "transitive": [
-                "net.minidev:accessors-smart"
-            ]
+            "locked": "3.1.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.8.0-alpha1",
-            "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "com.netflix.conductor:conductor-common",
-                "com.netflix.servo:servo-core",
-                "com.netflix.spectator:spectator-api",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
-                "org.slf4j:slf4j-log4j12"
-            ]
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "1.8.0-alpha1"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.8.0-alpha1",
-            "requested": "1.8.0-alpha1",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.1",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
+            "locked": "1.8.0-alpha1"
         }
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

As explained in #2642, the Redisson version current being used in 2.31 branch has an issue where the schema part of the URL returns null. This is very easy to be reproduced outside of conductor:

* Create a simple java app;
* Add redisson in the classpath;
* Copy and paste the same block of code that conductor is using to connect to redis sentinel:

```java
Config redisConfig = new Config();
redisConfig.useSentinelServers()
		.setScanInterval(2000)
		.setMasterName("mymaster")
		.addSentinelAddress("redis://localhost:7002") // This is a redis sentinel up and running on my machine
		.setPassword("<PASSWORD>") // This is the redis sentinel password
		.setTimeout(10000);
RedissonClient redisson = Redisson.create(redisConfig);
```
* In this simple Java app, make sure you are referring in the pom.xml the exact same redisson version that conductor is currently using (3.11.4);
* Run the app. You will see the exact error mentioned in #2642: ```Redis url should start with redis:// or rediss:// (for SSL connection)```.

This issue seems to be fixed in redisson >= ```3.12.1```:

* Bump the version in pom.xml to any version >= 3.12.1;
* Error goes away and redisson successfully connects to the redis sentinel.

Therefore, by updating the version in this PR this should address the issue. Tested in a local Kubernetes cluster and it works great.

Alternatives considered
----

No alternative considered as this an library issue that conductor depends.
