### PR TITLE
update log4j to 2.17 to avoid DoS vulnerability

### DIFF
--- a/annotations-processor/dependencies.lock
+++ b/annotations-processor/dependencies.lock
@@ -4,150 +4,99 @@
             "locked": "2.3.12.RELEASE"
         }
     },
-    "annotationsProcessorCodegen": {
+    "compileClasspath": {
         "com.github.jknack:handlebars": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
             "locked": "4.0.7"
         },
         "com.google.guava:guava": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
             "locked": "25.1-jre"
         },
         "com.google.protobuf:protobuf-java": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
             "locked": "3.5.1"
         },
         "com.netflix.conductor:conductor-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "project": true
-        },
-        "com.netflix.conductor:conductor-annotations-processor": {
             "project": true
         },
         "com.squareup:javapoet": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
             "locked": "1.11.1"
         },
         "javax.annotation:javax.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
             "locked": "1.3.2"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.11.4"
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.11.4"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0"
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.13.0"
-        },
+    "exampleCompileClasspath": {
+        "com.netflix.conductor:conductor-annotations": {
+            "project": true
+        }
+    },
+    "exampleRuntimeClasspath": {
         "com.netflix.conductor:conductor-annotations": {
             "project": true
         },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.5"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.10"
-        },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.17.0"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations"
+            ],
+            "locked": "2.13.3"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.17.0"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations"
+            ],
+            "locked": "2.13.3"
         },
         "org.apache.logging.log4j:log4j-jul": {
-            "locked": "2.17.0"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations"
+            ],
+            "locked": "2.13.3"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.17.0"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations"
+            ],
+            "locked": "2.13.3"
         },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.17.0"
-        },
-        "org.springdoc:springdoc-openapi-ui": {
-            "locked": "1.4.8"
-        },
-        "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.3.12.RELEASE"
-        },
-        "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.3.12.RELEASE"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations"
+            ],
+            "locked": "2.13.3"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.11.4"
+        "com.github.jknack:handlebars": {
+            "locked": "4.0.7"
         },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.11.4"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0"
+        "com.google.guava:guava": {
+            "locked": "25.1-jre"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.13.0"
+            "locked": "3.5.1"
         },
         "com.netflix.conductor:conductor-annotations": {
             "project": true
         },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.5"
+        "com.squareup:javapoet": {
+            "locked": "1.11.1"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.10"
+        "javax.annotation:javax.annotation-api": {
+            "locked": "1.3.2"
         },
         "org.apache.logging.log4j:log4j-api": {
             "firstLevelTransitive": [
@@ -181,26 +130,23 @@
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.11.4"
+        "com.github.jknack:handlebars": {
+            "locked": "4.0.7"
         },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.11.4"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0"
+        "com.google.guava:guava": {
+            "locked": "25.1-jre"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.13.0"
+            "locked": "3.5.1"
         },
         "com.netflix.conductor:conductor-annotations": {
             "project": true
         },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.5"
+        "com.squareup:javapoet": {
+            "locked": "1.11.1"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.10"
+        "javax.annotation:javax.annotation-api": {
+            "locked": "1.3.2"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.0"
@@ -221,33 +167,27 @@
             "locked": "2.3.12.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.12.RELEASE"
-        },
-        "org.springframework.boot:spring-boot-starter-validation": {
             "locked": "2.3.12.RELEASE"
         }
     },
     "testRuntimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.11.4"
+        "com.github.jknack:handlebars": {
+            "locked": "4.0.7"
         },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.11.4"
-        },
-        "com.github.rholder:guava-retrying": {
-            "locked": "2.0.0"
+        "com.google.guava:guava": {
+            "locked": "25.1-jre"
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.13.0"
+            "locked": "3.5.1"
         },
         "com.netflix.conductor:conductor-annotations": {
             "project": true
         },
-        "org.apache.bval:bval-jsr": {
-            "locked": "2.0.5"
+        "com.squareup:javapoet": {
+            "locked": "1.11.1"
         },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.10"
+        "javax.annotation:javax.annotation-api": {
+            "locked": "1.3.2"
         },
         "org.apache.logging.log4j:log4j-api": {
             "firstLevelTransitive": [
@@ -283,9 +223,6 @@
             "locked": "2.3.12.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.12.RELEASE"
-        },
-        "org.springframework.boot:spring-boot-starter-validation": {
             "locked": "2.3.12.RELEASE"
         }
     }

--- a/annotations/dependencies.lock
+++ b/annotations/dependencies.lock
@@ -21,16 +21,6 @@
             "locked": "2.17.0"
         }
     },
-    "jacocoAgent": {
-        "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.6"
-        }
-    },
-    "jacocoAnt": {
-        "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.6"
-        }
-    },
     "runtimeClasspath": {
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.17.0"

--- a/azureblob-storage/dependencies.lock
+++ b/azureblob-storage/dependencies.lock
@@ -17,6 +17,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         }
@@ -51,12 +66,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -75,6 +84,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -134,6 +149,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -148,6 +203,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"
@@ -186,12 +256,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -210,6 +274,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -269,6 +339,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"

--- a/build.gradle
+++ b/build.gradle
@@ -97,27 +97,27 @@ allprojects {
     dependencies {
         implementation('org.apache.logging.log4j:log4j-core') {
             version {
-                strictly '2.16.0'
+                strictly '2.17.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-api') {
             version {
-                strictly '2.16.0'
+                strictly '2.17.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-slf4j-impl') {
             version {
-                strictly '2.16.0'
+                strictly '2.17.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-jul') {
             version {
-                strictly '2.16.0'
+                strictly '2.17.0'
             }
         }
         implementation('org.apache.logging.log4j:log4j-web') {
             version {
-                strictly '2.16.0'
+                strictly '2.17.0'
             }
         }
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/cassandra-persistence/dependencies.lock
+++ b/cassandra-persistence/dependencies.lock
@@ -17,6 +17,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         }
@@ -51,12 +66,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -75,6 +84,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -134,6 +149,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -151,6 +206,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"
@@ -204,12 +274,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -228,6 +292,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -287,6 +357,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"

--- a/client-spring/dependencies.lock
+++ b/client-spring/dependencies.lock
@@ -14,6 +14,21 @@
         "com.netflix.eureka:eureka-client": {
             "locked": "1.10.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         }
@@ -55,12 +70,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
@@ -72,6 +81,12 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-client": {
             "project": true
@@ -119,6 +134,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
@@ -138,6 +193,21 @@
         },
         "com.netflix.eureka:eureka-client": {
             "locked": "1.10.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
@@ -186,12 +256,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client"
@@ -203,6 +267,12 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-client": {
             "project": true
@@ -249,6 +319,46 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -35,6 +35,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
         }
@@ -72,12 +87,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -86,6 +95,12 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -113,6 +128,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -159,6 +209,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.powermock:powermock-api-mockito2": {
             "locked": "2.0.9"
         },
@@ -203,12 +268,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -217,6 +276,12 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -244,6 +309,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.powermock:powermock-api-mockito2": {
             "locked": "2.0.9"

--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -53,6 +53,21 @@
         "org.apache.kafka:kafka-clients": {
             "locked": "2.6.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         },
@@ -93,12 +108,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -117,6 +126,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -203,6 +218,46 @@
         },
         "org.apache.kafka:kafka-clients": {
             "locked": "2.6.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -254,6 +309,21 @@
         "org.apache.kafka:kafka-clients": {
             "locked": "2.6.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.mock-server:mockserver-client-java": {
             "locked": "5.11.2"
         },
@@ -303,12 +373,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -327,6 +391,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -413,6 +483,46 @@
         },
         "org.apache.kafka:kafka-clients": {
             "locked": "2.6.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.mock-server:mockserver-client-java": {
             "locked": "5.11.2"

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -50,6 +50,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         },
@@ -79,12 +94,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -96,6 +105,12 @@
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -129,6 +144,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -177,6 +227,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"
         },
@@ -221,12 +286,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -238,6 +297,12 @@
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -271,6 +336,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"

--- a/es6-persistence/dependencies.lock
+++ b/es6-persistence/dependencies.lock
@@ -20,6 +20,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.8.12"
         },
@@ -60,12 +75,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -84,6 +93,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -144,6 +159,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "6.8.12"
         },
@@ -169,6 +224,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.6"
@@ -219,12 +289,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -243,6 +307,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -302,6 +372,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.6"

--- a/es7-persistence/dependencies.lock
+++ b/es7-persistence/dependencies.lock
@@ -26,6 +26,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "7.6.2"
         },
@@ -63,12 +78,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -87,6 +96,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -147,6 +162,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "locked": "7.6.2"
         },
@@ -180,6 +235,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.6"
@@ -227,12 +297,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -251,6 +315,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -310,6 +380,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.awaitility:awaitility": {
             "locked": "3.1.6"

--- a/grpc-client/dependencies.lock
+++ b/grpc-client/dependencies.lock
@@ -29,6 +29,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
         }
@@ -52,12 +67,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -67,6 +76,12 @@
                 "com.netflix.conductor:conductor-grpc"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -109,6 +124,46 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -139,6 +194,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
         },
@@ -168,12 +238,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "locked": "30.0-jre"
         },
@@ -183,6 +247,12 @@
                 "com.netflix.conductor:conductor-grpc"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -225,6 +295,46 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"

--- a/grpc-server/dependencies.lock
+++ b/grpc-server/dependencies.lock
@@ -23,6 +23,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         }
@@ -54,12 +69,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -79,6 +88,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -166,6 +181,51 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -189,6 +249,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"
@@ -227,12 +302,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -252,6 +321,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -342,6 +417,51 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-grpc"
+            ],
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"

--- a/grpc/dependencies.lock
+++ b/grpc/dependencies.lock
@@ -19,6 +19,21 @@
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         }
     },
     "compileProtoPath": {
@@ -40,17 +55,17 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -75,6 +90,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         }
     },
     "protobufToolsLocator_grpc": {
@@ -106,17 +156,17 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -141,6 +191,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -158,6 +243,21 @@
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"
@@ -185,17 +285,17 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -220,6 +320,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"
@@ -247,17 +382,17 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.protobuf:protobuf-java": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.13.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "project": true
@@ -282,6 +417,41 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common"
+            ],
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"

--- a/mysql-persistence/dependencies.lock
+++ b/mysql-persistence/dependencies.lock
@@ -26,6 +26,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
         },
@@ -63,12 +78,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -87,6 +96,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -150,6 +165,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
         },
@@ -178,6 +233,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
@@ -222,12 +292,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -246,6 +310,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -308,6 +378,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"

--- a/postgres-persistence/dependencies.lock
+++ b/postgres-persistence/dependencies.lock
@@ -23,6 +23,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
         },
@@ -63,12 +78,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -87,6 +96,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -147,6 +162,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
         },
@@ -175,6 +230,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"
@@ -222,12 +292,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -246,6 +310,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -305,6 +375,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.flywaydb:flyway-core": {
             "locked": "6.4.4"

--- a/redis-concurrency-limit/dependencies.lock
+++ b/redis-concurrency-limit/dependencies.lock
@@ -14,6 +14,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         },
@@ -51,12 +66,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -75,6 +84,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -135,6 +150,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "redis.clients:jedis": {
             "locked": "3.3.0"
         }
@@ -151,6 +206,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"
@@ -207,12 +277,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -231,6 +295,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -290,6 +360,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"

--- a/redis-lock/dependencies.lock
+++ b/redis-lock/dependencies.lock
@@ -14,6 +14,21 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.redisson:redisson": {
             "locked": "3.13.3"
         },
@@ -48,12 +63,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -72,6 +81,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -132,6 +147,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.redisson:redisson": {
             "locked": "3.13.3"
         }
@@ -148,6 +203,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.redisson:redisson": {
             "locked": "3.13.3"
@@ -189,12 +259,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -213,6 +277,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -272,6 +342,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.redisson:redisson": {
             "locked": "3.13.3"

--- a/redis-persistence/dependencies.lock
+++ b/redis-persistence/dependencies.lock
@@ -17,6 +17,21 @@
         "com.thoughtworks.xstream:xstream": {
             "locked": "1.4.18"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.rarefiedredis.redis:redis-java": {
             "locked": "0.0.17"
         },
@@ -54,12 +69,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -78,6 +87,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -144,6 +159,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.rarefiedredis.redis:redis-java": {
             "locked": "0.0.17"
         },
@@ -163,6 +218,21 @@
         },
         "com.thoughtworks.xstream:xstream": {
             "locked": "1.4.18"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.rarefiedredis.redis:redis-java": {
             "locked": "0.0.17"
@@ -204,12 +274,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -228,6 +292,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -293,6 +363,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.rarefiedredis.redis:redis-java": {
             "locked": "0.0.17"

--- a/rest/dependencies.lock
+++ b/rest/dependencies.lock
@@ -14,6 +14,21 @@
         "com.netflix.runtime:health-api": {
             "locked": "1.1.4"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"
         },
@@ -48,12 +63,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -72,6 +81,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -135,6 +150,46 @@
             ],
             "locked": "3.10"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"
         },
@@ -151,6 +206,21 @@
         },
         "com.netflix.runtime:health-api": {
             "locked": "1.1.4"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"
@@ -192,12 +262,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -216,6 +280,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -278,6 +348,46 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -41,8 +41,20 @@
         "com.rabbitmq:amqp-client": {
             "locked": "5.13.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"
@@ -115,12 +127,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
@@ -144,6 +150,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
@@ -381,8 +393,95 @@
             ],
             "locked": "2.5.1"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.13.3"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "firstLevelTransitive": [
@@ -520,12 +619,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
@@ -549,6 +642,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
@@ -786,8 +885,95 @@
             ],
             "locked": "2.5.1"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.13.3"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "firstLevelTransitive": [
@@ -928,8 +1114,20 @@
         "io.grpc:grpc-testing": {
             "locked": "1.33.1"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.13.3"
+            "locked": "2.17.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.4.8"
@@ -1005,12 +1203,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-contribs",
@@ -1034,6 +1226,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "project": true
@@ -1274,8 +1472,95 @@
             ],
             "locked": "2.5.1"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
+        },
         "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.13.3"
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest"
+            ],
+            "locked": "2.17.0"
         },
         "org.elasticsearch.client:elasticsearch-rest-client": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -4,6 +4,40 @@
             "locked": "2.3.12.RELEASE"
         }
     },
+    "compileClasspath": {
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        }
+    },
+    "runtimeClasspath": {
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        }
+    },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.11.4"
@@ -64,6 +98,21 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"
@@ -169,12 +218,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-client",
@@ -201,6 +244,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-cassandra-persistence": {
             "firstLevelTransitive": [
@@ -505,11 +554,110 @@
             ],
             "locked": "2.5.1"
         },
-        "org.apache.logging.log4j:log4j-web": {
+        "org.apache.logging.log4j:log4j-api": {
             "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest",
                 "com.netflix.conductor:conductor-server"
             ],
-            "locked": "2.13.3"
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest",
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest",
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest",
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-cassandra-persistence",
+                "com.netflix.conductor:conductor-client",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-contribs",
+                "com.netflix.conductor:conductor-core",
+                "com.netflix.conductor:conductor-es6-persistence",
+                "com.netflix.conductor:conductor-grpc",
+                "com.netflix.conductor:conductor-grpc-client",
+                "com.netflix.conductor:conductor-grpc-server",
+                "com.netflix.conductor:conductor-mysql-persistence",
+                "com.netflix.conductor:conductor-postgres-persistence",
+                "com.netflix.conductor:conductor-redis-lock",
+                "com.netflix.conductor:conductor-redis-persistence",
+                "com.netflix.conductor:conductor-rest",
+                "com.netflix.conductor:conductor-server"
+            ],
+            "locked": "2.17.0"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"

--- a/zookeeper-lock/dependencies.lock
+++ b/zookeeper-lock/dependencies.lock
@@ -17,6 +17,21 @@
         "org.apache.curator:curator-recipes": {
             "locked": "2.4.0"
         },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
+        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.3.12.RELEASE"
         }
@@ -48,12 +63,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -72,6 +81,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -134,6 +149,46 @@
         },
         "org.apache.curator:curator-recipes": {
             "locked": "2.4.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         }
     },
     "testCompileClasspath": {
@@ -151,6 +206,21 @@
         },
         "org.apache.curator:curator-test": {
             "locked": "2.4.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"
@@ -186,12 +256,6 @@
             ],
             "locked": "2.0.0"
         },
-        "com.github.vmg.protogen:protogen-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "1.0.0"
-        },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-core"
@@ -210,6 +274,12 @@
                 "com.netflix.conductor:conductor-core"
             ],
             "locked": "2.4.0"
+        },
+        "com.netflix.conductor:conductor-annotations": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-common"
+            ],
+            "project": true
         },
         "com.netflix.conductor:conductor-common": {
             "firstLevelTransitive": [
@@ -275,6 +345,46 @@
         },
         "org.apache.curator:curator-test": {
             "locked": "2.4.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-jul": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
+        },
+        "org.apache.logging.log4j:log4j-web": {
+            "firstLevelTransitive": [
+                "com.netflix.conductor:conductor-annotations",
+                "com.netflix.conductor:conductor-common",
+                "com.netflix.conductor:conductor-core"
+            ],
+            "locked": "2.17.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.3.12.RELEASE"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----

Update the version of log4j from 2.16 to 2.17 because the 2.16 contains a deny of service vulnerability

sources: [here](https://www.zdnet.com/article/apache-releases-new-2-17-0-patch-for-log4j-to-solve-denial-of-service-vulnerability/) and [on apache log4j project](https://logging.apache.org/log4j/2.x/index.html)

Edit:
dependency locks are updated

Alternatives considered
----

