### PR TITLE
Rework Metrics API to reduce possibility of empty values in tags

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.conductor.cassandra.config.CassandraProperties;
 import com.netflix.conductor.metrics.Monitors;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -240,8 +239,7 @@ public abstract class CassandraBaseDAO {
     }
 
     void recordCassandraDaoPayloadSize(String action, int size, String taskType, String workflowType) {
-        Monitors.recordDaoPayloadSize(DAO_NAME, action, StringUtils.defaultIfBlank(taskType, ""),
-            StringUtils.defaultIfBlank(workflowType, ""), size);
+        Monitors.recordDaoPayloadSize(DAO_NAME, action, taskType, workflowType, size);
     }
 
     static class WorkflowMetadata {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
@@ -124,7 +124,7 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
                 for (String taskId : polledTaskIds) {
                     if (StringUtils.isNotBlank(taskId)) {
                         LOGGER.debug("Task: {} from queue: {} being sent to the workflow executor", taskId, queueName);
-                        Monitors.recordTaskPollCount(queueName, "", 1);
+                        Monitors.recordTaskPollCount(queueName, 1);
 
                         executionService.ackTaskReceived(taskId);
 
@@ -144,7 +144,7 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
         } catch (Exception e) {
             // release the permit if exception is thrown during polling, because the thread would not be busy
             semaphoreUtil.completeProcessing(acquiredSlots);
-            Monitors.recordTaskPollError(taskName, "", e.getClass().getSimpleName());
+            Monitors.recordTaskPollError(taskName, e.getClass().getSimpleName());
             LOGGER.error("Error polling system task in queue:{}", queueName, e);
         }
     }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -145,8 +145,8 @@ public class Monitors {
         getCounter(className, "workflow_server_error", "methodName", methodName).increment();
     }
 
-    public static void recordGauge(String name, long count, String... tags) {
-        gauge(classQualifier, name, count, tags);
+    public static void recordGauge(String name, long count) {
+        gauge(classQualifier, name, count);
     }
 
     public static void recordQueueWaitTime(String taskType, long queueWaitTime) {
@@ -281,21 +281,25 @@ public class Monitors {
     }
 
     public static void recordDaoRequests(String dao, String action, String taskType, String workflowType) {
-        counter(classQualifier, "dao_requests", "dao", dao, "action", action, "taskType", taskType, "workflowType",
-            workflowType);
+        counter(classQualifier, "dao_requests",
+                "dao", dao,
+                "action", action,
+                "taskType", StringUtils.defaultIfBlank(taskType, "unknown"),
+                "workflowType", StringUtils.defaultIfBlank(workflowType, "unknown")
+        );
     }
 
     public static void recordDaoEventRequests(String dao, String action, String event) {
         counter(classQualifier, "dao_event_requests", "dao", dao, "action", action, "event", event);
     }
 
-    public static void recordDaoPayloadSize(String dao, String action, int size) {
-        gauge(classQualifier, "dao_payload_size", size, "dao", dao, "action", action);
-    }
-
     public static void recordDaoPayloadSize(String dao, String action, String taskType, String workflowType, int size) {
-        gauge(classQualifier, "dao_payload_size", size, "dao", dao, "action", action, "taskType", taskType,
-            "workflowType", workflowType);
+        gauge(classQualifier, "dao_payload_size", size,
+                "dao", dao,
+                "action", action,
+                "taskType", StringUtils.defaultIfBlank(taskType, "unknown"),
+                "workflowType", StringUtils.defaultIfBlank(workflowType, "unknown")
+        );
     }
 
     public static void recordExternalPayloadStorageUsage(String name, String operation, String payloadType) {

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -33,6 +33,8 @@ public class Monitors {
 
     private static final Registry registry = Spectator.globalRegistry();
 
+    public static final String NO_DOMAIN = "NO_DOMAIN";
+
     private static final Map<String, Map<Map<String, String>, Counter>> counters = new ConcurrentHashMap<>();
 
     private static final Map<String, Map<Map<String, String>, PercentileTimer>> timers = new ConcurrentHashMap<>();
@@ -157,12 +159,20 @@ public class Monitors {
             "status", status.name()).record(duration, TimeUnit.MILLISECONDS);
     }
 
+    public static void recordTaskPollError(String taskType, String exception) {
+        recordTaskPollError(taskType, NO_DOMAIN, exception);
+    }
+
     public static void recordTaskPollError(String taskType, String domain, String exception) {
         counter(classQualifier, "task_poll_error", "taskType", taskType, "domain", domain, "exception", exception);
     }
 
     public static void recordTaskPoll(String taskType) {
         counter(classQualifier, "task_poll", "taskType", taskType);
+    }
+
+    public static void recordTaskPollCount(String taskType, int count) {
+        recordTaskPollCount(taskType, NO_DOMAIN, count);
     }
 
     public static void recordTaskPollCount(String taskType, String domain, int count) {


### PR DESCRIPTION
Pull Request type
----

- [ X] Bugfix

Changes in this PR
----
Update Monitors API to include new methods for use by the System task.  
Rework API to reduce possibility of empty values in tags.

_Describe the new behavior from this PR, and why it's needed_
Issue #2437, #2534 


----

Monitors toMap method will drop tags with empty values.  This could in the end cause an issue with a downstream metrics API.  Might need to consider defaulting tags with empty values to something like "unknown".
