### PR TITLE
Fix for failure workflow

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -568,6 +568,7 @@ public class WorkflowExecutor {
 
         workflow.getTasks().clear();
         workflow.setReasonForIncompletion(null);
+        workflow.setFailedTaskId(null);
         workflow.setCreateTime(System.currentTimeMillis());
         workflow.setEndTime(0);
         workflow.setLastRetriedTime(0);
@@ -803,7 +804,11 @@ public class WorkflowExecutor {
                             terminationStatus, terminateTask.get().getTaskId());
             if (WorkflowModel.Status.FAILED.name().equals(terminationStatus)) {
                 workflow.setStatus(WorkflowModel.Status.FAILED);
-                workflow = terminate(workflow, new TerminateWorkflowException(reason));
+                workflow =
+                        terminate(
+                                workflow,
+                                new TerminateWorkflowException(
+                                        reason, workflow.getStatus(), terminateTask.get()));
             } else {
                 workflow.setReasonForIncompletion(reason);
                 workflow = completeWorkflow(workflow);
@@ -849,6 +854,7 @@ public class WorkflowExecutor {
         workflow.setTasks(workflow.getTasks());
         workflow.setOutput(workflow.getOutput());
         workflow.setReasonForIncompletion(workflow.getReasonForIncompletion());
+        workflow.setFailedTaskId(workflow.getFailedTaskId());
         workflow.setExternalOutputPayloadStoragePath(
                 workflow.getExternalOutputPayloadStoragePath());
 
@@ -974,6 +980,9 @@ public class WorkflowExecutor {
                 input.put("workflowId", workflowId);
                 input.put("reason", reason);
                 input.put("failureStatus", workflow.getStatus().toString());
+                if (workflow.getFailedTaskId() != null) {
+                    input.put("failureTaskId", workflow.getFailedTaskId());
+                }
 
                 try {
                     WorkflowDef latestFailureWorkflow =
@@ -990,7 +999,7 @@ public class WorkflowExecutor {
                                     latestFailureWorkflow,
                                     input,
                                     null,
-                                    workflowId,
+                                    workflow.getCorrelationId(),
                                     null,
                                     workflow.getTaskToDomain());
 
@@ -1778,6 +1787,10 @@ public class WorkflowExecutor {
             workflow.setStatus(terminateWorkflowException.getWorkflowStatus());
         }
 
+        if (terminateWorkflowException.getTask() != null && workflow.getFailedTaskId() == null) {
+            workflow.setFailedTaskId(terminateWorkflowException.getTask().getTaskId());
+        }
+
         String failureWorkflow = workflow.getWorkflowDefinition().getFailureWorkflow();
         if (failureWorkflow != null) {
             if (failureWorkflow.startsWith("$")) {
@@ -1812,6 +1825,7 @@ public class WorkflowExecutor {
             workflow.setStatus(WorkflowModel.Status.RUNNING);
             // Reset failure reason from previous run to default
             workflow.setReasonForIncompletion(null);
+            workflow.setFailedTaskId(null);
             workflow.setFailedReferenceTaskNames(new HashSet<>());
             if (correlationId != null) {
                 workflow.setCorrelationId(correlationId);
@@ -1858,6 +1872,7 @@ public class WorkflowExecutor {
             workflow.setStatus(WorkflowModel.Status.RUNNING);
             // Reset failure reason from previous run to default
             workflow.setReasonForIncompletion(null);
+            workflow.setFailedTaskId(null);
             workflow.setFailedReferenceTaskNames(new HashSet<>());
             if (correlationId != null) {
                 workflow.setCorrelationId(correlationId);

--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -98,6 +98,9 @@ public class WorkflowModel {
 
     private String updatedBy;
 
+    // Capture the failed taskId if the workflow execution failed because of task failure
+    private String failedTaskId;
+
     public Status getStatus() {
         return status;
     }
@@ -305,6 +308,14 @@ public class WorkflowModel {
 
     public void setUpdatedBy(String updatedBy) {
         this.updatedBy = updatedBy;
+    }
+
+    public String getFailedTaskId() {
+        return failedTaskId;
+    }
+
+    public void setFailedTaskId(String failedTaskId) {
+        this.failedTaskId = failedTaskId;
     }
 
     /**

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/FailureWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/FailureWorkflowSpec.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.SubWorkflow
+import com.netflix.conductor.test.base.AbstractSpecification
+
+import spock.lang.Shared
+
+class FailureWorkflowSpec extends AbstractSpecification {
+
+    @Shared
+    def WORKFLOW_WITH_TERMINATE_TASK_FAILED = 'test_terminate_task_failed_wf'
+
+    @Shared
+    def PARENT_WORKFLOW_WITH_FAILURE_TASK = 'test_task_failed_parent_wf'
+
+    @Autowired
+    SubWorkflow subWorkflowTask
+
+    def setup() {
+        workflowTestUtil.registerWorkflows(
+                'failure_workflow_for_terminate_task_workflow.json',
+                'terminate_task_failed_workflow_integration.json',
+                'test_task_failed_parent_workflow.json',
+                'test_task_failed_sub_workflow.json'
+        )
+    }
+
+    def "Test workflow with a task that failed"() {
+        given: "workflow input"
+        def workflowInput = new HashMap()
+        workflowInput['a'] = 1
+
+        when: "Start the workflow which has the failed task"
+        def testId = 'testId'
+        def workflowInstanceId = workflowExecutor.startWorkflow(WORKFLOW_WITH_TERMINATE_TASK_FAILED, 1,
+                testId, workflowInput, null, null, null)
+
+        then: "Verify that the workflow has failed"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 2
+            reasonForIncompletion.contains('Workflow is FAILED by TERMINATE task')
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'LAMBDA'
+            tasks[0].seq == 1
+            tasks[1].status == Task.Status.COMPLETED
+            tasks[1].taskType == 'TERMINATE'
+            tasks[1].seq == 2
+            output
+            def failedWorkflowId = output['conductor.failure_workflow'] as String
+            def workflowCorrelationId = correlationId
+            def workflowFailureTaskId = tasks[1].taskId
+            with(workflowExecutionService.getExecutionStatus(failedWorkflowId, true)) {
+                status == Workflow.WorkflowStatus.COMPLETED
+                correlationId == workflowCorrelationId
+                input['workflowId'] == workflowInstanceId
+                input['failureTaskId'] == workflowFailureTaskId
+                tasks.size() == 1
+                tasks[0].taskType == 'LAMBDA'
+            }
+        }
+    }
+
+    def "Test workflow with a task failed in subworkflow"() {
+        given: "workflow input"
+        def workflowInput = new HashMap()
+        workflowInput['a'] = 1
+
+        when: "Start the workflow which has the subworkflow task"
+        def workflowInstanceId = workflowExecutor.startWorkflow(PARENT_WORKFLOW_WITH_FAILURE_TASK, 1,
+                '', workflowInput, null, null, null)
+
+        then: "verify that the workflow has started and the tasks are as expected"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.RUNNING
+            tasks.size() == 2
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'LAMBDA'
+            tasks[0].referenceTaskName == 'lambdaTask1'
+            tasks[0].seq == 1
+            tasks[1].status == Task.Status.SCHEDULED
+            tasks[1].taskType == 'SUB_WORKFLOW'
+            tasks[1].seq == 2
+        }
+
+        when: "subworkflow is retrieved"
+        def workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
+        def subWorkflowTaskId = workflow.getTaskByRefName("test_task_failed_sub_wf").getTaskId()
+        asyncSystemTaskExecutor.execute(subWorkflowTask, subWorkflowTaskId)
+        workflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
+        def subWorkflowId = workflow.getTaskByRefName("test_task_failed_sub_wf").subWorkflowId
+
+        then: "verify that the sub workflow has failed"
+        with(workflowExecutionService.getExecutionStatus(subWorkflowId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 2
+            reasonForIncompletion.contains('Workflow is FAILED by TERMINATE task')
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'LAMBDA'
+            tasks[0].seq == 1
+            tasks[1].status == Task.Status.COMPLETED
+            tasks[1].taskType == 'TERMINATE'
+            tasks[1].seq == 2
+        }
+
+        then: "Verify that the workflow has failed and correct inputs passed into the failure workflow"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.FAILED
+            tasks.size() == 2
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].taskType == 'LAMBDA'
+            tasks[0].referenceTaskName == 'lambdaTask1'
+            tasks[0].seq == 1
+            tasks[1].status == Task.Status.FAILED
+            tasks[1].taskType == 'SUB_WORKFLOW'
+            tasks[1].seq == 2
+            def failedWorkflowId = output['conductor.failure_workflow'] as String
+            def workflowCorrelationId = correlationId
+            def workflowFailureTaskId = tasks[1].taskId
+            with(workflowExecutionService.getExecutionStatus(failedWorkflowId, true)) {
+                status == Workflow.WorkflowStatus.COMPLETED
+                correlationId == workflowCorrelationId
+                input['workflowId'] == workflowInstanceId
+                input['failureTaskId'] == workflowFailureTaskId
+                tasks.size() == 1
+                tasks[0].taskType == 'LAMBDA'
+            }
+        }
+    }
+}

--- a/test-harness/src/test/resources/test_task_failed_parent_workflow.json
+++ b/test-harness/src/test/resources/test_task_failed_parent_workflow.json
@@ -1,0 +1,37 @@
+{
+  "name": "test_task_failed_parent_wf",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "test_lambda_task1",
+      "taskReferenceName": "lambdaTask1",
+      "inputParameters": {
+        "lambdaValue": "${workflow.input.lambdaValue}",
+        "scriptExpression": "var i = 10; if ($.lambdaValue == 1){ return {testvalue: 'Lambda value was 1', iValue: i} } else { return {testvalue: 'Lambda value was NOT 1', iValue: i + 3} }"
+      },
+      "type": "LAMBDA"
+    },
+    {
+      "name": "test_task_failed_sub_wf",
+      "taskReferenceName": "test_task_failed_sub_wf",
+      "inputParameters": {
+      },
+      "type": "SUB_WORKFLOW",
+      "subWorkflowParam": {
+        "name": "test_task_failed_sub_wf"
+      }
+    },
+    {
+      "name": "test_lambda_task2",
+      "taskReferenceName": "lambdaTask2",
+      "inputParameters": {
+        "lambdaValue": "${workflow.input.lambdaValue}",
+        "scriptExpression": "var i = 10; if ($.lambdaValue == 1){ return {testvalue: 'Lambda value was 1', iValue: i} } else { return {testvalue: 'Lambda value was NOT 1', iValue: i + 3} }"
+      },
+      "type": "LAMBDA"
+    }
+  ],
+  "schemaVersion": 2,
+  "ownerEmail": "test@harness.com",
+  "failureWorkflow": "failure_workflow"
+}

--- a/test-harness/src/test/resources/test_task_failed_sub_workflow.json
+++ b/test-harness/src/test/resources/test_task_failed_sub_workflow.json
@@ -1,0 +1,65 @@
+{
+  "name": "test_task_failed_sub_wf",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "lambda",
+      "taskReferenceName": "lambda0",
+      "inputParameters": {
+        "input": "${workflow.input}",
+        "scriptExpression": "if ($.input.a==1){return {testvalue: true}} else{return {testvalue: false}}"
+      },
+      "type": "LAMBDA",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    },
+    {
+      "name": "terminate",
+      "taskReferenceName": "terminate0",
+      "inputParameters": {
+        "terminationStatus": "FAILED",
+        "workflowOutput": "${lambda0.output}"
+      },
+      "type": "TERMINATE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    },
+    {
+      "name": "integration_task_2",
+      "taskReferenceName": "t2",
+      "inputParameters": {},
+      "type": "SIMPLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] Other (please describe):

Changes in this PR
----
- fix correlationId for failure workflow
- add failure taskId to input

_Describe the new behavior from this PR, and why it's needed_
Issue # MWI-3508

Alternatives considered
----

_Describe alternative implementation you have considered_
