### PR TITLE
Support task level thread counts

### DIFF
--- a/client-spring/src/main/java/com/netflix/conductor/client/spring/ClientProperties.java
+++ b/client-spring/src/main/java/com/netflix/conductor/client/spring/ClientProperties.java
@@ -33,6 +33,8 @@ public class ClientProperties {
 
     private Map<String, String> taskToDomain = new HashMap<>();
 
+    private Map<String, Integer> taskThreadCount = new HashMap<>();
+
     private int shutdownGracePeriodSeconds = 10;
 
     public String getRootUri() {
@@ -89,5 +91,13 @@ public class ClientProperties {
 
     public void setShutdownGracePeriodSeconds(int shutdownGracePeriodSeconds) {
         this.shutdownGracePeriodSeconds = shutdownGracePeriodSeconds;
+    }
+
+    public Map<String, Integer> getTaskThreadCount() {
+        return taskThreadCount;
+    }
+
+    public void setTaskThreadCount(Map<String, Integer> taskThreadCount) {
+        this.taskThreadCount = taskThreadCount;
     }
 }

--- a/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorClientAutoConfiguration.java
+++ b/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorClientAutoConfiguration.java
@@ -49,6 +49,7 @@ public class ConductorClientAutoConfiguration {
     public TaskRunnerConfigurer taskRunnerConfigurer(
             TaskClient taskClient, ClientProperties clientProperties) {
         return new TaskRunnerConfigurer.Builder(taskClient, workers)
+                .withTaskThreadCount(clientProperties.getTaskThreadCount())
                 .withThreadCount(clientProperties.getThreadCount())
                 .withSleepWhenRetry((int) clientProperties.getSleepWhenRetryDuration().toMillis())
                 .withUpdateRetryCount(clientProperties.getUpdateRetryCount())


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] Other (please describe):

Changes in this PR
----
Client can either specify different thread counts for different workers (task definitions) or continue to use the existing global shared thread counts.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
