### PR TITLE
Hide com.google.protobuf.Any from Swagger introspection

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 
 import com.google.protobuf.Any;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /** Result of the task execution. */
 @ProtoMessage
@@ -63,6 +64,7 @@ public class TaskResult {
     private Map<String, Object> outputData = new HashMap<>();
 
     @ProtoField(id = 8)
+    @Hidden
     private Any outputMessage;
 
     private List<TaskExecLog> logs = new CopyOnWriteArrayList<>();

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SkipTaskRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SkipTaskRequest.java
@@ -18,6 +18,7 @@ import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 
 import com.google.protobuf.Any;
+import io.swagger.v3.oas.annotations.Hidden;
 
 @ProtoMessage(toProto = false)
 public class SkipTaskRequest {
@@ -29,9 +30,11 @@ public class SkipTaskRequest {
     private Map<String, Object> taskOutput;
 
     @ProtoField(id = 3)
+    @Hidden
     private Any taskInputMessage;
 
     @ProtoField(id = 4)
+    @Hidden
     private Any taskOutputMessage;
 
     public Map<String, Object> getTaskInput() {


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] Other (please describe):

Changes in this PR
----

`Any` type is cpu intensive to introspect and could kill Swagger UI in some cases.

Issue #2694

Alternatives considered
----

None
