### PR TITLE
use domain models in default queues

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
@@ -256,7 +256,7 @@ public class TaskClient extends ClientBase {
                                         * 1024L) {
                     taskResult.setReasonForIncompletion(
                             String.format(
-                                    "The TaskResult payload size: %d is greater than the permissible %d MB",
+                                    "The TaskResult payload size: %d is greater than the permissible %d bytes",
                                     taskResultSize, payloadSizeThreshold));
                     taskResult.setStatus(TaskResult.Status.FAILED_WITH_TERMINAL_ERROR);
                     taskResult.setOutputData(null);

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/config/AMQPEventQueueConfiguration.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/config/AMQPEventQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,12 +21,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.netflix.conductor.common.metadata.tasks.Task;
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.contribs.queue.amqp.AMQPObservableQueue.Builder;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.model.TaskModel.Status;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AMQPEventQueueProperties.class)
@@ -68,7 +67,7 @@ public class AMQPEventQueueConfiguration {
         }
         final boolean useExchange = properties.isUseExchange();
 
-        Status[] statuses = new Task.Status[] {Status.COMPLETED, Status.FAILED};
+        Status[] statuses = new Status[] {Status.COMPLETED, Status.FAILED};
         Map<Status, ObservableQueue> queues = new HashMap<>();
         for (Status status : statuses) {
             String queuePrefix =

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/config/SQSEventQueueConfiguration.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/config/SQSEventQueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,11 +22,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.contribs.queue.sqs.SQSObservableQueue.Builder;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.model.TaskModel.Status;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.sqs.AmazonSQSClient;

--- a/core/src/main/java/com/netflix/conductor/core/dal/ModelMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ModelMapper.java
@@ -121,6 +121,10 @@ public class ModelMapper {
         return task;
     }
 
+    public Task.Status mapToTaskStatus(TaskModel.Status status) {
+        return Task.Status.valueOf(status.name());
+    }
+
     /**
      * Populates the workflow input data and the tasks input/output data if stored in external
      * payload storage.

--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
@@ -12,12 +12,7 @@
  */
 package com.netflix.conductor.core.events;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -29,13 +24,13 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.events.EventHandler;
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.core.LifecycleAwareComponent;
 import com.netflix.conductor.core.events.queue.DefaultEventQueueProcessor;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.model.TaskModel.Status;
 
 /**
  * Manages the event queues registered in the system and sets up listeners for these.
@@ -108,8 +103,8 @@ public class DefaultEventQueueManager extends LifecycleAwareComponent implements
                 (status, queue) -> {
                     LOGGER.info(
                             "Start listening on default queue {} for status {}",
-                            status,
-                            queue.getName());
+                            queue.getName(),
+                            status);
                     queue.start();
                 });
     }

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/DefaultEventQueueProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/DefaultEventQueueProcessor.java
@@ -12,12 +12,7 @@
  */
 package com.netflix.conductor.core.events.queue;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -26,12 +21,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
-import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.dal.ModelMapper;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.exception.ApplicationException.Code;
-import com.netflix.conductor.service.ExecutionService;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.TaskModel.Status;
+import com.netflix.conductor.model.WorkflowModel;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -55,16 +52,19 @@ public class DefaultEventQueueProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultEventQueueProcessor.class);
     private final Map<Status, ObservableQueue> queues;
-    private final ExecutionService executionService;
+    private final WorkflowExecutor workflowExecutor;
+    private final ModelMapper modelMapper;
     private static final TypeReference<Map<String, Object>> _mapType = new TypeReference<>() {};
     private final ObjectMapper objectMapper;
 
     public DefaultEventQueueProcessor(
             Map<Status, ObservableQueue> queues,
-            ExecutionService executionService,
+            WorkflowExecutor workflowExecutor,
+            ModelMapper modelMapper,
             ObjectMapper objectMapper) {
         this.queues = queues;
-        this.executionService = executionService;
+        this.workflowExecutor = workflowExecutor;
+        this.modelMapper = modelMapper;
         this.objectMapper = objectMapper;
         queues.forEach(this::startMonitor);
         LOGGER.info(
@@ -98,9 +98,9 @@ public class DefaultEventQueueProcessor {
                                     queue.ack(Collections.singletonList(msg));
                                     return;
                                 }
-                                Workflow workflow =
-                                        executionService.getExecutionStatus(workflowId, true);
-                                Optional<Task> taskOptional;
+                                WorkflowModel workflow =
+                                        workflowExecutor.getWorkflow(workflowId, true);
+                                Optional<TaskModel> taskOptional;
                                 if (StringUtils.isNotEmpty(taskId)) {
                                     taskOptional =
                                             workflow.getTasks().stream()
@@ -145,11 +145,11 @@ public class DefaultEventQueueProcessor {
                                     return;
                                 }
 
-                                Task task = taskOptional.get();
-                                task.setStatus(status);
+                                Task task = modelMapper.getTask(taskOptional.get());
+                                task.setStatus(modelMapper.mapToTaskStatus(status));
                                 task.getOutputData()
                                         .putAll(objectMapper.convertValue(payloadJSON, _mapType));
-                                executionService.updateTask(new TaskResult(task));
+                                workflowExecutor.updateTask(new TaskResult(task));
 
                                 List<String> failures = queue.ack(Collections.singletonList(msg));
                                 if (!failures.isEmpty()) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -400,8 +400,7 @@ public class DeciderService {
         workflow.setOutput(output);
     }
 
-    @VisibleForTesting
-    boolean checkForWorkflowCompletion(final WorkflowModel workflow)
+    public boolean checkForWorkflowCompletion(final WorkflowModel workflow)
             throws TerminateWorkflowException {
         List<TaskModel> allTasks = workflow.getTasks();
         if (allTasks.isEmpty()) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SetVariable.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SetVariable.java
@@ -59,7 +59,7 @@ public class SetVariable extends WorkflowSystemTask {
             if (payloadSize > maxThreshold * 1024) {
                 String errorMsg =
                         String.format(
-                                "The variables payload size: %dB of workflow: %s is greater than the permissible limit: %dKB",
+                                "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d bytes",
                                 payloadSize, workflowId, maxThreshold);
                 LOGGER.error(errorMsg);
                 task.setReasonForIncompletion(errorMsg);

--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -126,7 +126,7 @@ public class ExternalPayloadStorageUtils {
                 if (entity instanceof TaskModel) {
                     String errorMsg =
                             String.format(
-                                    "The payload size: %dB of task: %s in workflow: %s  is greater than the permissible limit: %dKB",
+                                    "The payload size: %d of task: %s in workflow: %s  is greater than the permissible limit: %d bytes",
                                     payloadSize,
                                     ((TaskModel) entity).getTaskId(),
                                     ((TaskModel) entity).getWorkflowInstanceId(),
@@ -135,7 +135,7 @@ public class ExternalPayloadStorageUtils {
                 } else {
                     String errorMsg =
                             String.format(
-                                    "The output payload size: %dB of workflow: %s is greater than the permissible limit: %dKB",
+                                    "The output payload size: %dB of workflow: %s is greater than the permissible limit: %d bytes",
                                     payloadSize,
                                     ((WorkflowModel) entity).getWorkflowId(),
                                     maxThreshold);

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanUtils;
 
-import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
@@ -61,10 +60,6 @@ public class TaskModel {
 
         public boolean isRetriable() {
             return retriable;
-        }
-
-        public static Task.Status getTaskStatusDTO(Status status) {
-            return Task.Status.valueOf(status.name());
         }
     }
 

--- a/core/src/test/groovy/com/netflix/conductor/core/dal/ModelMapperSpec.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/dal/ModelMapperSpec.groovy
@@ -153,4 +153,21 @@ class ModelMapperSpec extends Specification {
             externalInputPayloadStoragePath == '/relative/task/path'
         }
     }
+
+    def "map task model status to task status"() {
+        expect:
+        taskStatus == modelMapper.mapToTaskStatus(taskModelStatus)
+
+        where:
+        taskModelStatus                             || taskStatus
+        TaskModel.Status.IN_PROGRESS                || Task.Status.IN_PROGRESS
+        TaskModel.Status.CANCELED                   || Task.Status.CANCELED
+        TaskModel.Status.FAILED                     || Task.Status.FAILED
+        TaskModel.Status.FAILED_WITH_TERMINAL_ERROR || Task.Status.FAILED_WITH_TERMINAL_ERROR
+        TaskModel.Status.COMPLETED                  || Task.Status.COMPLETED
+        TaskModel.Status.COMPLETED_WITH_ERRORS      || Task.Status.COMPLETED_WITH_ERRORS
+        TaskModel.Status.SCHEDULED                  || Task.Status.SCHEDULED
+        TaskModel.Status.TIMED_OUT                  || Task.Status.TIMED_OUT
+        TaskModel.Status.SKIPPED                    || Task.Status.SKIPPED
+    }
 }

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.netflix.conductor.common.metadata.tasks.Task.Status;
 import com.netflix.conductor.core.events.queue.DefaultEventQueueProcessor;
+import com.netflix.conductor.model.TaskModel.Status;
 
 import io.swagger.v3.oas.annotations.Operation;
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SetVariableTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SetVariableTaskSpec.groovy
@@ -62,7 +62,7 @@ class SetVariableTaskSpec extends AbstractSpecification {
         def EXTRA_HASHMAP_SIZE = 17
         def expectedErrorMessage =
                 String.format(
-                        "The variables payload size: %dB of workflow: %s is greater than the permissible limit: %dKB",
+                        "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d bytes",
                         EXTRA_HASHMAP_SIZE + maxThreshold * 1024 + 1, workflowInstanceId, maxThreshold)
 
         then: "verify that the task is completed and variables were set"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Use domain models introduced in #2702 when creating and using default queues within the server.
Also, fixed the payload size units in error messages when payload exceeds permissible limit.