### PR TITLE
Reset workflow index when workflow changed status after reached to terminal status

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/dao/index/NoopIndexDAO.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dao/index/NoopIndexDAO.java
@@ -62,10 +62,10 @@ public class NoopIndexDAO implements IndexDAO {
     }
 
     @Override
-    public void removeWorkflow(String workflowId) {}
+    public void removeWorkflow(String workflowId, String reason) {}
 
     @Override
-    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
+    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId, String reason) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWithTTLWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWithTTLWorkflowStatusListener.java
@@ -29,6 +29,7 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(ArchivingWithTTLWorkflowStatusListener.class);
+    private static final String REASON = "archived";
 
     private final ExecutionDAOFacade executionDAOFacade;
     private final int archiveTTLSeconds;
@@ -84,7 +85,7 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
                     TimeUnit.SECONDS);
         } else {
             this.executionDAOFacade.removeWorkflowWithExpiry(
-                    workflow.getWorkflowId(), true, archiveTTLSeconds);
+                    workflow.getWorkflowId(), true, archiveTTLSeconds, REASON);
             Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
         }
     }
@@ -99,7 +100,7 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
                     TimeUnit.SECONDS);
         } else {
             this.executionDAOFacade.removeWorkflowWithExpiry(
-                    workflow.getWorkflowId(), true, archiveTTLSeconds);
+                    workflow.getWorkflowId(), true, archiveTTLSeconds, REASON);
             Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
         }
     }
@@ -122,7 +123,7 @@ public class ArchivingWithTTLWorkflowStatusListener implements WorkflowStatusLis
         public void run() {
             try {
                 this.executionDAOFacade.removeWorkflowWithExpiry(
-                        workflowId, true, archiveTTLSeconds);
+                        workflowId, true, archiveTTLSeconds, REASON);
                 LOGGER.info("Archived workflow {}", workflowId);
                 Monitors.recordWorkflowArchived(workflowName, status);
                 Monitors.recordArchivalDelayQueueSize(

--- a/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWorkflowStatusListener.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/listener/archive/ArchivingWorkflowStatusListener.java
@@ -30,6 +30,7 @@ public class ArchivingWorkflowStatusListener implements WorkflowStatusListener {
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(ArchivingWorkflowStatusListener.class);
+    private static final String REASON = "archived";
     private final ExecutionDAOFacade executionDAOFacade;
 
     public ArchivingWorkflowStatusListener(ExecutionDAOFacade executionDAOFacade) {
@@ -39,14 +40,14 @@ public class ArchivingWorkflowStatusListener implements WorkflowStatusListener {
     @Override
     public void onWorkflowCompleted(WorkflowModel workflow) {
         LOGGER.info("Archiving workflow {} on completion ", workflow.getWorkflowId());
-        this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true);
+        this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true, REASON);
         Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
     }
 
     @Override
     public void onWorkflowTerminated(WorkflowModel workflow) {
         LOGGER.info("Archiving workflow {} on termination", workflow.getWorkflowId());
-        this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true);
+        this.executionDAOFacade.removeWorkflow(workflow.getWorkflowId(), true, REASON);
         Monitors.recordWorkflowArchived(workflow.getWorkflowName(), workflow.getStatus());
     }
 }

--- a/contribs/src/test/java/com/netflix/conductor/contribs/listener/ArchivingWorkflowStatusListenerTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/listener/ArchivingWorkflowStatusListenerTest.java
@@ -48,14 +48,16 @@ public class ArchivingWorkflowStatusListenerTest {
     @Test
     public void testArchiveOnWorkflowCompleted() {
         listener.onWorkflowCompleted(workflow);
-        verify(executionDAOFacade, times(1)).removeWorkflow(workflow.getWorkflowId(), true);
+        verify(executionDAOFacade, times(1))
+                .removeWorkflow(workflow.getWorkflowId(), true, "archived");
         verifyNoMoreInteractions(executionDAOFacade);
     }
 
     @Test
     public void testArchiveOnWorkflowTerminated() {
         listener.onWorkflowTerminated(workflow);
-        verify(executionDAOFacade, times(1)).removeWorkflow(workflow.getWorkflowId(), true);
+        verify(executionDAOFacade, times(1))
+                .removeWorkflow(workflow.getWorkflowId(), true, "archived");
         verifyNoMoreInteractions(executionDAOFacade);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/IndexDAO.java
@@ -78,16 +78,18 @@ public interface IndexDAO {
      * Remove the workflow index
      *
      * @param workflowId workflow to be removed
+     * @param reason reason of why the workflow needs to be removed
      */
-    void removeWorkflow(String workflowId);
+    void removeWorkflow(String workflowId, String reason);
 
     /**
      * Remove the workflow index
      *
      * @param workflowId workflow to be removed
+     * @param reason reason of why the workflow needs to be removed
      * @return CompletableFuture of type void
      */
-    CompletableFuture<Void> asyncRemoveWorkflow(String workflowId);
+    CompletableFuture<Void> asyncRemoveWorkflow(String workflowId, String reason);
 
     /**
      * Updates the index

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -394,8 +394,8 @@ public class ExecutionService {
         return executionDAOFacade.getRunningWorkflowIds(workflowName, version);
     }
 
-    public void removeWorkflow(String workflowId, boolean archiveWorkflow) {
-        executionDAOFacade.removeWorkflow(workflowId, archiveWorkflow);
+    public void removeWorkflow(String workflowId, boolean archiveWorkflow, String reason) {
+        executionDAOFacade.removeWorkflow(workflowId, archiveWorkflow, reason);
     }
 
     public SearchResult<WorkflowSummary> search(

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -269,7 +269,7 @@ public class WorkflowServiceImpl implements WorkflowService {
      * @param archiveWorkflow Archives the workflow.
      */
     public void deleteWorkflow(String workflowId, boolean archiveWorkflow) {
-        executionService.removeWorkflow(workflowId, archiveWorkflow);
+        executionService.removeWorkflow(workflowId, archiveWorkflow, "deleted by user");
     }
 
     /**

--- a/core/src/test/java/com/netflix/conductor/core/dal/ExecutionDAOFacadeTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/dal/ExecutionDAOFacadeTest.java
@@ -140,9 +140,9 @@ public class ExecutionDAOFacadeTest {
         WorkflowModel workflow = new WorkflowModel();
         workflow.setStatus(WorkflowModel.Status.COMPLETED);
         when(executionDAO.getWorkflow(anyString(), anyBoolean())).thenReturn(workflow);
-        executionDAOFacade.removeWorkflow("workflowId", false);
+        executionDAOFacade.removeWorkflow("workflowId", false, "test");
         verify(indexDAO, never()).updateWorkflow(any(), any(), any());
-        verify(indexDAO, times(1)).asyncRemoveWorkflow(workflow.getWorkflowId());
+        verify(indexDAO, times(1)).asyncRemoveWorkflow(workflow.getWorkflowId(), "test");
     }
 
     @Test
@@ -151,9 +151,9 @@ public class ExecutionDAOFacadeTest {
         WorkflowModel workflow = objectMapper.readValue(stream, WorkflowModel.class);
 
         when(executionDAO.getWorkflow(anyString(), anyBoolean())).thenReturn(workflow);
-        executionDAOFacade.removeWorkflow("workflowId", true);
+        executionDAOFacade.removeWorkflow("workflowId", true, "test");
         verify(indexDAO, times(1)).updateWorkflow(any(), any(), any());
-        verify(indexDAO, never()).removeWorkflow(any());
+        verify(indexDAO, never()).removeWorkflow(any(), any());
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -263,7 +263,7 @@ public class WorkflowServiceTest {
     @Test
     public void testDeleteWorkflow() {
         workflowService.deleteWorkflow("w123", true);
-        verify(executionService, times(1)).removeWorkflow(anyString(), anyBoolean());
+        verify(executionService, times(1)).removeWorkflow(anyString(), anyBoolean(), anyString());
     }
 
     @Test(expected = ConstraintViolationException.class)

--- a/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchDAOV6.java
@@ -692,7 +692,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
     }
 
     @Override
-    public void removeWorkflow(String workflowId) {
+    public void removeWorkflow(String workflowId, String reason) {
         try {
             long startTime = Instant.now().toEpochMilli();
             DeleteRequest request =
@@ -703,7 +703,10 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
             }
             long endTime = Instant.now().toEpochMilli();
             LOGGER.debug(
-                    "Time taken {} for removing workflow: {}", endTime - startTime, workflowId);
+                    "Time taken {} for removing workflow: {}, reason: {}",
+                    endTime - startTime,
+                    workflowId,
+                    reason);
             Monitors.recordESIndexTime("remove_workflow", WORKFLOW_DOC_TYPE, endTime - startTime);
             Monitors.recordWorkerQueueSize(
                     "indexQueue", ((ThreadPoolExecutor) executorService).getQueue().size());
@@ -714,8 +717,9 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
     }
 
     @Override
-    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
-        return CompletableFuture.runAsync(() -> removeWorkflow(workflowId), executorService);
+    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId, String reason) {
+        return CompletableFuture.runAsync(
+                () -> removeWorkflow(workflowId, reason), executorService);
     }
 
     @Override

--- a/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchRestDAOV6.java
@@ -769,7 +769,7 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
     }
 
     @Override
-    public void removeWorkflow(String workflowId) {
+    public void removeWorkflow(String workflowId, String reason) {
         long startTime = Instant.now().toEpochMilli();
         String docType = StringUtils.isBlank(docTypeOverride) ? WORKFLOW_DOC_TYPE : docTypeOverride;
         DeleteRequest request = new DeleteRequest(workflowIndexName, docType, workflowId);
@@ -782,7 +782,10 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
             }
             long endTime = Instant.now().toEpochMilli();
             LOGGER.debug(
-                    "Time taken {} for removing workflow: {}", endTime - startTime, workflowId);
+                    "Time taken {} for removing workflow: {}, reason: {}",
+                    endTime - startTime,
+                    workflowId,
+                    reason);
             Monitors.recordESIndexTime("remove_workflow", WORKFLOW_DOC_TYPE, endTime - startTime);
             Monitors.recordWorkerQueueSize(
                     "indexQueue", ((ThreadPoolExecutor) executorService).getQueue().size());
@@ -793,8 +796,9 @@ public class ElasticSearchRestDAOV6 extends ElasticSearchBaseDAO implements Inde
     }
 
     @Override
-    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
-        return CompletableFuture.runAsync(() -> removeWorkflow(workflowId), executorService);
+    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId, String reason) {
+        return CompletableFuture.runAsync(
+                () -> removeWorkflow(workflowId, reason), executorService);
     }
 
     @Override

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
@@ -122,7 +122,7 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
         List<String> workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.removeWorkflow(workflow.getWorkflowId());
+        indexDAO.removeWorkflow(workflow.getWorkflowId(), "test");
 
         workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 0);
 
@@ -138,7 +138,7 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
         List<String> workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.asyncRemoveWorkflow(workflow.getWorkflowId()).get();
+        indexDAO.asyncRemoveWorkflow(workflow.getWorkflowId(), "test").get();
 
         workflows = tryFindResults(() -> searchWorkflows(workflow.getWorkflowId()), 0);
 

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
@@ -117,7 +117,7 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
                 tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.removeWorkflow(workflowSummary.getWorkflowId());
+        indexDAO.removeWorkflow(workflowSummary.getWorkflowId(), "test");
 
         workflows = tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 0);
 
@@ -135,7 +135,7 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
                 tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.asyncRemoveWorkflow(workflowSummary.getWorkflowId()).get();
+        indexDAO.asyncRemoveWorkflow(workflowSummary.getWorkflowId(), "test").get();
 
         workflows = tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 0);
 

--- a/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
+++ b/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
@@ -802,7 +802,7 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
     }
 
     @Override
-    public void removeWorkflow(String workflowId) {
+    public void removeWorkflow(String workflowId, String reason) {
         long startTime = Instant.now().toEpochMilli();
         DeleteRequest request = new DeleteRequest(workflowIndexName, workflowId);
 
@@ -814,7 +814,10 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
             }
             long endTime = Instant.now().toEpochMilli();
             logger.debug(
-                    "Time taken {} for removing workflow: {}", endTime - startTime, workflowId);
+                    "Time taken {} for removing workflow: {}, reason: {}",
+                    endTime - startTime,
+                    workflowId,
+                    reason);
             Monitors.recordESIndexTime("remove_workflow", WORKFLOW_DOC_TYPE, endTime - startTime);
             Monitors.recordWorkerQueueSize(
                     "indexQueue", ((ThreadPoolExecutor) executorService).getQueue().size());
@@ -825,8 +828,9 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
     }
 
     @Override
-    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId) {
-        return CompletableFuture.runAsync(() -> removeWorkflow(workflowId), executorService);
+    public CompletableFuture<Void> asyncRemoveWorkflow(String workflowId, String reason) {
+        return CompletableFuture.runAsync(
+                () -> removeWorkflow(workflowId, reason), executorService);
     }
 
     @Override

--- a/es7-persistence/src/test/java/com/netflix/conductor/es7/dao/index/TestElasticSearchRestDAOV7.java
+++ b/es7-persistence/src/test/java/com/netflix/conductor/es7/dao/index/TestElasticSearchRestDAOV7.java
@@ -115,7 +115,7 @@ public class TestElasticSearchRestDAOV7 extends ElasticSearchRestDaoBaseTest {
                 tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.removeWorkflow(workflowSummary.getWorkflowId());
+        indexDAO.removeWorkflow(workflowSummary.getWorkflowId(), "test");
 
         workflows = tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 0);
 
@@ -133,7 +133,7 @@ public class TestElasticSearchRestDAOV7 extends ElasticSearchRestDaoBaseTest {
                 tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 1);
         assertEquals(1, workflows.size());
 
-        indexDAO.asyncRemoveWorkflow(workflowSummary.getWorkflowId()).get();
+        indexDAO.asyncRemoveWorkflow(workflowSummary.getWorkflowId(), "test").get();
 
         workflows = tryFindResults(() -> searchWorkflows(workflowSummary.getWorkflowId()), 0);
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Add reason param to removeWorkflow methods to keep record of why the workflow needs to be removed as we'd like to keep a record of the reasons behind it.
- Reset workflow index when workflow changed status after already reached to terminal status. Possible actions include:  retry/restart/rerun/terminate operations. Reason for that is workflow could've been removed to secondary index already after reach to terminal status, while updateIndex will always create a new index on primary index.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
