### PR TITLE
[UI] Optimize display format of task logs

### DIFF
--- a/ui/src/pages/execution/TaskLogs.jsx
+++ b/ui/src/pages/execution/TaskLogs.jsx
@@ -13,8 +13,8 @@ export default function TaskLogs({ task }) {
     <DataTable
       data={log}
       columns={[
-        { name: "createdTime", type: "date", label: "Timestamp" },
-        { name: "log", label: "Entry" },
+        { name: "createdTime", type: "date", label: "Timestamp", width: "180px" },
+        { name: "log", label: "Entry", style: "div:first-child { white-space: pre-wrap }" },
       ]}
       title="Task Logs"
     />


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Changes:
1. Now, timestamp column uses 50% width in task log which wastes lots of area. In this chage, log time column is fixed to 180px which is enough to show timestamp.
2. Time entry doesn't support word wrap, for a log message contains \n, the UI table can't display it in a new line. This change also add css styles to support it.

Alternatives considered
----
Maybe there are other ways to approach the same target, this change can also be abandoned if there are better ways. But please consider the idea of this display improvement.
