### PR TITLE
Fix the path to architecture diagram

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -1,6 +1,6 @@
 ## High Level Architecture
 
-![Architecture diagram](/img/conductor-architecture.png)
+![Architecture diagram](img/conductor-architecture.png)
 
 The API and storage layers are pluggable and provide ability to work with different backends and queue service providers.
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [x] Other (please describe): Documentation

Changes in this PR
----
`png` file for architecture diagram exists in `img` folder, but the link is incorrect. Fix is simply deleting the leading `/`.