### PR TITLE
Local only lock fix

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
@@ -41,7 +41,8 @@ public class LocalOnlyLock implements Lock {
                     return new Semaphore(1, true);
                 }
             };
-    private static final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledFutures = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledFutures =
+            new ConcurrentHashMap<>();
     private static final LoadingCache<String, Semaphore> lockIdtoSemaphoreMap =
             CacheBuilder.newBuilder().build(LOADER);
     private static final ThreadGroup THREAD_GROUP = new ThreadGroup("LocalOnlyLock-scheduler");
@@ -78,7 +79,8 @@ public class LocalOnlyLock implements Lock {
                 unit);
         if (acquireLock(lockId, timeToTry, unit)) {
             LOGGER.trace("Releasing {} automatically after {} {}", lockId, leaseTime, unit);
-            scheduledFutures.put(lockId, SCHEDULER.schedule(() -> releaseLock(lockId), leaseTime, unit));
+            scheduledFutures.put(
+                    lockId, SCHEDULER.schedule(() -> releaseLock(lockId), leaseTime, unit));
             return true;
         }
         return false;
@@ -86,7 +88,7 @@ public class LocalOnlyLock implements Lock {
 
     private void removeLeaseExpirationJob(String lockId) {
         ScheduledFuture<?> schedFuture = scheduledFutures.get(lockId);
-        if(schedFuture != null && schedFuture.cancel(false)) {
+        if (schedFuture != null && schedFuture.cancel(false)) {
             scheduledFutures.remove(lockId);
             LOGGER.trace("lockId {} removed from lease expiration job", lockId);
         }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
@@ -118,4 +118,8 @@ public class LocalOnlyLock implements Lock {
     LoadingCache<String, Semaphore> cache() {
         return lockIdtoSemaphoreMap;
     }
+
+    ConcurrentHashMap<String, ScheduledFuture<?>> scheduledFutures() {
+        return scheduledFutures;
+    }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java
@@ -88,7 +88,7 @@ public class LocalOnlyLock implements Lock {
         ScheduledFuture<?> schedFuture = scheduledFutures.get(lockId);
         if(schedFuture != null && schedFuture.cancel(false)) {
             scheduledFutures.remove(lockId);
-            LOGGER.info("lockId {} removed from lease expiration job", lockId);
+            LOGGER.trace("lockId {} removed from lease expiration job", lockId);
         }
     }
 

--- a/contribs/src/test/java/com/netflix/conductor/contribs/lock/LocalOnlyLockTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/lock/LocalOnlyLockTest.java
@@ -12,107 +12,84 @@
  */
 package com.netflix.conductor.contribs.lock;
 
-import org.junit.Ignore;
+import java.util.concurrent.TimeUnit;
 
-@Ignore
-// Test causes "OutOfMemoryError: GC overhead limit reached" error during build
+import org.junit.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class LocalOnlyLockTest {
 
-    //    // Lock can be global since it uses global cache internally
-    //    private final LocalOnlyLock localOnlyLock = new LocalOnlyLock();
-    //
-    //    @Test
-    //    public void testLockUnlock() {
-    //        localOnlyLock.acquireLock("a");
-    //        assertEquals(localOnlyLock.cache().size(), 1);
-    //        assertEquals(localOnlyLock.cache().getUnchecked("a").availablePermits(), 0);
-    //        localOnlyLock.releaseLock("a");
-    //        assertEquals(localOnlyLock.cache().getUnchecked("a").availablePermits(), 1);
-    //        localOnlyLock.deleteLock("a");
-    //        assertEquals(localOnlyLock.cache().size(), 0);
-    //    }
-    //
-    //    @Test(timeout = 10 * 1000)
-    //    public void testLockTimeout() {
-    //        localOnlyLock.acquireLock("c");
-    //        assertTrue(localOnlyLock.acquireLock("d", 100, TimeUnit.MILLISECONDS));
-    //        assertFalse(localOnlyLock.acquireLock("c", 100, TimeUnit.MILLISECONDS));
-    //        localOnlyLock.releaseLock("c");
-    //        localOnlyLock.releaseLock("d");
-    //    }
-    //
-    //    @Test(timeout = 10 * 1000)
-    //    public void testLockLeaseTime() {
-    //        for (int i = 0; i < 10; i++) {
-    //            localOnlyLock.acquireLock("a", 1000, 100, TimeUnit.MILLISECONDS);
-    //        }
-    //        localOnlyLock.acquireLock("a");
-    //        assertEquals(0, localOnlyLock.cache().getUnchecked("a").availablePermits());
-    //        localOnlyLock.releaseLock("a");
-    //    }
-    //
-    //    @Test(timeout = 10 * 1000)
-    //    public void testLockLeaseWithRelease() throws Exception {
-    //        localOnlyLock.acquireLock("b", 1000, 1000, TimeUnit.MILLISECONDS);
-    //        localOnlyLock.releaseLock("b");
-    //
-    //        // Wait for lease to run out and also call release
-    //        Thread.sleep(2000);
-    //
-    //        localOnlyLock.acquireLock("b");
-    //        assertEquals(0, localOnlyLock.cache().getUnchecked("b").availablePermits());
-    //        localOnlyLock.releaseLock("b");
-    //    }
-    //
-    //    @Test
-    //    public void testRelease() {
-    //        localOnlyLock.releaseLock("x54as4d2;23'4");
-    //        localOnlyLock.releaseLock("x54as4d2;23'4");
-    //        assertEquals(1,
-    // localOnlyLock.cache().getUnchecked("x54as4d2;23'4").availablePermits());
-    //    }
-    //
-    //    private final int ITER = 1;
-    //
-    //    @Test(timeout = ITER * 10 * 1000)
-    //    public void multithreaded() throws Exception {
-    //        ExecutorService pool = Executors.newFixedThreadPool(4);
-    //
-    //        for (int i = 0; i < ITER * 1000; i++) {
-    //            if (i % 3 == 0) {
-    //                pool.submit(() -> {
-    //                    localOnlyLock.acquireLock("a");
-    //                    localOnlyLock.releaseLock("a");
-    //                });
-    //            } else if (i % 3 == 1) {
-    //                pool.submit(() -> {
-    //                    if (localOnlyLock.acquireLock("a", ITER, TimeUnit.SECONDS)) {
-    //                        localOnlyLock.releaseLock("a");
-    //                    }
-    //                });
-    //            } else {
-    //                pool.submit(() -> {
-    //                    localOnlyLock.acquireLock("a", ITER * 1000, 5, TimeUnit.MILLISECONDS);
-    //                });
-    //            }
-    //        }
-    //        // Wait till pool has no more tasks in queue
-    //        pool.shutdown();
-    //        assertTrue(pool.awaitTermination(ITER * 5, TimeUnit.SECONDS));
-    //        // Wait till last possible lease time runs out (lease time == 5 seconds)
-    //        Thread.sleep(100);
-    //        // We should end up with lock with value 1
-    //        assertEquals(1, localOnlyLock.cache().getUnchecked("a").availablePermits());
-    //    }
-    //
-    //    @Test
-    //    public void testLockConfiguration() {
-    //        new ApplicationContextRunner()
-    //            .withPropertyValues("conductor.workflow-execution-lock.type=local_only")
-    //            .withUserConfiguration(LocalOnlyLockConfiguration.class)
-    //            .run(context -> {
-    //                LocalOnlyLock lock = context.getBean(LocalOnlyLock.class);
-    //                assertNotNull(lock);
-    //            });
-    //    }
+    // Lock can be global since it uses global cache internally
+    private final LocalOnlyLock localOnlyLock = new LocalOnlyLock();
+
+    @Test
+    public void testLockUnlock() {
+        localOnlyLock.acquireLock("a", 100, 1000, TimeUnit.MILLISECONDS);
+        assertEquals(localOnlyLock.cache().size(), 1);
+        assertEquals(localOnlyLock.cache().getUnchecked("a").availablePermits(), 0);
+        assertEquals(localOnlyLock.scheduledFutures().size(), 1);
+        localOnlyLock.releaseLock("a");
+        assertEquals(localOnlyLock.scheduledFutures().size(), 0);
+        assertEquals(localOnlyLock.cache().getUnchecked("a").availablePermits(), 1);
+        localOnlyLock.deleteLock("a");
+        assertEquals(localOnlyLock.cache().size(), 0);
+    }
+
+    @Test(timeout = 10 * 1000)
+    public void testLockTimeout() {
+        localOnlyLock.acquireLock("c", 100, 1000, TimeUnit.MILLISECONDS);
+        assertTrue(localOnlyLock.acquireLock("d", 100, 1000, TimeUnit.MILLISECONDS));
+        assertFalse(localOnlyLock.acquireLock("c", 100, 1000, TimeUnit.MILLISECONDS));
+        assertEquals(localOnlyLock.scheduledFutures().size(), 2);
+        localOnlyLock.releaseLock("c");
+        localOnlyLock.releaseLock("d");
+        assertEquals(localOnlyLock.scheduledFutures().size(), 0);
+    }
+
+    @Test(timeout = 10 * 1000)
+    public void testLockLeaseTime() {
+        for (int i = 0; i < 10; i++) {
+            localOnlyLock.acquireLock("a", 1000, 100, TimeUnit.MILLISECONDS);
+        }
+        localOnlyLock.acquireLock("a");
+        assertEquals(0, localOnlyLock.cache().getUnchecked("a").availablePermits());
+        localOnlyLock.releaseLock("a");
+    }
+
+    @Test(timeout = 10 * 1000)
+    public void testLockLeaseWithRelease() throws Exception {
+        localOnlyLock.acquireLock("b", 1000, 1000, TimeUnit.MILLISECONDS);
+        localOnlyLock.releaseLock("b");
+
+        // Wait for lease to run out and also call release
+        Thread.sleep(2000);
+
+        localOnlyLock.acquireLock("b");
+        assertEquals(0, localOnlyLock.cache().getUnchecked("b").availablePermits());
+        localOnlyLock.releaseLock("b");
+    }
+
+    @Test
+    public void testRelease() {
+        localOnlyLock.releaseLock("x54as4d2;23'4");
+        localOnlyLock.releaseLock("x54as4d2;23'4");
+        assertEquals(1, localOnlyLock.cache().getUnchecked("x54as4d2;23'4").availablePermits());
+    }
+
+    @Test
+    public void testLockConfiguration() {
+        new ApplicationContextRunner()
+                .withPropertyValues("conductor.workflow-execution-lock.type=local_only")
+                .withUserConfiguration(LocalOnlyLockConfiguration.class)
+                .run(
+                        context -> {
+                            LocalOnlyLock lock = context.getBean(LocalOnlyLock.class);
+                            assertNotNull(lock);
+                        });
+    }
 }


### PR DESCRIPTION
Cancel thread scheduled for stopping starvation in case of actually releasing a lock.
Background, 
As and when the lock is acquired, there is one [thread](https://github.com/Netflix/conductor/blob/main/contribs/src/main/java/com/netflix/conductor/contribs/lock/LocalOnlyLock.java#L78) is scheduled to release a lock. This is to stop the starvation scenario.
Now the issue is, when the operation is complete, the scheduled thread must be stopped otherwise after the interval it will take the lock preemptively.

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Canceled the thread to stop the starvation in a normal scenario.

_Describe the new behavior from this PR, and why it's needed_
Issue #https://github.com/Netflix/conductor/issues/2368

Alternatives considered
----

_Describe alternative implementation you have considered_
