### PR TITLE
[WIP:Do Not merge]Loopover task iteration fix.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -101,8 +101,10 @@ public class DoWhileTaskMapper implements TaskMapper {
         loopTask.setWorkflowTask(taskToSchedule);
         loopTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
         loopTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
-        // For the scenario where any of the loopover task wants to use iterator of parent do_while task
-        // Since these tasks are ot added in workflow, parameterUtils wants to use and of do_while property.
+        // For the scenario where any of the loopover task wants to use iterator of parent do_while
+        // task
+        // Since these tasks are ot added in workflow, parameterUtils wants to use and of do_while
+        // property.
         loopTask.getOutputData().put("iteration", 0);
         workflowInstance.getTasks().add(loopTask);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -101,6 +101,10 @@ public class DoWhileTaskMapper implements TaskMapper {
         loopTask.setWorkflowTask(taskToSchedule);
         loopTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
         loopTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
+        // For the scenario where any of the loopover task wants to use iterator of parent do_while task
+        // Since these tasks are ot added in workflow, parameterUtils wants to use and of do_while property.
+        loopTask.getOutputData().put("iteration", 0);
+        workflowInstance.getTasks().add(loopTask);
 
         tasksToBeScheduled.add(loopTask);
         List<WorkflowTask> loopOverTasks = taskToSchedule.getLoopOver();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
@@ -100,6 +100,7 @@ public class DoWhileTaskMapperTest {
         assertEquals("task1__1", mappedTasks.get(1).getReferenceTaskName());
         assertEquals(1, mappedTasks.get(1).getIteration());
         assertEquals(TASK_TYPE_DO_WHILE, mappedTasks.get(0).getTaskType());
+        assertEquals(0, mappedTasks.get(0).getOutputData().get("iteration"));
     }
 
     @Test


### PR DESCRIPTION
The do_while schedules the first loop-over task also. In case of the first loop over tasks being sync task, it may want to access the iteration value of do_while task. Now when task mapper gets called the tasks are not being added to workflow so parameterUtils will not be abel to access these tasks. This changes add the do while task to workflow so that input can be populated correctly. cc @v1r3n 

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #https://github.com/Netflix/conductor/issues/1677

Alternatives considered
----

_Describe alternative implementation you have considered_
