### PR TITLE
Fix NullPointerException for string compare

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -311,9 +311,9 @@ public class WorkflowSummary {
                 && getWorkflowType().equals(that.getWorkflowType())
                 && getWorkflowId().equals(that.getWorkflowId())
                 && Objects.equals(getCorrelationId(), that.getCorrelationId())
-                && getStartTime().equals(that.getStartTime())
-                && getUpdateTime().equals(that.getUpdateTime())
-                && getEndTime().equals(that.getEndTime())
+                && StringUtils.equals(getStartTime(), that.getStartTime())
+                && StringUtils.equals(getUpdateTime(), that.getUpdateTime())
+                && StringUtils.equals(getEndTime(), that.getEndTime())
                 && getStatus() == that.getStatus()
                 && Objects.equals(getReasonForIncompletion(), that.getReasonForIncompletion())
                 && Objects.equals(getEvent(), that.getEvent());


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Changed to use StringUtil.equals to avoid NullPointerException

_Describe the new behavior from this PR, and why it's needed_
Issue #
To fix this exception throw
```
java.lang.NullPointerException: 
  at com.netflix.conductor.common.run.WorkflowSummary.equals(WorkflowSummary.java:315)
```
Alternatives considered
----

_Describe alternative implementation you have considered_
