### PR TITLE
Disable ES in local docker config

### DIFF
--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -26,7 +26,7 @@ conductor.app.workflowRepairServiceEnabled=true
 conductor.redis.queuesNonQuorumPort=22122
 
 # Elastic search instance indexing is disabled.
-conductor.indexing.enabled=true
+conductor.indexing.enabled=false
 conductor.elasticsearch.url=http://es:9200
 conductor.elasticsearch.indexReplicasCount=0
 


### PR DESCRIPTION
Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Currently the local config actually enables ES which leads to issues when starting standalone. I don't think this is intentional, but let me know and I can create a separate `standalone` properties file.


### Error

When running `docker run -p 8080:8080 -d -t conductor:server` locally I see

```
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'taskServiceImpl' defined in URL [jar:file:/app/libs/conductor-server-3.7.0-SNAPSHOT-boot.jar!/BOOT-INF/lib/conductor-core-3.7.0-SNAPSHOT.jar!/com/netflix/conductor/service/TaskServiceImpl.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'executionService' defined in URL [jar:file:/app/libs/conductor-server-3.7.0-SNAPSHOT-boot.jar!/BOOT-INF/lib/conductor-core-3.7.0-SNAPSHOT.jar!/com/netflix/conductor/service/ExecutionService.class]: Unsatisfied dependency expressed through constructor parameter 0;
 nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'workflowExecutor' defined in URL [jar:file:/app/libs/conductor-server-3.7.0-SNAPSHOT-boot.jar!/BOOT-INF/lib/conductor-core-3.7.0-SNAPSHOT.jar!/com/netflix/conductor/core/execution/WorkflowExecutor.class]: Unsatisfied dependency expressed through constructor parameter 5;
 nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'executionDAOFacade' defined in URL [jar:file:/app/libs/conductor-server-3.7.0-SNAPSHOT-boot.jar!/BOOT-INF/lib/conductor-core-3.7.0-SNAPSHOT.jar!/com/netflix/conductor/core/dal/ExecutionDAOFacade.class]: Unsatisfied dependency expressed through constructor parameter 2; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'es6IndexRestDAO': Invocation of init method failed; nested exception is java.io.IOException: es: No address associated with hostname
```

