### PR TITLE
Allow Overrding of IDGenerator 

### DIFF
--- a/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/config/AzureBlobConfiguration.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/config/AzureBlobConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.azureblob.storage.AzureBlobPayloadStorage;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.utils.IDGenerator;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AzureBlobProperties.class)
@@ -26,7 +27,8 @@ import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 public class AzureBlobConfiguration {
 
     @Bean
-    public ExternalPayloadStorage azureBlobExternalPayloadStorage(AzureBlobProperties properties) {
-        return new AzureBlobPayloadStorage(properties);
+    public ExternalPayloadStorage azureBlobExternalPayloadStorage(
+            IDGenerator idGenerator, AzureBlobProperties properties) {
+        return new AzureBlobPayloadStorage(idGenerator, properties);
     }
 }

--- a/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorage.java
+++ b/azureblob-storage/src/main/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorage.java
@@ -52,6 +52,7 @@ public class AzureBlobPayloadStorage implements ExternalPayloadStorage {
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobPayloadStorage.class);
     private static final String CONTENT_TYPE = "application/json";
 
+    private final IDGenerator idGenerator;
     private final String workflowInputPath;
     private final String workflowOutputPath;
     private final String taskInputPath;
@@ -61,7 +62,8 @@ public class AzureBlobPayloadStorage implements ExternalPayloadStorage {
     private final long expirationSec;
     private final SasTokenCredential sasTokenCredential;
 
-    public AzureBlobPayloadStorage(AzureBlobProperties properties) {
+    public AzureBlobPayloadStorage(IDGenerator idGenerator, AzureBlobProperties properties) {
+        this.idGenerator = idGenerator;
         workflowInputPath = properties.getWorkflowInputPath();
         workflowOutputPath = properties.getWorkflowOutputPath();
         taskInputPath = properties.getTaskInputPath();
@@ -222,7 +224,7 @@ public class AzureBlobPayloadStorage implements ExternalPayloadStorage {
                 stringBuilder.append(taskOutputPath);
                 break;
         }
-        stringBuilder.append(IDGenerator.generate()).append(".json");
+        stringBuilder.append(idGenerator.generate()).append(".json");
         return stringBuilder.toString();
     }
 }

--- a/azureblob-storage/src/test/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorageTest.java
+++ b/azureblob-storage/src/test/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorageTest.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.azureblob.storage;
 
 import java.time.Duration;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,9 +35,12 @@ public class AzureBlobPayloadStorageTest {
 
     private AzureBlobProperties properties;
 
+    private IDGenerator idGenerator;
+
     @Before
     public void setUp() {
         properties = mock(AzureBlobProperties.class);
+        idGenerator = new IDGenerator();
         when(properties.getConnectionString()).thenReturn(null);
         when(properties.getContainerName()).thenReturn("conductor-payloads");
         when(properties.getEndpoint()).thenReturn(null);
@@ -57,26 +61,26 @@ public class AzureBlobPayloadStorageTest {
     @Test
     public void testNoStorageAccount() {
         expectedException.expect(ApplicationException.class);
-        new AzureBlobPayloadStorage(properties);
+        new AzureBlobPayloadStorage(idGenerator, properties);
     }
 
     @Test
     public void testUseConnectionString() {
         when(properties.getConnectionString()).thenReturn(azuriteConnectionString);
-        new AzureBlobPayloadStorage(properties);
+        new AzureBlobPayloadStorage(idGenerator, properties);
     }
 
     @Test
     public void testUseEndpoint() {
         String azuriteEndpoint = "http://127.0.0.1:10000/";
         when(properties.getEndpoint()).thenReturn(azuriteEndpoint);
-        new AzureBlobPayloadStorage(properties);
+        new AzureBlobPayloadStorage(idGenerator, properties);
     }
 
     @Test
     public void testGetLocationFixedPath() {
         when(properties.getConnectionString()).thenReturn(azuriteConnectionString);
-        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(properties);
+        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(idGenerator, properties);
         String path = "somewhere";
         ExternalStorageLocation externalStorageLocation =
                 azureBlobPayloadStorage.getLocation(
@@ -105,7 +109,7 @@ public class AzureBlobPayloadStorageTest {
     @Test
     public void testGetAllLocations() {
         when(properties.getConnectionString()).thenReturn(azuriteConnectionString);
-        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(properties);
+        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(idGenerator, properties);
 
         testGetLocation(
                 azureBlobPayloadStorage,

--- a/azureblob-storage/src/test/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorageTest.java
+++ b/azureblob-storage/src/test/java/com/netflix/conductor/azureblob/storage/AzureBlobPayloadStorageTest.java
@@ -14,7 +14,6 @@ package com.netflix.conductor.azureblob.storage;
 
 import java.time.Duration;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +23,7 @@ import com.netflix.conductor.azureblob.config.AzureBlobProperties;
 import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.exception.ApplicationException;
+import com.netflix.conductor.core.utils.IDGenerator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -80,7 +80,8 @@ public class AzureBlobPayloadStorageTest {
     @Test
     public void testGetLocationFixedPath() {
         when(properties.getConnectionString()).thenReturn(azuriteConnectionString);
-        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(idGenerator, properties);
+        AzureBlobPayloadStorage azureBlobPayloadStorage =
+                new AzureBlobPayloadStorage(idGenerator, properties);
         String path = "somewhere";
         ExternalStorageLocation externalStorageLocation =
                 azureBlobPayloadStorage.getLocation(
@@ -109,7 +110,8 @@ public class AzureBlobPayloadStorageTest {
     @Test
     public void testGetAllLocations() {
         when(properties.getConnectionString()).thenReturn(azuriteConnectionString);
-        AzureBlobPayloadStorage azureBlobPayloadStorage = new AzureBlobPayloadStorage(idGenerator, properties);
+        AzureBlobPayloadStorage azureBlobPayloadStorage =
+                new AzureBlobPayloadStorage(idGenerator, properties);
 
         testGetLocation(
                 azureBlobPayloadStorage,

--- a/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraExecutionDAOSpec.groovy
+++ b/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraExecutionDAOSpec.groovy
@@ -65,7 +65,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
 
     def "workflow CRUD"() {
         given:
-        String workflowId = IDGenerator.generate()
+        String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef()
         workflowDef.name = "def1"
         workflowDef.setVersion(1)
@@ -118,15 +118,15 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
 
     def "create tasks and verify methods that read tasks and workflow"() {
         given: 'we create a workflow'
-        String workflowId = IDGenerator.generate()
+        String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
         WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
 
         def taskList = [task1, task2, task3]
 
@@ -190,15 +190,15 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
 
     def "verify tasks are updated"() {
         given: 'we create a workflow'
-        String workflowId = IDGenerator.generate()
+        String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
         WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -228,15 +228,15 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
 
     def "verify tasks are removed"() {
         given: 'we create a workflow'
-        String workflowId = IDGenerator.generate()
+        String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
         WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: IDGenerator.generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -278,7 +278,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
     def "CRUD on task def limit"() {
         given:
         String taskDefName = "test_task_def"
-        String taskId = IDGenerator.generate()
+        String taskId = new IDGenerator().generate()
 
         TaskDef taskDef = new TaskDef(concurrentExecLimit: 1)
         WorkflowTask workflowTask = new WorkflowTask(taskDefinition: taskDef)
@@ -287,7 +287,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         TaskModel task = new TaskModel()
         task.taskDefName = taskDefName
         task.taskId = taskId
-        task.workflowInstanceId = IDGenerator.generate()
+        task.workflowInstanceId = new IDGenerator().generate()
         task.setWorkflowTask(workflowTask)
         task.setTaskType("test_task")
         task.setWorkflowType("test_workflow")
@@ -295,8 +295,8 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
 
         TaskModel newTask = new TaskModel()
         newTask.setTaskDefName(taskDefName)
-        newTask.setTaskId(IDGenerator.generate())
-        newTask.setWorkflowInstanceId(IDGenerator.generate())
+        newTask.setTaskId(new IDGenerator().generate())
+        newTask.setWorkflowInstanceId(new IDGenerator().generate())
         newTask.setWorkflowTask(workflowTask)
         newTask.setTaskType("test_task")
         newTask.setWorkflowType("test_workflow")
@@ -349,8 +349,8 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         ex && ex.code == INVALID_INPUT
 
         and: 'verify that a non-existing generated id returns null'
-        executionDAO.getTask(IDGenerator.generate()) == null
-        executionDAO.getWorkflow(IDGenerator.generate(), true) == null
+        executionDAO.getTask(new IDGenerator().generate()) == null
+        executionDAO.getWorkflow(new IDGenerator().generate(), true) == null
     }
 
     def "CRUD on event execution"() throws Exception {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/S3PayloadStorage.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/S3PayloadStorage.java
@@ -50,11 +50,13 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3PayloadStorage.class);
     private static final String CONTENT_TYPE = "application/json";
 
+    private final IDGenerator idGenerator;
     private final AmazonS3 s3Client;
     private final String bucketName;
     private final long expirationSec;
 
-    public S3PayloadStorage(S3Properties properties) {
+    public S3PayloadStorage(IDGenerator idGenerator, S3Properties properties) {
+        this.idGenerator = idGenerator;
         bucketName = properties.getBucketName();
         expirationSec = properties.getSignedUrlExpirationDuration().getSeconds();
         String region = properties.getRegion();
@@ -171,7 +173,7 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
                 stringBuilder.append("task/output/");
                 break;
         }
-        stringBuilder.append(IDGenerator.generate()).append(".json");
+        stringBuilder.append(idGenerator.generate()).append(".json");
         return stringBuilder.toString();
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/storage/config/S3Configuration.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/storage/config/S3Configuration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.contribs.storage.S3PayloadStorage;
+import com.netflix.conductor.core.utils.IDGenerator;
 
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
@@ -26,7 +27,8 @@ import com.netflix.conductor.contribs.storage.S3PayloadStorage;
 public class S3Configuration {
 
     @Bean
-    public ExternalPayloadStorage s3ExternalPayloadStorage(S3Properties properties) {
-        return new S3PayloadStorage(properties);
+    public ExternalPayloadStorage s3ExternalPayloadStorage(
+            IDGenerator idGenerator, S3Properties properties) {
+        return new S3PayloadStorage(idGenerator, properties);
     }
 }

--- a/contribs/src/test/java/com/netflix/conductor/contribs/tasks/http/HttpTaskTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/tasks/http/HttpTaskTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.MediaType;
@@ -356,6 +357,7 @@ public class HttpTaskTest {
         SystemTaskRegistry systemTaskRegistry = mock(SystemTaskRegistry.class);
 
         new DeciderService(
+                        new IDGenerator(),
                         parametersUtils,
                         metadataDAO,
                         externalPayloadStorageUtils,

--- a/contribs/src/test/java/com/netflix/conductor/contribs/tasks/http/HttpTaskTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/tasks/http/HttpTaskTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.MediaType;
@@ -33,6 +32,7 @@ import com.netflix.conductor.core.execution.DeciderService;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -60,6 +60,7 @@ public class DeciderService {
 
     @VisibleForTesting static final String MAX_TASK_LIMIT = "conductor.app.max-task-limit";
 
+    private final IDGenerator idGenerator;
     private final ParametersUtils parametersUtils;
     private final ExternalPayloadStorageUtils externalPayloadStorageUtils;
     private final MetadataDAO metadataDAO;
@@ -81,6 +82,7 @@ public class DeciderService {
                                                     && task.getStatus().isSuccessful());
 
     public DeciderService(
+            IDGenerator idGenerator,
             ParametersUtils parametersUtils,
             MetadataDAO metadataDAO,
             ExternalPayloadStorageUtils externalPayloadStorageUtils,
@@ -88,6 +90,7 @@ public class DeciderService {
             @Qualifier("taskMappersByTaskType") Map<TaskType, TaskMapper> taskMappers,
             @Value("${conductor.app.taskPendingTimeThreshold:60m}")
                     Duration taskPendingTimeThreshold) {
+        this.idGenerator = idGenerator;
         this.metadataDAO = metadataDAO;
         this.parametersUtils = parametersUtils;
         this.taskMappers = taskMappers;
@@ -569,7 +572,7 @@ public class DeciderService {
         rescheduled.setCallbackAfterSeconds(startDelay);
         rescheduled.setRetryCount(task.getRetryCount() + 1);
         rescheduled.setRetried(false);
-        rescheduled.setTaskId(IDGenerator.generate());
+        rescheduled.setTaskId(idGenerator.generate());
         rescheduled.setRetriedTaskId(task.getTaskId());
         rescheduled.setStatus(SCHEDULED);
         rescheduled.setPollCount(0);
@@ -832,7 +835,7 @@ public class DeciderService {
                         .map(TaskModel::getReferenceTaskName)
                         .collect(Collectors.toList());
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()
                         .withWorkflowModel(workflow)

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -73,6 +73,7 @@ public class WorkflowExecutor {
     private final MetadataMapperService metadataMapperService;
     private final ExecutionDAOFacade executionDAOFacade;
     private final ParametersUtils parametersUtils;
+    private final IDGenerator idGenerator;
     private final WorkflowStatusListener workflowStatusListener;
     private final SystemTaskRegistry systemTaskRegistry;
 
@@ -104,7 +105,8 @@ public class WorkflowExecutor {
             ConductorProperties properties,
             ExecutionLockService executionLockService,
             SystemTaskRegistry systemTaskRegistry,
-            ParametersUtils parametersUtils) {
+            ParametersUtils parametersUtils,
+            IDGenerator idGenerator) {
         this.deciderService = deciderService;
         this.metadataDAO = metadataDAO;
         this.queueDAO = queueDAO;
@@ -115,6 +117,7 @@ public class WorkflowExecutor {
         this.workflowStatusListener = workflowStatusListener;
         this.executionLockService = executionLockService;
         this.parametersUtils = parametersUtils;
+        this.idGenerator = idGenerator;
         this.systemTaskRegistry = systemTaskRegistry;
     }
 
@@ -361,7 +364,7 @@ public class WorkflowExecutor {
         validateWorkflow(workflowDefinition, workflowInput, externalInputPayloadStoragePath);
 
         // A random UUID is assigned to the work flow instance
-        String workflowId = IDGenerator.generate();
+        String workflowId = idGenerator.generate();
 
         // Persist the Workflow
         WorkflowModel workflow = new WorkflowModel();
@@ -756,7 +759,7 @@ public class WorkflowExecutor {
      */
     private TaskModel taskToBeRescheduled(WorkflowModel workflow, TaskModel task) {
         TaskModel taskToBeRetried = task.copy();
-        taskToBeRetried.setTaskId(IDGenerator.generate());
+        taskToBeRetried.setTaskId(idGenerator.generate());
         taskToBeRetried.setRetriedTaskId(task.getTaskId());
         taskToBeRetried.setStatus(SCHEDULED);
         taskToBeRetried.setRetryCount(task.getRetryCount() + 1);
@@ -1575,7 +1578,7 @@ public class WorkflowExecutor {
 
         // Now create a "SKIPPED" task for this workflow
         TaskModel taskToBeSkipped = new TaskModel();
-        taskToBeSkipped.setTaskId(IDGenerator.generate());
+        taskToBeSkipped.setTaskId(idGenerator.generate());
         taskToBeSkipped.setReferenceTaskName(taskReferenceName);
         taskToBeSkipped.setWorkflowInstanceId(workflowId);
         taskToBeSkipped.setWorkflowPriority(workflow.getPriority());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -54,6 +54,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ForkJoinDynamicTaskMapper.class);
 
+    private final IDGenerator idGenerator;
     private final ParametersUtils parametersUtils;
     private final ObjectMapper objectMapper;
     private final MetadataDAO metadataDAO;
@@ -62,7 +63,11 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
 
     @Autowired
     public ForkJoinDynamicTaskMapper(
-            ParametersUtils parametersUtils, ObjectMapper objectMapper, MetadataDAO metadataDAO) {
+            IDGenerator idGenerator,
+            ParametersUtils parametersUtils,
+            ObjectMapper objectMapper,
+            MetadataDAO metadataDAO) {
+        this.idGenerator = idGenerator;
         this.parametersUtils = parametersUtils;
         this.objectMapper = objectMapper;
         this.metadataDAO = metadataDAO;
@@ -226,14 +231,9 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
      * This method creates a FORK task and adds the list of dynamic fork tasks keyed by
      * "forkedTaskDefs" and their names keyed by "forkedTasks" into {@link TaskModel#getInputData()}
      *
-     * @param workflowTask A {@link WorkflowTask} representing {@link TaskType#FORK_JOIN_DYNAMIC}
-     * @param workflowModel: A instance of the {@link WorkflowModel} which represents the workflow
-     *     being executed.
-     * @param taskId: The string representation of {@link java.util.UUID} which will be set as the
-     *     taskId.
-     * @param dynForkTasks: The list of dynamic forked tasks, the reference names of these tasks
-     *     will be added to the forkDynamicTask
-     * @return A new instance of {@link TaskModel} representing a {@link TaskType#TASK_TYPE_FORK}
+     * @param taskMapperContext
+     * @param dynForkTasks
+     * @return
      */
     @VisibleForTesting
     TaskModel createDynamicForkTask(
@@ -284,7 +284,7 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         joinTask.setScheduledTime(System.currentTimeMillis());
         joinTask.setStartTime(System.currentTimeMillis());
         joinTask.setInputData(joinInput);
-        joinTask.setTaskId(IDGenerator.generate());
+        joinTask.setTaskId(idGenerator.generate());
         joinTask.setStatus(TaskModel.Status.IN_PROGRESS);
         joinTask.setWorkflowTask(joinWorkflowTask);
         joinTask.setWorkflowPriority(workflowModel.getPriority());

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -23,14 +23,12 @@ import org.springframework.stereotype.Component;
         havingValue = "default",
         matchIfMissing = true)
 /**
- * ID Generator used by Conductor
- * Note on overriding the ID Generator:
- * The default ID generator uses UUID v4 as the ID format.
- * By overriding this class it is possible to use different scheme for ID generation.  However, this is not normal and
- * should only be done after very careful consideration.
+ * ID Generator used by Conductor Note on overriding the ID Generator: The default ID generator uses
+ * UUID v4 as the ID format. By overriding this class it is possible to use different scheme for ID
+ * generation. However, this is not normal and should only be done after very careful consideration.
  *
- * Please note, if you use Cassandra persistence, the schema uses UUID as the column type and the IDs have to be valid
- * UUIDs supported by Cassandra.
+ * <p>Please note, if you use Cassandra persistence, the schema uses UUID as the column type and the
+ * IDs have to be valid UUIDs supported by Cassandra.
  */
 public class IDGenerator {
 

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -14,9 +14,19 @@ package com.netflix.conductor.core.utils;
 
 import java.util.UUID;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Component
 public class IDGenerator {
 
-    public static String generate() {
+    public IDGenerator() {
+
+    }
+
+    public String generate() {
         return UUID.randomUUID().toString();
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -14,17 +14,12 @@ package com.netflix.conductor.core.utils;
 
 import java.util.UUID;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
 @Component
 public class IDGenerator {
 
-    public IDGenerator() {
-
-    }
+    public IDGenerator() {}
 
     public String generate() {
         return UUID.randomUUID().toString();

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -15,11 +15,13 @@ package com.netflix.conductor.core.utils;
 import java.util.UUID;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty(name = "conductor.id.generator", havingValue = "default", matchIfMissing = true)
+@ConditionalOnProperty(
+        name = "conductor.id.generator",
+        havingValue = "default",
+        matchIfMissing = true)
 public class IDGenerator {
 
     public IDGenerator() {}

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -22,6 +22,16 @@ import org.springframework.stereotype.Component;
         name = "conductor.id.generator",
         havingValue = "default",
         matchIfMissing = true)
+/**
+ * ID Generator used by Conductor
+ * Note on overriding the ID Generator:
+ * The default ID generator uses UUID v4 as the ID format.
+ * By overriding this class it is possible to use different scheme for ID generation.  However, this is not normal and
+ * should only be done after very careful consideration.
+ *
+ * Please note, if you use Cassandra persistence, the schema uses UUID as the column type and the IDs have to be valid
+ * UUIDs supported by Cassandra.
+ */
 public class IDGenerator {
 
     public IDGenerator() {}

--- a/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/IDGenerator.java
@@ -14,9 +14,12 @@ package com.netflix.conductor.core.utils;
 
 import java.util.UUID;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(name = "conductor.id.generator", havingValue = "default", matchIfMissing = true)
 public class IDGenerator {
 
     public IDGenerator() {}

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -66,7 +66,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         String subWorkflowId = "subWorkflowId"
         SubWorkflow subWorkflowTask = new SubWorkflow(new ObjectMapper())
 
-        String task1Id = IDGenerator.generate()
+        String task1Id = new IDGenerator().generate()
         TaskModel task1 = new TaskModel()
         task1.setTaskType(SUB_WORKFLOW.name())
         task1.setReferenceTaskName("waitTask")

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -160,7 +161,7 @@ public class TestDeciderOutcomes {
         taskMappers.put(JOIN, new JoinTaskMapper());
         taskMappers.put(
                 FORK_JOIN_DYNAMIC,
-                new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO));
+                new ForkJoinDynamicTaskMapper(new IDGenerator(), parametersUtils, objectMapper, metadataDAO));
         taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
         taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
@@ -170,6 +171,7 @@ public class TestDeciderOutcomes {
 
         this.deciderService =
                 new DeciderService(
+                        new IDGenerator(),
                         parametersUtils,
                         metadataDAO,
                         externalPayloadStorageUtils,

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,6 +61,7 @@ import com.netflix.conductor.core.execution.tasks.Switch;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
@@ -161,7 +161,8 @@ public class TestDeciderOutcomes {
         taskMappers.put(JOIN, new JoinTaskMapper());
         taskMappers.put(
                 FORK_JOIN_DYNAMIC,
-                new ForkJoinDynamicTaskMapper(new IDGenerator(), parametersUtils, objectMapper, metadataDAO));
+                new ForkJoinDynamicTaskMapper(
+                        new IDGenerator(), parametersUtils, objectMapper, metadataDAO));
         taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
         taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,6 +52,7 @@ import com.netflix.conductor.core.execution.tasks.SubWorkflow;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -113,6 +114,11 @@ public class TestDeciderService {
         public ParametersUtils parametersUtils(ObjectMapper mapper) {
             return new ParametersUtils(mapper);
         }
+
+        @Bean
+        public IDGenerator idGenerator() {
+            return new IDGenerator();
+        }
     }
 
     private DeciderService deciderService;
@@ -153,6 +159,7 @@ public class TestDeciderService {
 
         deciderService =
                 new DeciderService(
+                        new IDGenerator(),
                         parametersUtils,
                         metadataDAO,
                         externalPayloadStorageUtils,

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -159,6 +159,7 @@ public class TestWorkflowExecutor {
         externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         executionLockService = mock(ExecutionLockService.class);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
+        IDGenerator idGenerator = new IDGenerator();
         Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
         taskMappers.put(DECISION, new DecisionTaskMapper());
         taskMappers.put(SWITCH, new SwitchTaskMapper(evaluators));
@@ -167,7 +168,7 @@ public class TestWorkflowExecutor {
         taskMappers.put(JOIN, new JoinTaskMapper());
         taskMappers.put(
                 FORK_JOIN_DYNAMIC,
-                new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO));
+                new ForkJoinDynamicTaskMapper(idGenerator, parametersUtils, objectMapper, metadataDAO));
         taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
         taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
@@ -179,6 +180,7 @@ public class TestWorkflowExecutor {
 
         DeciderService deciderService =
                 new DeciderService(
+                        idGenerator,
                         parametersUtils,
                         metadataDAO,
                         externalPayloadStorageUtils,
@@ -203,11 +205,13 @@ public class TestWorkflowExecutor {
                         properties,
                         executionLockService,
                         systemTaskRegistry,
-                        parametersUtils);
+                        parametersUtils,
+                        idGenerator);
     }
 
     @Test
     public void testScheduleTask() {
+        IDGenerator idGenerator = new IDGenerator();
         WorkflowSystemTaskStub httpTask = beanFactory.getBean("HTTP", WorkflowSystemTaskStub.class);
         WorkflowSystemTaskStub http2Task =
                 beanFactory.getBean("HTTP2", WorkflowSystemTaskStub.class);
@@ -240,7 +244,7 @@ public class TestWorkflowExecutor {
         task1.setWorkflowInstanceId(workflow.getWorkflowId());
         task1.setCorrelationId(workflow.getCorrelationId());
         task1.setScheduledTime(System.currentTimeMillis());
-        task1.setTaskId(IDGenerator.generate());
+        task1.setTaskId(idGenerator.generate());
         task1.setInputData(new HashMap<>());
         task1.setStatus(TaskModel.Status.SCHEDULED);
         task1.setRetryCount(0);
@@ -255,7 +259,7 @@ public class TestWorkflowExecutor {
         task2.setCorrelationId(workflow.getCorrelationId());
         task2.setScheduledTime(System.currentTimeMillis());
         task2.setInputData(new HashMap<>());
-        task2.setTaskId(IDGenerator.generate());
+        task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.IN_PROGRESS);
         task2.setWorkflowTask(taskToSchedule);
 
@@ -266,7 +270,7 @@ public class TestWorkflowExecutor {
         task3.setWorkflowInstanceId(workflow.getWorkflowId());
         task3.setCorrelationId(workflow.getCorrelationId());
         task3.setScheduledTime(System.currentTimeMillis());
-        task3.setTaskId(IDGenerator.generate());
+        task3.setTaskId(idGenerator.generate());
         task3.setInputData(new HashMap<>());
         task3.setStatus(TaskModel.Status.SCHEDULED);
         task3.setRetryCount(0);
@@ -1083,17 +1087,17 @@ public class TestWorkflowExecutor {
 
     @Test
     public void testRetryFromLastFailedSubWorkflowTaskThenStartWithLastFailedTask() {
-
+        IDGenerator idGenerator = new IDGenerator();
         // given
-        String id = IDGenerator.generate();
-        String workflowInstanceId = IDGenerator.generate();
+        String id = idGenerator.generate();
+        String workflowInstanceId = idGenerator.generate();
         TaskModel task = new TaskModel();
         task.setTaskType(TaskType.SIMPLE.name());
         task.setTaskDefName("task");
         task.setReferenceTaskName("task_ref");
         task.setWorkflowInstanceId(workflowInstanceId);
         task.setScheduledTime(System.currentTimeMillis());
-        task.setTaskId(IDGenerator.generate());
+        task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setRetryCount(0);
         task.setWorkflowTask(new WorkflowTask());
@@ -1107,7 +1111,7 @@ public class TestWorkflowExecutor {
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(workflowInstanceId);
         task1.setScheduledTime(System.currentTimeMillis());
-        task1.setTaskId(IDGenerator.generate());
+        task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.FAILED);
         task1.setRetryCount(0);
         task1.setWorkflowTask(new WorkflowTask());
@@ -1128,7 +1132,7 @@ public class TestWorkflowExecutor {
         TaskModel task2 = new TaskModel();
         task2.setWorkflowInstanceId(subWorkflow.getWorkflowId());
         task2.setScheduledTime(System.currentTimeMillis());
-        task2.setTaskId(IDGenerator.generate());
+        task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.FAILED);
         task2.setRetryCount(0);
         task2.setOutputData(new HashMap<>());
@@ -1305,9 +1309,10 @@ public class TestWorkflowExecutor {
 
     @Test
     public void testRerunSubWorkflow() {
+        IDGenerator idGenerator = new IDGenerator();
         // setup
-        String parentWorkflowId = IDGenerator.generate();
-        String subWorkflowId = IDGenerator.generate();
+        String parentWorkflowId = idGenerator.generate();
+        String subWorkflowId = idGenerator.generate();
 
         // sub workflow setup
         TaskModel task1 = new TaskModel();
@@ -1316,7 +1321,7 @@ public class TestWorkflowExecutor {
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
         task1.setScheduledTime(System.currentTimeMillis());
-        task1.setTaskId(IDGenerator.generate());
+        task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
         task1.setOutputData(new HashMap<>());
@@ -1327,7 +1332,7 @@ public class TestWorkflowExecutor {
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
         task2.setScheduledTime(System.currentTimeMillis());
-        task2.setTaskId(IDGenerator.generate());
+        task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.COMPLETED);
         task2.setWorkflowTask(new WorkflowTask());
         task2.setOutputData(new HashMap<>());
@@ -1347,7 +1352,7 @@ public class TestWorkflowExecutor {
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
         task.setScheduledTime(System.currentTimeMillis());
-        task.setTaskId(IDGenerator.generate());
+        task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setOutputData(new HashMap<>());
         task.setSubWorkflowId(subWorkflowId);
@@ -1453,8 +1458,9 @@ public class TestWorkflowExecutor {
 
     @Test
     public void testRerunWorkflowWithSyncSystemTaskId() {
+        IDGenerator idGenerator = new IDGenerator();
         // setup
-        String workflowId = IDGenerator.generate();
+        String workflowId = idGenerator.generate();
 
         TaskModel task1 = new TaskModel();
         task1.setTaskType(TaskType.SIMPLE.name());
@@ -1462,7 +1468,7 @@ public class TestWorkflowExecutor {
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(workflowId);
         task1.setScheduledTime(System.currentTimeMillis());
-        task1.setTaskId(IDGenerator.generate());
+        task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
         task1.setOutputData(new HashMap<>());
@@ -1511,9 +1517,11 @@ public class TestWorkflowExecutor {
 
     @Test
     public void testRerunSubWorkflowWithTaskId() {
+        IDGenerator idGenerator = new IDGenerator();
+
         // setup
-        String parentWorkflowId = IDGenerator.generate();
-        String subWorkflowId = IDGenerator.generate();
+        String parentWorkflowId = idGenerator.generate();
+        String subWorkflowId = idGenerator.generate();
 
         // sub workflow setup
         TaskModel task1 = new TaskModel();
@@ -1522,7 +1530,7 @@ public class TestWorkflowExecutor {
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
         task1.setScheduledTime(System.currentTimeMillis());
-        task1.setTaskId(IDGenerator.generate());
+        task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
         task1.setOutputData(new HashMap<>());
@@ -1533,7 +1541,7 @@ public class TestWorkflowExecutor {
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
         task2.setScheduledTime(System.currentTimeMillis());
-        task2.setTaskId(IDGenerator.generate());
+        task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.COMPLETED);
         task2.setWorkflowTask(new WorkflowTask());
         task2.setOutputData(new HashMap<>());
@@ -1553,7 +1561,7 @@ public class TestWorkflowExecutor {
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
         task.setScheduledTime(System.currentTimeMillis());
-        task.setTaskId(IDGenerator.generate());
+        task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setOutputData(new HashMap<>());
         task.setSubWorkflowId(subWorkflowId);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -168,7 +168,8 @@ public class TestWorkflowExecutor {
         taskMappers.put(JOIN, new JoinTaskMapper());
         taskMappers.put(
                 FORK_JOIN_DYNAMIC,
-                new ForkJoinDynamicTaskMapper(idGenerator, parametersUtils, objectMapper, metadataDAO));
+                new ForkJoinDynamicTaskMapper(
+                        idGenerator, parametersUtils, objectMapper, metadataDAO));
         taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
         taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
         taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.netflix.spectator.api.Id;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 public class DecisionTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private ParametersUtils parametersUtils;
     private DeciderService deciderService;
     // Subject
@@ -66,6 +68,7 @@ public class DecisionTaskMapperTest {
     @Before
     public void setUp() {
         parametersUtils = new ParametersUtils(objectMapper);
+        idGenerator = new IDGenerator();
 
         ip1 = new HashMap<>();
         ip1.put("p1", "${workflow.input.param1}");
@@ -135,7 +138,7 @@ public class DecisionTaskMapperTest {
 
         TaskModel theTask = new TaskModel();
         theTask.setReferenceTaskName("Foo");
-        theTask.setTaskId(IDGenerator.generate());
+        theTask.setTaskId(idGenerator.generate());
 
         when(deciderService.getTasksToBeScheduled(workflowModel, task2, 0, null))
                 .thenReturn(Collections.singletonList(theTask));
@@ -146,7 +149,7 @@ public class DecisionTaskMapperTest {
                         .withWorkflowTask(decisionTask)
                         .withTaskInput(input)
                         .withRetryCount(0)
-                        .withTaskId(IDGenerator.generate())
+                        .withTaskId(idGenerator.generate())
                         .withDeciderService(deciderService)
                         .build();
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapperTest.java
@@ -18,7 +18,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.netflix.spectator.api.Id;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapperTest.java
@@ -64,7 +64,7 @@ public class DoWhileTaskMapperTest {
         workflowTask.setLoopCondition(
                 "if ($.second_task + $.first_task > 10) { false; } else { true; }");
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapperTest.java
@@ -70,7 +70,7 @@ public class DynamicTaskMapperTest {
                         anyMap(), any(WorkflowModel.class), any(TaskDef.class), anyString()))
                 .thenReturn(taskInput);
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/EventTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/EventTaskMapperTest.java
@@ -42,7 +42,7 @@ public class EventTaskMapperTest {
 
         WorkflowTask taskToBeScheduled = new WorkflowTask();
         taskToBeScheduled.setSink("SQSSINK");
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         Map<String, Object> eventTaskInput = new HashMap<>();
         eventTaskInput.put("sink", "SQSSINK");

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.netflix.spectator.api.Id;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,7 +72,8 @@ public class ForkJoinDynamicTaskMapperTest {
         deciderService = Mockito.mock(DeciderService.class);
 
         forkJoinDynamicTaskMapper =
-                new ForkJoinDynamicTaskMapper(idGenerator, parametersUtils, objectMapper, metadataDAO);
+                new ForkJoinDynamicTaskMapper(
+                        idGenerator, parametersUtils, objectMapper, metadataDAO);
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapperTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.netflix.spectator.api.Id;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class ForkJoinDynamicTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private ParametersUtils parametersUtils;
     private ObjectMapper objectMapper;
     private DeciderService deciderService;
@@ -65,12 +67,13 @@ public class ForkJoinDynamicTaskMapperTest {
     @Before
     public void setUp() {
         MetadataDAO metadataDAO = Mockito.mock(MetadataDAO.class);
+        idGenerator = new IDGenerator();
         parametersUtils = Mockito.mock(ParametersUtils.class);
         objectMapper = Mockito.mock(ObjectMapper.class);
         deciderService = Mockito.mock(DeciderService.class);
 
         forkJoinDynamicTaskMapper =
-                new ForkJoinDynamicTaskMapper(parametersUtils, objectMapper, metadataDAO);
+                new ForkJoinDynamicTaskMapper(idGenerator, parametersUtils, objectMapper, metadataDAO);
     }
 
     @Test
@@ -140,7 +143,7 @@ public class ForkJoinDynamicTaskMapperTest {
         when(deciderService.getTasksToBeScheduled(workflowModel, wt3, 0))
                 .thenReturn(Collections.singletonList(simpleTask2));
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()
@@ -223,7 +226,7 @@ public class ForkJoinDynamicTaskMapperTest {
         when(deciderService.getTasksToBeScheduled(workflowModel, wt3, 0))
                 .thenReturn(Collections.singletonList(simpleTask2));
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()
                         .withWorkflowModel(workflowModel)
@@ -486,7 +489,7 @@ public class ForkJoinDynamicTaskMapperTest {
         when(deciderService.getTasksToBeScheduled(workflowModel, wt2, 0))
                 .thenReturn(Lists.newArrayList());
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()
                         .withWorkflowModel(workflowModel)

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapperTest.java
@@ -41,6 +41,7 @@ public class ForkJoinTaskMapperTest {
 
     private DeciderService deciderService;
     private ForkJoinTaskMapper forkJoinTaskMapper;
+    private IDGenerator idGenerator;
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
@@ -48,6 +49,7 @@ public class ForkJoinTaskMapperTest {
     public void setUp() {
         deciderService = Mockito.mock(DeciderService.class);
         forkJoinTaskMapper = new ForkJoinTaskMapper();
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -115,7 +117,7 @@ public class ForkJoinTaskMapperTest {
         Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2, 0))
                 .thenReturn(Collections.singletonList(task3));
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()
                         .withWorkflowModel(workflow)
@@ -195,7 +197,7 @@ public class ForkJoinTaskMapperTest {
         Mockito.when(deciderService.getTasksToBeScheduled(workflow, wft2, 0))
                 .thenReturn(Collections.singletonList(task3));
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         TaskMapperContext taskMapperContext =
                 TaskMapperContext.newBuilder()

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapperTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 public class HTTPTaskMapperTest {
 
     private HTTPTaskMapper httpTaskMapper;
+    private IDGenerator idGenerator;
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
@@ -44,6 +45,7 @@ public class HTTPTaskMapperTest {
         ParametersUtils parametersUtils = mock(ParametersUtils.class);
         MetadataDAO metadataDAO = mock(MetadataDAO.class);
         httpTaskMapper = new HTTPTaskMapper(parametersUtils, metadataDAO);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -53,8 +55,8 @@ public class HTTPTaskMapperTest {
         workflowTask.setName("http_task");
         workflowTask.setType(TaskType.HTTP.name());
         workflowTask.setTaskDefinition(new TaskDef("http_task"));
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();
@@ -85,8 +87,8 @@ public class HTTPTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("http_task");
         workflowTask.setType(TaskType.HTTP.name());
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapperTest.java
@@ -55,7 +55,7 @@ public class InlineTaskMapperTest {
                 "function scriptFun() {if ($.input.a==1){return {testValue: true}} else{return "
                         + "{testValue: false} }}; scriptFun();");
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();
@@ -89,7 +89,7 @@ public class InlineTaskMapperTest {
                 "function scriptFun() {if ($.input.a==1){return {testValue: true}} else{return "
                         + "{testValue: false} }}; scriptFun();");
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapperTest.java
@@ -39,7 +39,7 @@ public class JoinTaskMapperTest {
         workflowTask.setType(TaskType.JOIN.name());
         workflowTask.setJoinOn(Arrays.asList("task1", "task2"));
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef wd = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.netflix.spectator.api.Id;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapperTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.netflix.spectator.api.Id;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.mock;
 
 public class JsonJQTransformTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private ParametersUtils parametersUtils;
     private MetadataDAO metadataDAO;
 
@@ -42,6 +44,7 @@ public class JsonJQTransformTaskMapperTest {
     public void setUp() {
         parametersUtils = mock(ParametersUtils.class);
         metadataDAO = mock(MetadataDAO.class);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -58,7 +61,7 @@ public class JsonJQTransformTaskMapperTest {
         taskInput.put("queryExpression", "{ out: (.in1 + .in2) }");
         workflowTask.setInputParameters(taskInput);
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();
@@ -95,7 +98,7 @@ public class JsonJQTransformTaskMapperTest {
         taskInput.put("queryExpression", "{ out: (.in1 + .in2) }");
         workflowTask.setInputParameters(taskInput);
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapperTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.mock;
 
 public class KafkaPublishTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private KafkaPublishTaskMapper kafkaTaskMapper;
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
@@ -44,6 +45,7 @@ public class KafkaPublishTaskMapperTest {
         ParametersUtils parametersUtils = mock(ParametersUtils.class);
         MetadataDAO metadataDAO = mock(MetadataDAO.class);
         kafkaTaskMapper = new KafkaPublishTaskMapper(parametersUtils, metadataDAO);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -53,8 +55,8 @@ public class KafkaPublishTaskMapperTest {
         workflowTask.setName("kafka_task");
         workflowTask.setType(TaskType.KAFKA_PUBLISH.name());
         workflowTask.setTaskDefinition(new TaskDef("kafka_task"));
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();
@@ -85,8 +87,8 @@ public class KafkaPublishTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("kafka_task");
         workflowTask.setType(TaskType.KAFKA_PUBLISH.name());
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapperTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.mock;
 
 public class LambdaTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private ParametersUtils parametersUtils;
     private MetadataDAO metadataDAO;
 
@@ -40,6 +41,7 @@ public class LambdaTaskMapperTest {
     public void setUp() {
         parametersUtils = mock(ParametersUtils.class);
         metadataDAO = mock(MetadataDAO.class);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -52,7 +54,7 @@ public class LambdaTaskMapperTest {
         workflowTask.setScriptExpression(
                 "if ($.input.a==1){return {testValue: true}} else{return {testValue: false} }");
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();
@@ -84,7 +86,7 @@ public class LambdaTaskMapperTest {
         workflowTask.setScriptExpression(
                 "if ($.input.a==1){return {testValue: true}} else{return {testValue: false} }");
 
-        String taskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapperTest.java
@@ -33,7 +33,7 @@ public class SetVariableTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setType(TaskType.TASK_TYPE_SET_VARIABLE);
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapperTest.java
@@ -37,6 +37,8 @@ public class SimpleTaskMapperTest {
 
     private SimpleTaskMapper simpleTaskMapper;
 
+    private IDGenerator idGenerator = new IDGenerator();
+
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Before
@@ -52,8 +54,8 @@ public class SimpleTaskMapperTest {
         workflowTask.setName("simple_task");
         workflowTask.setTaskDefinition(new TaskDef("simple_task"));
 
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();
@@ -81,8 +83,8 @@ public class SimpleTaskMapperTest {
         // Given
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("simple_task");
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapperTest.java
@@ -46,6 +46,7 @@ public class SubWorkflowTaskMapperTest {
     private SubWorkflowTaskMapper subWorkflowTaskMapper;
     private ParametersUtils parametersUtils;
     private DeciderService deciderService;
+    private IDGenerator idGenerator;
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
@@ -55,6 +56,7 @@ public class SubWorkflowTaskMapperTest {
         MetadataDAO metadataDAO = mock(MetadataDAO.class);
         subWorkflowTaskMapper = new SubWorkflowTaskMapper(parametersUtils, metadataDAO);
         deciderService = mock(DeciderService.class);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -91,7 +93,7 @@ public class SubWorkflowTaskMapperTest {
                         .withWorkflowTask(workflowTask)
                         .withTaskInput(taskInput)
                         .withRetryCount(0)
-                        .withTaskId(IDGenerator.generate())
+                        .withTaskId(idGenerator.generate())
                         .withDeciderService(deciderService)
                         .build();
 
@@ -142,7 +144,7 @@ public class SubWorkflowTaskMapperTest {
                         .withWorkflowTask(workflowTask)
                         .withTaskInput(taskInput)
                         .withRetryCount(0)
-                        .withTaskId(IDGenerator.generate())
+                        .withTaskId(new IDGenerator().generate())
                         .withDeciderService(deciderService)
                         .build();
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 public class SwitchTaskMapperTest {
 
+    private IDGenerator idGenerator;
     private ParametersUtils parametersUtils;
     private DeciderService deciderService;
     // Subject
@@ -80,6 +81,7 @@ public class SwitchTaskMapperTest {
     @Before
     public void setUp() {
         parametersUtils = new ParametersUtils(objectMapper);
+        idGenerator = new IDGenerator();
 
         ip1 = new HashMap<>();
         ip1.put("p1", "${workflow.input.param1}");
@@ -149,7 +151,7 @@ public class SwitchTaskMapperTest {
 
         TaskModel theTask = new TaskModel();
         theTask.setReferenceTaskName("Foo");
-        theTask.setTaskId(IDGenerator.generate());
+        theTask.setTaskId(idGenerator.generate());
 
         when(deciderService.getTasksToBeScheduled(workflowModel, task2, 0, null))
                 .thenReturn(Collections.singletonList(theTask));
@@ -160,7 +162,7 @@ public class SwitchTaskMapperTest {
                         .withWorkflowTask(switchTask)
                         .withTaskInput(input)
                         .withRetryCount(0)
-                        .withTaskId(IDGenerator.generate())
+                        .withTaskId(idGenerator.generate())
                         .withDeciderService(deciderService)
                         .build();
 
@@ -217,7 +219,7 @@ public class SwitchTaskMapperTest {
 
         TaskModel theTask = new TaskModel();
         theTask.setReferenceTaskName("Foo");
-        theTask.setTaskId(IDGenerator.generate());
+        theTask.setTaskId(idGenerator.generate());
 
         when(deciderService.getTasksToBeScheduled(workflowModel, task2, 0, null))
                 .thenReturn(Collections.singletonList(theTask));
@@ -228,7 +230,7 @@ public class SwitchTaskMapperTest {
                         .withWorkflowTask(switchTask)
                         .withTaskInput(input)
                         .withRetryCount(0)
-                        .withTaskId(IDGenerator.generate())
+                        .withTaskId(idGenerator.generate())
                         .withDeciderService(deciderService)
                         .build();
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapperTest.java
@@ -43,7 +43,7 @@ public class TerminateTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setType(TaskType.TASK_TYPE_TERMINATE);
 
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/UserDefinedTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/UserDefinedTaskMapperTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.mock;
 
 public class UserDefinedTaskMapperTest {
 
+    private IDGenerator idGenerator;
+
     private UserDefinedTaskMapper userDefinedTaskMapper;
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
@@ -45,6 +47,7 @@ public class UserDefinedTaskMapperTest {
         ParametersUtils parametersUtils = mock(ParametersUtils.class);
         MetadataDAO metadataDAO = mock(MetadataDAO.class);
         userDefinedTaskMapper = new UserDefinedTaskMapper(parametersUtils, metadataDAO);
+        idGenerator = new IDGenerator();
     }
 
     @Test
@@ -54,8 +57,8 @@ public class UserDefinedTaskMapperTest {
         workflowTask.setName("user_task");
         workflowTask.setType(TaskType.USER_DEFINED.name());
         workflowTask.setTaskDefinition(new TaskDef("user_task"));
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();
@@ -86,8 +89,8 @@ public class UserDefinedTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("user_task");
         workflowTask.setType(TaskType.USER_DEFINED.name());
-        String taskId = IDGenerator.generate();
-        String retriedTaskId = IDGenerator.generate();
+        String taskId = idGenerator.generate();
+        String retriedTaskId = idGenerator.generate();
 
         WorkflowModel workflow = new WorkflowModel();
         WorkflowDef workflowDef = new WorkflowDef();

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapperTest.java
@@ -40,7 +40,7 @@ public class WaitTaskMapperTest {
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("Wait_task");
         workflowTask.setType(TaskType.WAIT.name());
-        String taskId = IDGenerator.generate();
+        String taskId = new IDGenerator().generate();
 
         ParametersUtils parametersUtils = mock(ParametersUtils.class);
         WorkflowModel workflow = new WorkflowModel();

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestDoWhile.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestDoWhile.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,6 +29,7 @@ import com.netflix.conductor.core.execution.DeciderService;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.listener.WorkflowStatusListener;
 import com.netflix.conductor.core.metadata.MetadataMapperService;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
@@ -101,7 +101,8 @@ public class TestDoWhile {
                                 properties,
                                 executionLockService,
                                 systemTaskRegistry,
-                                parametersUtils, new IDGenerator()));
+                                parametersUtils,
+                                new IDGenerator()));
         WorkflowTask loopWorkflowTask1 = new WorkflowTask();
         loopWorkflowTask1.setTaskReferenceName("task1");
         loopWorkflowTask1.setName("task1");

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestDoWhile.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestDoWhile.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -100,7 +101,7 @@ public class TestDoWhile {
                                 properties,
                                 executionLockService,
                                 systemTaskRegistry,
-                                parametersUtils));
+                                parametersUtils, new IDGenerator()));
         WorkflowTask loopWorkflowTask1 = new WorkflowTask();
         loopWorkflowTask1.setTaskReferenceName("task1");
         loopWorkflowTask1.setName("task1");

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/utils/TestUtils.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/utils/TestUtils.java
@@ -31,7 +31,7 @@ public class TestUtils {
             ObjectMapper objectMapper, String resourceFileName) {
         try {
             String content = loadJsonResource(resourceFileName);
-            String workflowId = IDGenerator.generate();
+            String workflowId = new IDGenerator().generate();
             content = content.replace(WORKFLOW_INSTANCE_ID_PLACEHOLDER, workflowId);
 
             return objectMapper.readValue(content, WorkflowSummary.class);
@@ -43,7 +43,7 @@ public class TestUtils {
     public static TaskSummary loadTaskSnapshot(ObjectMapper objectMapper, String resourceFileName) {
         try {
             String content = loadJsonResource(resourceFileName);
-            String workflowId = IDGenerator.generate();
+            String workflowId = new IDGenerator().generate();
             content = content.replace(WORKFLOW_INSTANCE_ID_PLACEHOLDER, workflowId);
 
             return objectMapper.readValue(content, TaskSummary.class);

--- a/es7-persistence/src/test/java/com/netflix/conductor/es7/utils/TestUtils.java
+++ b/es7-persistence/src/test/java/com/netflix/conductor/es7/utils/TestUtils.java
@@ -30,7 +30,7 @@ public class TestUtils {
             ObjectMapper objectMapper, String resourceFileName) {
         try {
             String content = loadJsonResource(resourceFileName);
-            String workflowId = IDGenerator.generate();
+            String workflowId = new IDGenerator().generate();
             content = content.replace(WORKFLOW_INSTANCE_ID_PLACEHOLDER, workflowId);
 
             return objectMapper.readValue(content, WorkflowSummary.class);
@@ -42,7 +42,7 @@ public class TestUtils {
     public static TaskSummary loadTaskSnapshot(ObjectMapper objectMapper, String resourceFileName) {
         try {
             String content = loadJsonResource(resourceFileName);
-            String workflowId = IDGenerator.generate();
+            String workflowId = new IDGenerator().generate();
             content = content.replace(WORKFLOW_INSTANCE_ID_PLACEHOLDER, workflowId);
 
             return objectMapper.readValue(content, TaskSummary.class);

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -38,11 +38,11 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:${revProtoBuf}"
+        artifact = "com.google.protobuf:protoc:${revProtoBuf}:osx-x86_64"
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:${revGrpc}"
+            artifact = "io.grpc:protoc-gen-grpc-java:${revGrpc}:osx-x86_64"
         }
     }
     generateProtoTasks {

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -38,11 +38,11 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:${revProtoBuf}:osx-x86_64"
+        artifact = "com.google.protobuf:protoc:${revProtoBuf}"
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:${revGrpc}:osx-x86_64"
+            artifact = "io.grpc:protoc-gen-grpc-java:${revGrpc}"
         }
     }
     generateProtoTasks {

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -745,28 +745,6 @@ public abstract class AbstractProtoMapper {
         return to;
     }
 
-    public TaskDefPb.TaskDef.RetryLogic toProto(TaskDef.RetryLogic from) {
-        TaskDefPb.TaskDef.RetryLogic to;
-        switch (from) {
-            case FIXED: to = TaskDefPb.TaskDef.RetryLogic.FIXED; break;
-            case EXPONENTIAL_BACKOFF: to = TaskDefPb.TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
-            case LINEAR_BACKOFF: to = TaskDefPb.TaskDef.RetryLogic.LINEAR_BACKOFF; break;
-            default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
-        }
-        return to;
-    }
-
-    public TaskDef.RetryLogic fromProto(TaskDefPb.TaskDef.RetryLogic from) {
-        TaskDef.RetryLogic to;
-        switch (from) {
-            case FIXED: to = TaskDef.RetryLogic.FIXED; break;
-            case EXPONENTIAL_BACKOFF: to = TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
-            case LINEAR_BACKOFF: to = TaskDef.RetryLogic.LINEAR_BACKOFF; break;
-            default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
-        }
-        return to;
-    }
-
     public TaskDefPb.TaskDef.TimeoutPolicy toProto(TaskDef.TimeoutPolicy from) {
         TaskDefPb.TaskDef.TimeoutPolicy to;
         switch (from) {
@@ -784,6 +762,28 @@ public abstract class AbstractProtoMapper {
             case RETRY: to = TaskDef.TimeoutPolicy.RETRY; break;
             case TIME_OUT_WF: to = TaskDef.TimeoutPolicy.TIME_OUT_WF; break;
             case ALERT_ONLY: to = TaskDef.TimeoutPolicy.ALERT_ONLY; break;
+            default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
+        }
+        return to;
+    }
+
+    public TaskDefPb.TaskDef.RetryLogic toProto(TaskDef.RetryLogic from) {
+        TaskDefPb.TaskDef.RetryLogic to;
+        switch (from) {
+            case FIXED: to = TaskDefPb.TaskDef.RetryLogic.FIXED; break;
+            case EXPONENTIAL_BACKOFF: to = TaskDefPb.TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
+            case LINEAR_BACKOFF: to = TaskDefPb.TaskDef.RetryLogic.LINEAR_BACKOFF; break;
+            default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
+        }
+        return to;
+    }
+
+    public TaskDef.RetryLogic fromProto(TaskDefPb.TaskDef.RetryLogic from) {
+        TaskDef.RetryLogic to;
+        switch (from) {
+            case FIXED: to = TaskDef.RetryLogic.FIXED; break;
+            case EXPONENTIAL_BACKOFF: to = TaskDef.RetryLogic.EXPONENTIAL_BACKOFF; break;
+            case LINEAR_BACKOFF: to = TaskDef.RetryLogic.LINEAR_BACKOFF; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -8,15 +8,15 @@ option java_outer_classname = "TaskDefPb";
 option go_package = "github.com/netflix/conductor/client/gogrpc/conductor/model";
 
 message TaskDef {
-    enum RetryLogic {
-        FIXED = 0;
-        EXPONENTIAL_BACKOFF = 1;
-        LINEAR_BACKOFF = 2;
-    }
     enum TimeoutPolicy {
         RETRY = 0;
         TIME_OUT_WF = 1;
         ALERT_ONLY = 2;
+    }
+    enum RetryLogic {
+        FIXED = 0;
+        EXPONENTIAL_BACKOFF = 1;
+        LINEAR_BACKOFF = 2;
     }
     string name = 1;
     string description = 2;

--- a/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/config/PostgresPayloadConfiguration.java
+++ b/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/config/PostgresPayloadConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.postgres.storage.PostgresPayloadStorage;
 
 @Configuration(proxyBeanMethods = false)
@@ -70,7 +71,7 @@ public class PostgresPayloadConfiguration {
 
     @Bean
     public ExternalPayloadStorage postgresExternalPayloadStorage(
-            PostgresPayloadProperties properties) {
+            IDGenerator idGenerator, PostgresPayloadProperties properties) {
         DataSource dataSource =
                 DataSourceBuilder.create()
                         .driverClassName("org.postgresql.Driver")
@@ -78,6 +79,6 @@ public class PostgresPayloadConfiguration {
                         .username(properties.getUsername())
                         .password(properties.getPassword())
                         .build();
-        return new PostgresPayloadStorage(properties, dataSource);
+        return new PostgresPayloadStorage(idGenerator, properties, dataSource);
     }
 }

--- a/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
+++ b/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
@@ -41,8 +41,11 @@ public class PostgresPayloadStorage implements ExternalPayloadStorage {
     private final DataSource postgresDataSource;
     private final String tableName;
     private final String conductorUrl;
+    private final IDGenerator idGenerator;
 
-    public PostgresPayloadStorage(PostgresPayloadProperties properties, DataSource dataSource) {
+    public PostgresPayloadStorage(
+            IDGenerator idGenerator, PostgresPayloadProperties properties, DataSource dataSource) {
+        this.idGenerator = idGenerator;
         tableName = properties.getTableName();
         conductorUrl = properties.getConductorUrl();
         this.postgresDataSource = dataSource;
@@ -64,7 +67,7 @@ public class PostgresPayloadStorage implements ExternalPayloadStorage {
         if (StringUtils.isNotBlank(path)) {
             objectKey = path;
         } else {
-            objectKey = IDGenerator.generate() + ".json";
+            objectKey = idGenerator.generate() + ".json";
         }
         String uri = conductorUrl + "/api/external/postgres/" + objectKey;
         externalStorageLocation.setUri(uri);

--- a/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
+++ b/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +62,7 @@ public class PostgresPayloadStorageTest {
         testPostgres = new PostgresPayloadTestUtil(postgreSQLContainer);
         executionPostgres =
                 new PostgresPayloadStorage(
+                        new IDGenerator(),
                         testPostgres.getTestProperties(), testPostgres.getDataSource());
     }
 

--- a/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
+++ b/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
@@ -20,7 +20,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import com.netflix.conductor.core.utils.IDGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +30,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.core.utils.IDGenerator;
 
 import static org.junit.Assert.assertEquals;
 
@@ -63,7 +63,8 @@ public class PostgresPayloadStorageTest {
         executionPostgres =
                 new PostgresPayloadStorage(
                         new IDGenerator(),
-                        testPostgres.getTestProperties(), testPostgres.getDataSource());
+                        testPostgres.getTestProperties(),
+                        testPostgres.getDataSource());
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
IDGenerator is a fixed class today with a static generate() method to generate ID for workflows and tasks.
This makes it impossible to override the id generation logic for cases where users want to have a separate scheme for id generation.

This change allows users to override the IDGenerator class while keeping the default implementation intact.


_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
