### PR TITLE
Added dedicated methods to serialize/deserialize input/output data

### DIFF
--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.protobuf.Any;
 
 public class TaskModel {
@@ -68,8 +69,6 @@ public class TaskModel {
     private String taskType;
 
     private Status status;
-
-    private Map<String, Object> inputData = new HashMap<>();
 
     private String referenceTaskName;
 
@@ -119,8 +118,6 @@ public class TaskModel {
 
     private String workerId;
 
-    private Map<String, Object> outputData = new HashMap<>();
-
     private WorkflowTask workflowTask;
 
     private String domain;
@@ -159,6 +156,10 @@ public class TaskModel {
 
     @JsonIgnore private Map<String, Object> outputPayload = new HashMap<>();
 
+    @JsonIgnore private Map<String, Object> inputData = new HashMap<>();
+
+    @JsonIgnore private Map<String, Object> outputData = new HashMap<>();
+
     public String getTaskType() {
         return taskType;
     }
@@ -175,15 +176,31 @@ public class TaskModel {
         this.status = status;
     }
 
+    @JsonIgnore
     public Map<String, Object> getInputData() {
         return externalInputPayloadStoragePath != null ? inputPayload : inputData;
     }
 
+    @JsonIgnore
     public void setInputData(Map<String, Object> inputData) {
         if (inputData == null) {
             inputData = new HashMap<>();
         }
         this.inputData = inputData;
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @JsonProperty("inputData")
+    @Deprecated
+    public void setRawInputData(Map<String, Object> inputData) {
+        setInputData(inputData);
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @JsonProperty("inputData")
+    @Deprecated
+    public Map<String, Object> getRawInputData() {
+        return inputData;
     }
 
     public String getReferenceTaskName() {
@@ -365,15 +382,31 @@ public class TaskModel {
         this.workerId = workerId;
     }
 
+    @JsonIgnore
     public Map<String, Object> getOutputData() {
         return externalOutputPayloadStoragePath != null ? outputPayload : outputData;
     }
 
+    @JsonIgnore
     public void setOutputData(Map<String, Object> outputData) {
         if (outputData == null) {
             outputData = new HashMap<>();
         }
         this.outputData = outputData;
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @JsonProperty("outputData")
+    @Deprecated
+    public void setRawOutputData(Map<String, Object> inputData) {
+        setOutputData(inputData);
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @JsonProperty("outputData")
+    @Deprecated
+    public Map<String, Object> getRawOutputData() {
+        return outputData;
     }
 
     public WorkflowTask getWorkflowTask() {

--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -22,6 +22,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.Workflow;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
 public class WorkflowModel {
@@ -63,14 +64,6 @@ public class WorkflowModel {
 
     private List<TaskModel> tasks = new LinkedList<>();
 
-    private Map<String, Object> input = new HashMap<>();
-
-    private Map<String, Object> output = new HashMap<>();
-
-    @JsonIgnore private Map<String, Object> inputPayload = new HashMap<>();
-
-    @JsonIgnore private Map<String, Object> outputPayload = new HashMap<>();
-
     private String correlationId;
 
     private String reRunFromWorkflowId;
@@ -109,6 +102,14 @@ public class WorkflowModel {
     private String failedTaskId;
 
     private Status previousStatus;
+
+    @JsonIgnore private Map<String, Object> input = new HashMap<>();
+
+    @JsonIgnore private Map<String, Object> output = new HashMap<>();
+
+    @JsonIgnore private Map<String, Object> inputPayload = new HashMap<>();
+
+    @JsonIgnore private Map<String, Object> outputPayload = new HashMap<>();
 
     public Status getPreviousStatus() {
         return previousStatus;
@@ -170,10 +171,12 @@ public class WorkflowModel {
         this.tasks = tasks;
     }
 
+    @JsonIgnore
     public Map<String, Object> getInput() {
         return externalInputPayloadStoragePath != null ? inputPayload : input;
     }
 
+    @JsonIgnore
     public void setInput(Map<String, Object> input) {
         if (input == null) {
             input = new HashMap<>();
@@ -181,15 +184,45 @@ public class WorkflowModel {
         this.input = input;
     }
 
+    @JsonIgnore
     public Map<String, Object> getOutput() {
         return externalOutputPayloadStoragePath != null ? outputPayload : output;
     }
 
+    @JsonIgnore
     public void setOutput(Map<String, Object> output) {
         if (output == null) {
             output = new HashMap<>();
         }
         this.output = output;
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @Deprecated
+    @JsonProperty("input")
+    public Map<String, Object> getRawInput() {
+        return input;
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @Deprecated
+    @JsonProperty("input")
+    public void setRawInput(Map<String, Object> input) {
+        setInput(input);
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @Deprecated
+    @JsonProperty("output")
+    public Map<String, Object> getRawOutput() {
+        return output;
+    }
+
+    /** @deprecated Used only for JSON serialization and deserialization. */
+    @Deprecated
+    @JsonProperty("output")
+    public void setRawOutput(Map<String, Object> output) {
+        setOutput(output);
     }
 
     public String getCorrelationId() {

--- a/core/src/test/groovy/com/netflix/conductor/model/TaskModelSpec.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/model/TaskModelSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.model
+
+import com.netflix.conductor.common.config.ObjectMapperProvider
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TaskModelSpec extends Specification {
+
+    @Subject
+    TaskModel taskModel
+
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper()
+
+    def setup() {
+        taskModel = new TaskModel()
+    }
+
+    def "check inputData serialization"() {
+        given:
+        String path = "task/input/${UUID.randomUUID()}.json"
+        taskModel.addInput(['key1': 'value1', 'key2': 'value2'])
+        taskModel.externalizeInput(path)
+
+        when:
+        def json = objectMapper.writeValueAsString(taskModel)
+        println(json)
+
+        then:
+        json != null
+        JsonNode node = objectMapper.readTree(json)
+        node.path("inputData").isEmpty()
+        node.path("externalInputPayloadStoragePath").isTextual()
+    }
+
+    def "check outputData serialization"() {
+        given:
+        String path = "task/output/${UUID.randomUUID()}.json"
+        taskModel.addOutput(['key1': 'value1', 'key2': 'value2'])
+        taskModel.externalizeOutput(path)
+
+        when:
+        def json = objectMapper.writeValueAsString(taskModel)
+        println(json)
+
+        then:
+        json != null
+        JsonNode node = objectMapper.readTree(json)
+        node.path("outputData").isEmpty()
+        node.path("externalOutputPayloadStoragePath").isTextual()
+    }
+}

--- a/core/src/test/groovy/com/netflix/conductor/model/WorkflowModelSpec.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/model/WorkflowModelSpec.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.model
+
+import com.netflix.conductor.common.config.ObjectMapperProvider
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+import spock.lang.Subject
+
+class WorkflowModelSpec extends Specification {
+
+    @Subject
+    WorkflowModel workflowModel
+
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper()
+
+    def setup() {
+        def workflowDef = new WorkflowDef(name: "test def name", version: 1)
+        workflowModel = new WorkflowModel(workflowDefinition: workflowDef)
+    }
+
+    def "check input serialization"() {
+        given:
+        String path = "task/input/${UUID.randomUUID()}.json"
+        workflowModel.input = ['key1': 'value1', 'key2': 'value2']
+        workflowModel.externalizeInput(path)
+
+        when:
+        def json = objectMapper.writeValueAsString(workflowModel)
+        println(json)
+
+        then:
+        json != null
+        JsonNode node = objectMapper.readTree(json)
+        node.path("input").isEmpty()
+        node.path("externalInputPayloadStoragePath").isTextual()
+    }
+
+    def "check output serialization"() {
+        given:
+        String path = "task/output/${UUID.randomUUID()}.json"
+        workflowModel.output = ['key1': 'value1', 'key2': 'value2']
+        workflowModel.externalizeOutput(path)
+
+        when:
+        def json = objectMapper.writeValueAsString(workflowModel)
+        println(json)
+
+        then:
+        json != null
+        JsonNode node = objectMapper.readTree(json)
+        node.path("output").isEmpty()
+        node.path("externalOutputPayloadStoragePath").isTextual()
+    }
+}


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Introduced methods for reading input and output data during the serialization process. The existing getters have logic to check to where the payload exists and return them. During serialization, the getter returns the large payload which is then persisted along with the execution data._

Issue #2899

Alternatives considered
----

This is a temporary patch to fix the issue introduced in 3.6.0 and 3.6.1. A more elaborate fix is to refactor all references of `getInput` or `getOutput` methods to use a new method and remove the additional logic (of checking the external storage path) from them. 
