### PR TITLE
Fix message delivery tag to be of long type (and not UUID)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
@@ -63,7 +63,7 @@ public class Event extends WorkflowSystemTask {
 
         try {
             String payloadJson = objectMapper.writeValueAsString(payload);
-            Message message = new Message(task.getTaskId(), payloadJson, task.getTaskId());
+            Message message = new Message(task.getTaskId(), payloadJson, Integer.toString(task.getTaskId().hashCode()));
             ObservableQueue queue = getQueue(workflow, task);
             queue.publish(List.of(message));
             LOGGER.debug("Published message:{} to queue:{}", message.getId(), queue.getName());
@@ -106,7 +106,7 @@ public class Event extends WorkflowSystemTask {
 
     @Override
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
-        Message message = new Message(task.getTaskId(), null, task.getTaskId());
+        Message message = new Message(task.getTaskId(), null, Integer.toString(task.getTaskId().hashCode()));
         ObservableQueue queue = getQueue(workflow, task);
         queue.ack(List.of(message));
     }

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/tasks/EventSpec.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/tasks/EventSpec.groovy
@@ -294,7 +294,7 @@ class EventSpec extends Specification {
     private void verifyMessage(Message expectedMessage, TaskModel task) {
         assert expectedMessage != null
         assert expectedMessage.id == task.taskId
-        assert expectedMessage.receipt == task.taskId
+        assert expectedMessage.receipt == Integer.toString(task.taskId.hashCode())
         assert expectedMessage.payload == payloadJSON
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Issue #2927 
Fix message delivery tag to be of long type (and not GUID) since can be parsed later for ack on a message, on AMQPObservableQueue class -> ack method -> chn.basicAck(Long.parseLong(message.getReceipt()), false)

