### PR TITLE
Reinstated the null check for TaskModel

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -449,7 +449,9 @@ public class ExecutionDAOFacade {
 
     public TaskModel getTaskModel(String taskId) {
         TaskModel taskModel = getTaskFromDatastore(taskId);
-        populateTaskData(taskModel);
+        if (taskModel != null) {
+            populateTaskData(taskModel);
+        }
         return taskModel;
     }
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_In ExecutionDAOFacade.getTaskModel(), it is possible in certain scenarios for TaskModel from the datastore to be null. Added a null check so callers upstream can appropriately handle the error_

Issue #2926 

Alternatives considered
----

_None_
