### PR TITLE
Fix NPE when header values are null

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/tasks/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/tasks/http/HttpTask.java
@@ -154,7 +154,11 @@ public class HttpTask extends WorkflowSystemTask {
         headers.setContentType(MediaType.valueOf(input.getContentType()));
         headers.setAccept(Collections.singletonList(MediaType.valueOf(input.getAccept())));
 
-        input.headers.forEach((key, value) -> headers.add(key, value.toString()));
+        input.headers.forEach((key, value) -> {
+            if (value != null) {
+                headers.add(key, value.toString());
+            }
+        });
 
         HttpEntity<Object> request = new HttpEntity<>(input.getBody(), headers);
 


### PR DESCRIPTION
This happens to our workflow with optional headers

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Fix NPE when optional headers like below are not provided.
```json
"headers": {
    "header1": "${workflow.input.header1}"
}
```

Alternatives considered
----
No alternatives considered
