### PR TITLE
Redis password authentication support

### DIFF
--- a/docs/docs/how-tos/redis.md
+++ b/docs/docs/how-tos/redis.md
@@ -1,0 +1,38 @@
+# Redis Configuration
+
+By default conductor runs with an in-memory Redis mock. However, you
+can change the configuration by setting the properties `conductor.db.type` and `conductor.redis.hosts`.
+
+## `conductor.db.type`
+
+| Value                          | Description                                                                            |
+|--------------------------------|----------------------------------------------------------------------------------------|
+| dynomite                       | Dynomite Cluster. Dynomite is a proxy layer that provides sharding and replication.    |
+| memory                         | Uses an in-memory Redis mock. Should be used only for development and testing purposes.|
+| redis_cluster                  | Redis Cluster configuration.                                                           |
+| redis_sentinel                 | Redis Sentinel configuration.                                                          |
+| redis_standalone               | Redis Standalone configuration.                                                        |
+
+
+
+## `conductor.redis.hosts`
+
+Expected format is `host:port:rack` separated by semicolon, e.g.: 
+
+```properties
+conductor.redis.hosts=host0:6379:us-east-1c;host1:6379:us-east-1c;host2:6379:us-east-1c
+```
+
+### Auth Support
+
+Password authentication is supported. The password should be set as the 4th param of the first host `host:port:rack:password`, e.g.:
+
+```properties
+conductor.redis.hosts=host0:6379:us-east-1c:my_str0ng_pazz;host1:6379:us-east-1c;host2:6379:us-east-1c
+```
+
+
+**Notes**
+
+- In a cluster, all nodes use the same password.
+- In a sentinel configuration, sentinels and redis nodes use the same password.

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -12,24 +12,34 @@
  */
 package com.netflix.conductor.redis.config;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.redis.jedis.JedisCluster;
+import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
 
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.JedisCommands;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "conductor.db.type", havingValue = "redis_cluster")
 public class RedisClusterConfiguration extends JedisCommandsConfigurer {
+
+    private static final Logger log = LoggerFactory.getLogger(JedisCommandsConfigurer.class);
+
+    // Same as redis.clients.jedis.BinaryJedisCluster
+    protected static final int DEFAULT_MAX_ATTEMPTS = 5;
 
     @Override
     protected JedisCommands createJedisCommands(
@@ -43,7 +53,25 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
                 hostSupplier.getHosts().stream()
                         .map(h -> new HostAndPort(h.getHostName(), h.getPort()))
                         .collect(Collectors.toSet());
-        return new JedisCluster(
-                new redis.clients.jedis.JedisCluster(hosts, genericObjectPoolConfig));
+        String password = getPassword(hostSupplier.getHosts());
+
+        if (password != null) {
+            log.info("Connecting to Redis Cluster with AUTH");
+            return new JedisCluster(
+                    new redis.clients.jedis.JedisCluster(
+                            hosts,
+                            Protocol.DEFAULT_TIMEOUT,
+                            Protocol.DEFAULT_TIMEOUT,
+                            DEFAULT_MAX_ATTEMPTS,
+                            password,
+                            genericObjectPoolConfig));
+        } else {
+            return new JedisCluster(
+                    new redis.clients.jedis.JedisCluster(hosts, genericObjectPoolConfig));
+        }
+    }
+
+    private String getPassword(List<Host> hosts) {
+        return hosts.isEmpty() ? null : hosts.get(0).getPassword();
     }
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
@@ -25,6 +25,7 @@ import com.netflix.dyno.connectionpool.TokenMapSupplier;
 
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.JedisCommands;
 
 @Configuration(proxyBeanMethods = false)
@@ -44,6 +45,20 @@ public class RedisStandaloneConfiguration extends JedisCommandsConfigurer {
         config.setMaxTotal(properties.getMaxConnectionsPerHost());
         log.info("Starting conductor server using redis_standalone.");
         Host host = hostSupplier.getHosts().get(0);
-        return new JedisStandalone(new JedisPool(config, host.getHostName(), host.getPort()));
+        return new JedisStandalone(getJedisPool(config, host));
+    }
+
+    private JedisPool getJedisPool(JedisPoolConfig config, Host host) {
+        if (host.getPassword() != null) {
+            log.info("Connecting to Redis Standalone with AUTH");
+            return new JedisPool(
+                    config,
+                    host.getHostName(),
+                    host.getPort(),
+                    Protocol.DEFAULT_TIMEOUT,
+                    host.getPassword());
+        } else {
+            return new JedisPool(config, host.getHostName(), host.getPort());
+        }
     }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -18,8 +18,9 @@ conductor.db.type=memory
 
 conductor.indexing.enabled=false
 
-#Dynomite Cluster details.
+#Redis configuration details.
 #format is host:port:rack separated by semicolon
+#Auth is supported. Password is taken from host[0]. format: host:port:rack:password
 conductor.redis.hosts=host1:port:rack;host2:port:rack:host3:port:rack
 
 #namespace for the keys stored in Dynomite/Redis


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Added Redis password authentication support for `conductor.db.type`
- `redis_standalone` 
- `redis_cluster`
- `redis_sentinel`

Issue #2533

---
The password is set as the 4th param in the host configuration. E.g.:

```properties
conductor.redis.hosts=localhost:6379:us-east-1c:my_str0ng_pazz
```

For Cluster and Sentinel configuration the password from the first host is used. 

In Sentinel configuration sentinels and redis nodes use the same password.

![image](https://user-images.githubusercontent.com/4755315/165292813-05408cd1-7187-4a31-882b-f3ed45afc70c.png)

Alternatives considered
----

Considered changing `RedisProperties` to add a new password property un `conductor.redis`. That would have made it more explicit but since `host.getPassword()` already exists it seems like an OK alternative if documented properly.
