### PR TITLE
Fix export ConductorHttpClientConfig fields

### DIFF
--- a/polyglot-clients/go/conductorhttpclient.go
+++ b/polyglot-clients/go/conductorhttpclient.go
@@ -34,17 +34,17 @@ func NewConductorHttpClient(baseUrl string) *ConductorHttpClient {
 }
 
 type ConductorHttpClientConfig struct {
-	baseUrl     string
-	bearerToken *string
+	BaseUrl     string
+	BearerToken *string
 }
 
 func NewConductorHttpClientWithConfig(config ConductorHttpClientConfig) *ConductorHttpClient {
 	conductorClient := new(ConductorHttpClient)
 	headers := map[string]string{"Content-Type": "application/json", "Accept": "application/json"}
-	if config.bearerToken != nil {
-		headers["Authorization"] = fmt.Sprintf("Bearer %s", *config.bearerToken)
+	if config.BearerToken != nil {
+		headers["Authorization"] = fmt.Sprintf("Bearer %s", *config.BearerToken)
 	}
-	httpClient := httpclient.NewHttpClient(config.baseUrl, headers, true)
+	httpClient := httpclient.NewHttpClient(config.BaseUrl, headers, true)
 	conductorClient.httpClient = httpClient
 	return conductorClient
 }

--- a/polyglot-clients/go/conductorworker.go
+++ b/polyglot-clients/go/conductorworker.go
@@ -47,6 +47,16 @@ func NewConductorWorker(baseUrl string, threadCount int, pollingInterval int) *C
 	return conductorWorker
 }
 
+// NewConductorWorkerWithConfig Create a new Conductor worker with configuration
+func NewConductorWorkerWithConfig(cfg ConductorHttpClientConfig, threadCount int, pollingInterval int) *ConductorWorker {
+	conductorWorker := new(ConductorWorker)
+	conductorWorker.ThreadCount = threadCount
+	conductorWorker.PollingInterval = pollingInterval
+	conductorHttpClient := NewConductorHttpClientWithConfig(cfg)
+	conductorWorker.ConductorHttpClient = conductorHttpClient
+	return conductorWorker
+}
+
 func (c *ConductorWorker) Execute(t *task.Task, executeFunction func(t *task.Task) (*task.TaskResult, error)) {
 	taskResult, err := executeFunction(t)
 	if taskResult == nil {


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
When worker initialized with config `ConductorHttpClientConfig` struct fileds `baseUrl`, and `bearerToken` are private, and can only be accessed from the package it is declared in.
This change:
- exports `baseUrl` and `bearerToken` fields
- add new worker constructor function `NewConductorWorkerWithConfig`

Alternatives considered
----

_Describe alternative implementation you have considered_
