### PR TITLE
Fix for NPE when header values are null

### DIFF
--- a/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
+++ b/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
@@ -155,11 +155,12 @@ public class HttpTask extends WorkflowSystemTask {
         headers.setContentType(MediaType.valueOf(input.getContentType()));
         headers.setAccept(Collections.singletonList(MediaType.valueOf(input.getAccept())));
 
-        input.headers.forEach((key, value) -> {
-            if (value != null) {
-                headers.add(key, value.toString());
-            }
-        });
+        input.headers.forEach(
+                (key, value) -> {
+                    if (value != null) {
+                        headers.add(key, value.toString());
+                    }
+                });
 
         HttpEntity<Object> request = new HttpEntity<>(input.getBody(), headers);
 

--- a/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
+++ b/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
@@ -155,7 +155,11 @@ public class HttpTask extends WorkflowSystemTask {
         headers.setContentType(MediaType.valueOf(input.getContentType()));
         headers.setAccept(Collections.singletonList(MediaType.valueOf(input.getAccept())));
 
-        input.headers.forEach((key, value) -> headers.add(key, value.toString()));
+        input.headers.forEach((key, value) -> {
+            if (value != null) {
+                headers.add(key, value.toString());
+            }
+        });
 
         HttpEntity<Object> request = new HttpEntity<>(input.getBody(), headers);
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Fix NPE when optional headers like below are not provided.

```
"headers": {
    "header1": "${workflow.input.header1}"
}
```
_Describe the new behavior from this PR, and why it's needed_
Issue #2884 
In the new version of conductor HTTP tasks fail with NPE is a header value is not provided. As HTTP task is generic it is a good practice to support header values which are defined in workflow but not sent while making a call to execute the workflow.
Also its good to note that this feature was working in 2.x version of conductor. 

Alternatives considered
----
No alternatives considered

