### PR TITLE
only allow rerun on terminal workflows

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1823,6 +1823,13 @@ public class WorkflowExecutor {
 
         // Get the workflow
         WorkflowModel workflow = executionDAOFacade.getWorkflowModel(workflowId, true);
+        if (!workflow.getStatus().isTerminal()) {
+            String errorMsg =
+                    String.format(
+                            "Workflow: %s is not in terminal state, unable to rerun.", workflow);
+            LOGGER.error(errorMsg);
+            throw new ApplicationException(CONFLICT, errorMsg);
+        }
         updateAndPushParents(workflow, "reran");
 
         // If the task Id is null it implies that the entire workflow has to be rerun

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -197,7 +197,7 @@ public class ExecutionService {
         }
         executionDAOFacade.updateTaskLastPoll(taskType, domain, workerId);
         Monitors.recordTaskPoll(queueName);
-        tasks.stream().forEach(task -> ackTaskReceived(task));
+        tasks.forEach(this::ackTaskReceived);
         return tasks;
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -591,7 +591,7 @@ public class TestWorkflowExecutor {
         workflowDef.setName("testDef");
         workflowDef.setVersion(1);
         workflowDef.setRestartable(true);
-        workflowDef.getTasks().addAll(Collections.singletonList(workflowTask));
+        workflowDef.getTasks().add(workflowTask);
 
         TaskModel task_1 = new TaskModel();
         task_1.setTaskId(UUID.randomUUID().toString());
@@ -1240,6 +1240,18 @@ public class TestWorkflowExecutor {
         assertTrue(workflow.getLastRetriedTime() > 0);
         assertEquals(1, updateWorkflowCalledCounter.get());
         assertEquals(1, updateTasksCalledCounter.get());
+    }
+
+    @Test(expected = ApplicationException.class)
+    public void testRerunNonTerminalWorkflow() {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("testRetryNonTerminalWorkflow");
+        workflow.setStatus(WorkflowModel.Status.RUNNING);
+        when(executionDAOFacade.getWorkflowModel(anyString(), anyBoolean())).thenReturn(workflow);
+
+        RerunWorkflowRequest rerunWorkflowRequest = new RerunWorkflowRequest();
+        rerunWorkflowRequest.setReRunFromWorkflowId(workflow.getWorkflowId());
+        workflowExecutor.rerun(rerunWorkflowRequest);
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Allow rerun only on terminal state workflows
