### PR TITLE
Fix update with large payload task result

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskResult.java
@@ -311,25 +311,4 @@ public class TaskResult {
         result.setStatus(status);
         return result;
     }
-
-    /**
-     * Copy the given task result object
-     *
-     * @return a deep copy of the task result object except the externalOutputPayloadStoragePath
-     *     field
-     */
-    public TaskResult copy() {
-        TaskResult taskResult = new TaskResult();
-        taskResult.setWorkflowInstanceId(workflowInstanceId);
-        taskResult.setTaskId(taskId);
-        taskResult.setReasonForIncompletion(reasonForIncompletion);
-        taskResult.setCallbackAfterSeconds(callbackAfterSeconds);
-        taskResult.setWorkerId(workerId);
-        taskResult.setStatus(status);
-        taskResult.setOutputData(outputData);
-        taskResult.setOutputMessage(outputMessage);
-        taskResult.setLogs(logs);
-        taskResult.setSubWorkflowId(subWorkflowId);
-        return taskResult;
-    }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Fixes a bug where large payload location in task result was not being propagated as part of task result by the client.
