### PR TITLE
Fix: Enable extra task fields in Java-SDK

### DIFF
--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
@@ -205,6 +205,8 @@ public abstract class Task<T> {
         workflowTask.setWorkflowTaskType(type);
         workflowTask.setDescription(description);
         workflowTask.setInputParameters(input);
+        workflowTask.setStartDelay(startDelay);
+        workflowTask.setOptional(optional)
 
         // Let the sub-classes enrich the workflow task before returning back
         updateWorkflowTask(workflowTask);


### PR DESCRIPTION
I have been trying to set the `Start Delay` and `Optional` fields in the Java SDK.  I can't find a whole load of documentation on what the SDK supports, but a quick read through the code seems to suggest the `Start Delay` and `Optional` fields are not copied into the `WorkflowTask`, meaning when I register by Workflows/Tasks, there is no current way to set these values except through the API/UI.

* Enables `Start Delay` field for a Task.
* Enables `Optional` field for a Task.

PLEASE NOTE:

If this is indeed an issue, I will create two new tests which:
* Creates a `Simple Task`, sets the `startDelay` field and asserts against the value given in the workflow to make sure equals the expected value.
* * Creates a `Simple Task`, sets the `optional` field and asserts against the value given in the workflow to make sure equals the expected value.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
