### PR TITLE
[WIP] JSON_JQ inside DO_WHILE task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -78,6 +78,11 @@ public class DoWhile extends WorkflowSystemTask {
             }
         }
         Collection<TaskModel> loopOverTasks = relevantTasks.values();
+
+        // Check for any JSON_JQ task within do-while task.
+        // If yes find all task after json-jq and create dummy task model and add it in relevant task map so that
+        // Loop task does not schedule next iteration abruptly.
+
         LOGGER.debug(
                 "Workflow {} waiting for tasks {} to complete iteration {}",
                 workflow.getWorkflowId(),


### PR DESCRIPTION
Hi @apanicker-nflx  @aravindanr , There is a bug in do-while task when json_jq task is being used as loopOver task.
The reason being, json_jq has written task execution logic as a part of [start](https://github.com/Netflix/conductor/blob/main/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java#L60) method only. So if that is used as one of the loopOver tasks then do-while task wont wait for any task after the json-jq task and schedule a next iteration.
Consider a scenario where loopOver task has three task
```HTTP--> JSON_JQ--> SIMPLE```
Here the do-while task does not wait for SIMPLE task to get scheduled since JSON_JQ start method has execution logic and it immediately completes.  Now there can be two ways to fix this that I can think of,
1. Rename the start method with the execute method.
2. Write logic in do-while for this kind of scenario. I have written a comment that I will put into the code once we finalize the approach.

HTTP task also does same thing but do-while works in that case because http task goes into the queue before even calling the start method. If we make HTTP task sync then this issue we can reproduce with http task also.

cc @v1r3n @evgvain