### PR TITLE
Performance improvements to Decider

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -66,17 +66,6 @@ public class DeciderService {
 
     private final Map<TaskType, TaskMapper> taskMappers;
 
-    private final Predicate<TaskModel> isNonPendingTask =
-            task -> !task.isRetried() && !task.getStatus().equals(SKIPPED) && !task.isExecuted();
-
-    private final Predicate<WorkflowModel> containsSuccessfulTerminateTask =
-            workflow ->
-                    workflow.getTasks().stream()
-                            .anyMatch(
-                                    task ->
-                                            TERMINATE.name().equals(task.getTaskType())
-                                                    && task.getStatus().isTerminal()
-                                                    && task.getStatus().isSuccessful());
 
     public DeciderService(
             IDGenerator idGenerator,

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -14,7 +14,6 @@ package com.netflix.conductor.core.execution;
 
 import java.time.Duration;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -65,7 +64,6 @@ public class DeciderService {
     private final long taskPendingTimeThresholdMins;
 
     private final Map<TaskType, TaskMapper> taskMappers;
-
 
     public DeciderService(
             IDGenerator idGenerator,
@@ -137,17 +135,17 @@ public class DeciderService {
             // Filter the list of tasks and include only tasks that are not retried, not executed
             // marked to be skipped and not part of System tasks that is DECISION, FORK, JOIN
             // This list will be empty for a new workflow being started
-            if(!task.isRetried() && !task.getStatus().equals(SKIPPED) && !task.isExecuted()) {
+            if (!task.isRetried() && !task.getStatus().equals(SKIPPED) && !task.isExecuted()) {
                 pendingTasks.add(task);
             }
 
             // Get all the tasks that have not completed their lifecycle yet
             // This list will be empty for a new workflow
-            if(task.isExecuted()) {
+            if (task.isExecuted()) {
                 executedTaskRefNames.add(task.getReferenceTaskName());
             }
 
-            if(TERMINATE.name().equals(task.getTaskType())
+            if (TERMINATE.name().equals(task.getTaskType())
                     && task.getStatus().isTerminal()
                     && task.getStatus().isSuccessful()) {
                 hasSuccessfulTerminateTask = true;
@@ -418,7 +416,7 @@ public class DeciderService {
                     && task.getStatus().isSuccessful()) {
                 return true;
             }
-            if(!task.isRetried() || !task.isExecuted()) {
+            if (!task.isRetried() || !task.isExecuted()) {
                 nonExecutedTasks.add(task);
             }
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1445,10 +1445,10 @@ public class WorkflowExecutor {
 
     @VisibleForTesting
     List<TaskModel> dedupAndAddTasks(WorkflowModel workflow, List<TaskModel> tasks) {
-        List<String> tasksInWorkflow =
+        Set<String> tasksInWorkflow =
                 workflow.getTasks().stream()
                         .map(task -> task.getReferenceTaskName() + "_" + task.getRetryCount())
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toSet());
 
         List<TaskModel> dedupedTasks =
                 tasks.stream()

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -15,6 +15,8 @@ package com.netflix.conductor.core.reconciliation;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.model.WorkflowModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +75,8 @@ public class WorkflowSweeper {
                 workflowRepairService.verifyAndRepairWorkflowTasks(workflowId);
             }
 
-            boolean done = workflowExecutor.decide(workflowId);
-            if (done) {
+            WorkflowModel workflow = workflowExecutor.decide(workflowId);
+            if (workflow.getStatus().isTerminal()) {
                 queueDAO.remove(DECIDER_QUEUE, workflowId);
                 return;
             }

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -15,8 +15,6 @@ package com.netflix.conductor.core.reconciliation;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import com.netflix.conductor.common.run.Workflow;
-import com.netflix.conductor.model.WorkflowModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +27,7 @@ import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.model.WorkflowModel;
 
 import static com.netflix.conductor.core.config.SchedulerConfiguration.SWEEPER_EXECUTOR_NAME;
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [x] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR

- Remove redundant iterations of the workflow tasks when running decider.  This can have a significant performance penalties at large scale or workflows with thousands of tasks
- checkWorkflowCompletion improvements to reduce iterations and potential nested iterations and reducing the need to check for all the tasks.
- `decide()` method to return  the updated workflowmodel which can be used to inspect the state.  Currently, only way is to do another get operation increasing the number of DAO calls.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
