### PR TITLE
Improve message for payload size threshold calculation

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -122,7 +122,8 @@ public class ExternalPayloadStorageUtils {
             byte[] payloadBytes = byteArrayOutputStream.toByteArray();
             long payloadSize = payloadBytes.length;
 
-            if (payloadSize > maxThreshold * 1024) {
+            final long maxThresholdInBytes = maxThreshold * 1024;
+            if (payloadSize > maxThresholdInBytes) {
                 if (entity instanceof TaskModel) {
                     String errorMsg =
                             String.format(
@@ -130,15 +131,15 @@ public class ExternalPayloadStorageUtils {
                                     payloadSize,
                                     ((TaskModel) entity).getTaskId(),
                                     ((TaskModel) entity).getWorkflowInstanceId(),
-                                    maxThreshold);
+                                    maxThresholdInBytes);
                     failTask(((TaskModel) entity), payloadType, errorMsg);
                 } else {
                     String errorMsg =
                             String.format(
-                                    "The output payload size: %dB of workflow: %s is greater than the permissible limit: %d bytes",
+                                    "The payload size: %d of workflow: %s is greater than the permissible limit: %d bytes",
                                     payloadSize,
                                     ((WorkflowModel) entity).getWorkflowId(),
-                                    maxThreshold);
+                                    maxThresholdInBytes);
                     failWorkflow(((WorkflowModel) entity), payloadType, errorMsg);
                 }
             } else if (payloadSize > threshold * 1024) {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

When we reach the input or output limit for task and workflow the current code returns the limit as the value configured by the user in the properties file which is in Kilobytes. This causes confusion because the actual size calculation is in bytes, so, in the end, we end up in a situation where we are comparing two different units. Also, for the particular message of the workflow limit the word **output** was being used for both scenarios: inpiut limit and output limit. Therefore, this PR also tries to address it by making the message generic for both cases.

cc: @v1r3n 

Alternatives considered
----

_Describe alternative implementation you have considered_
