### PR TITLE
Cap retryCount limit to 10

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -62,6 +63,7 @@ public class TaskDef extends Auditable {
 
     @ProtoField(id = 3)
     @Min(value = 0, message = "TaskDef retryCount: {value} must be >= 0")
+    @Max(value = 10, message = "TaskDef retryCount: {value} must be <=10")
     private int retryCount = 3; // Default
 
     @ProtoField(id = 4)


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Currently, tasks can have an arbitrary retry count. Since conductor stores history of task execution, this means that all retry attempt information is stored and for a large value of retryCount, this means that a large number of task executions are being stored.
The PR limits retryCount to a maximum value of 10 to new Task definitions. Going forward, the validation will also be checked when updating any TaskDef but won't impact reading of existing Tasks.

