### PR TITLE
Set size limit for task exec log and add metrics

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -210,6 +210,9 @@ public class ConductorProperties {
     @DataSizeUnit(DataUnit.KILOBYTES)
     private DataSize maxWorkflowVariablesPayloadSizeThreshold = DataSize.ofKilobytes(256L);
 
+    /** Used to limit the size of task execution logs. */
+    private int taskExecLogSizeLimit = 1000;
+
     public String getStack() {
         return stack;
     }
@@ -508,6 +511,14 @@ public class ConductorProperties {
     public void setMaxWorkflowVariablesPayloadSizeThreshold(
             DataSize maxWorkflowVariablesPayloadSizeThreshold) {
         this.maxWorkflowVariablesPayloadSizeThreshold = maxWorkflowVariablesPayloadSizeThreshold;
+    }
+
+    public int getTaskExecLogSizeLimit() {
+        return taskExecLogSizeLimit;
+    }
+
+    public void setTaskExecLogSizeLimit(int taskExecLogSizeLimit) {
+        this.taskExecLogSizeLimit = taskExecLogSizeLimit;
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -211,7 +211,7 @@ public class ConductorProperties {
     private DataSize maxWorkflowVariablesPayloadSizeThreshold = DataSize.ofKilobytes(256L);
 
     /** Used to limit the size of task execution logs. */
-    private int taskExecLogSizeLimit = 1000;
+    private int taskExecLogSizeLimit = 10;
 
     public String getStack() {
         return stack;

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -571,6 +571,6 @@ public class Monitors {
     }
 
     public static void recordTaskExecLogSize(int val) {
-        gauge(Monitors.classQualifier, "task_exec_log_size", val);
+        gauge(classQualifier, "task_exec_log_size", val);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -569,4 +569,8 @@ public class Monitors {
     public static void recordQueueMessageRepushFromRepairService(String queueName) {
         counter(classQualifier, "queue_message_repushed", "queueName", queueName);
     }
+
+    public static void recordTaskExecLogSize(int val) {
+        gauge(Monitors.classQualifier, "task_exec_log_size", val);
+    }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Set size limit for task exec log and add metrics

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
