### PR TITLE
For INLINE task, reasonForIncompletion field includes the script evaluation error message

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/evaluators/JavascriptEvaluator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/evaluators/JavascriptEvaluator.java
@@ -36,9 +36,8 @@ public class JavascriptEvaluator implements Evaluator {
             LOGGER.debug("Javascript evaluator -- result: {}", result);
             return result;
         } catch (ScriptException e) {
-            String errorMsg = String.format("Error while evaluating script: %s", expression);
-            LOGGER.error(errorMsg, e);
-            throw new TerminateWorkflowException(errorMsg);
+            LOGGER.error("Error while evaluating script: {}", expression, e);
+            throw new TerminateWorkflowException(e.getMessage());
         }
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/InlineTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/InlineTest.java
@@ -44,7 +44,7 @@ public class InlineTest {
         TaskModel task = new TaskModel();
         task.getInputData().putAll(inputObj);
         inline.execute(workflow, task, executor);
-        assertEquals(TaskModel.Status.FAILED, task.getStatus());
+        assertEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
         assertEquals(
                 "Empty 'expression' in Inline task's input parameters. A non-empty String value must be provided.",
                 task.getReasonForIncompletion());
@@ -57,9 +57,9 @@ public class InlineTest {
         task = new TaskModel();
         task.getInputData().putAll(inputObj);
         inline.execute(workflow, task, executor);
-        assertEquals(TaskModel.Status.FAILED, task.getStatus());
+        assertEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
         assertEquals(
-                "Empty 'evaluatorType' in Inline task's input parameters. A non-empty String value must be provided.",
+                "Empty 'evaluatorType' in INLINE task's input parameters. A non-empty String value must be provided.",
                 task.getReasonForIncompletion());
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_The error message from the evaluation engine is sent in the TerminateWorkflowException message by the Evaluator implementation. The same is set in the reasonForIncompletion field._

Alternatives considered
----

_Throwing TerminateWorkflowException from Evaluator breaks the encapsulation. The ideal fix is to have Evaluator throw a custom exception and let the caller decide if the workflow should be terminated._
