### PR TITLE
include modules in setup

### DIFF
--- a/polyglot-clients/python/setup.py
+++ b/polyglot-clients/python/setup.py
@@ -18,6 +18,7 @@ from setuptools import setup
 setup(
   name = 'conductor',
   packages = ['conductor'], # this must be the same as the name above
+  py_models=['conductor', 'ConductorWorker'],
   version = '1.0.0',
   description = 'Conductor python client',
   author = 'Viren Baraiya',


### PR DESCRIPTION
so the files will be included in distributed package

Pull Request type
----
- [x] Bugfix


**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
setting py_modules in setup.py so the direct modules will appear in the distributed package and client installed by pip
