### PR TITLE
Adjust maven repostiory URL for grpc.

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -24,7 +24,7 @@ plugins {
 }
 
 repositories{
-    maven { url "https://dl.bintray.com/chaos-systems/mvn" }
+    maven { url "https://mvnrepository.com/artifact" }
 }
 
 dependencies {


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Corrected maven repository URL -- the old one 502s

Issue #3121
