### PR TITLE
eclipse temurin replacing openjdk base images

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -5,7 +5,7 @@
 # ===========================================================================================================
 # 0. Builder stage
 # ===========================================================================================================
-FROM openjdk:11-jdk AS builder
+FROM eclipse-temurin:11-jdk-focal AS builder
 
 LABEL maintainer="Netflix OSS <conductor@netflix.com>"
 
@@ -19,7 +19,7 @@ RUN ./gradlew build -x test --stacktrace
 # ===========================================================================================================
 # 1. Bin stage
 # ===========================================================================================================
-FROM openjdk:11-jre
+FROM eclipse-temurin:11-jre-focal 
 
 LABEL maintainer="Netflix OSS <conductor@netflix.com>"
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
OpenJDK Docker base images are now deprecated and as such these are replaced in this PR by [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin/) Docker base images that are now considered as the official OpenJDK images.

This PR uses jdk11/jre11 with Ubuntu Focal (20.04.4LTS) tags, as this version of Linux comes geared out of the box with the necessary dependencies to build Conductor (most issues with Alpine tags are the lack of dependencies to build `protoc` complied artifacts)

_Describe the new behavior from this PR, and why it's needed_
Issue #3090 

Alternatives considered
----

_Describe alternative implementation you have considered_
