### PR TITLE
Fix loop inside switch

### DIFF
--- a/ui/src/components/diagram/WorkflowDAG.js
+++ b/ui/src/components/diagram/WorkflowDAG.js
@@ -274,6 +274,16 @@ export default class WorkflowDAG {
     );
 
     if (hasDoWhileExecuted) {
+      // Create cosmetic LOOP edges between top and bottom bars
+      this.graph.setEdge(
+        doWhileTask.taskReferenceName,
+        doWhileTask.taskReferenceName + "-END",
+        {
+          type: "loop",
+          executed: hasDoWhileExecuted,
+        }
+      );
+
       const loopOverRefs = Array.from(this.taskResults.keys()).filter((key) => {
         for (let prefix of loopOverRefPrefixes) {
           if (key.startsWith(prefix)) return true;
@@ -297,6 +307,16 @@ export default class WorkflowDAG {
       }
       this.addVertex(endDoWhileTask, [...loopTasks]);
     } else {
+      // Create cosmetic LOOP edges between top and bottom bars
+      this.graph.setEdge(
+        doWhileTask.taskReferenceName,
+        doWhileTask.taskReferenceName + "-END",
+        {
+          type: "loop",
+          executed: hasDoWhileExecuted,
+        }
+      );
+
       // Definition view (or not executed)
       this.processTaskList(doWhileTask.loopOver, [doWhileTask]);
 
@@ -319,10 +339,9 @@ export default class WorkflowDAG {
       this.addVertex(endDoWhileTask, [lastLoopTask]);
     }
 
-    // Create cosmetic LOOP edges between top and bottom bars
     this.graph.setEdge(
-      doWhileTask.taskReferenceName,
       doWhileTask.taskReferenceName + "-END",
+      doWhileTask.taskReferenceName,
       {
         type: "loop",
         executed: hasDoWhileExecuted,

--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -582,6 +582,11 @@ class WorkflowGraph extends React.Component {
       if (right > maxX) maxX = right;
       if (left < minX) minX = left;
     }
+
+    if (minX < 0) {
+      maxX = maxX - minX;
+    }
+
     translateX = minX;
     barNode.elem.setAttribute(
       "transform",

--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -584,7 +584,8 @@ class WorkflowGraph extends React.Component {
     }
 
     if (minX < 0) {
-      maxX = maxX - minX;
+      maxX = maxX - minX + BAR_MARGIN;
+      minX = -BAR_MARGIN;
     }
 
     translateX = minX;


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #3139
https://github.com/Netflix/conductor/issues/3139

This restores the left-side cosmetic edge for loops and adds a few missing connections between edges and top/bottom bars.

Execution:
![image](https://user-images.githubusercontent.com/340766/183340529-c7417ab3-c52f-4fbc-b06c-9133afcc2fbe.png)

Definition:
![image](https://user-images.githubusercontent.com/340766/183340556-6892ecd1-508b-47b2-8ab5-126934915e8b.png)

Alternatives considered
----
Rolling back to a previous version

