### PR TITLE
Updated tasklifecycle.md - mis-spelled word

### DIFF
--- a/docs/docs/architecture/tasklifecycle.md
+++ b/docs/docs/architecture/tasklifecycle.md
@@ -20,7 +20,7 @@ Timeout is the maximum amount of time that the task must reach a terminal state 
 
 ![Task Timeout](/img/TimeoutSeconds.png)
 
-**0 seconds** -> Worker polls for task T1 fom the Conductor server and receives the task. T1 is put into IN_PROGRESS status by the server.  
+**0 seconds** -> Worker polls for task T1 from the Conductor server and receives the task. T1 is put into IN_PROGRESS status by the server.  
 Worker starts processing the task but is unable to process the task at this time. Worker updates the server with T1 set to IN_PROGRESS status and a callback of 9 seconds.  
 Server puts T1 back in the queue but makes it invisible and the worker continues to poll for the task but does not receive T1 for 9 seconds.  
 


### PR DESCRIPTION
Corrected the mis-spelled word 'fom' to 'from'

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [X] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #
Corrected the mis-spelled word 'fom' to 'from'

Alternatives considered
----

_Describe alternative implementation you have considered_
