### PR TITLE
Failed task names

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -322,8 +322,8 @@ public class Workflow extends Auditable {
         return failedReferenceTaskNames;
     }
 
-    public void setFailedReferenceTaskNames(Set<String> failedTaskNames) {
-        this.failedReferenceTaskNames = failedTaskNames;
+    public void setFailedReferenceTaskNames(Set<String> failedReferenceTaskNames) {
+        this.failedReferenceTaskNames = failedReferenceTaskNames;
     }
 
     public Set<String> getFailedTaskNames() {

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -123,6 +123,9 @@ public class Workflow extends Auditable {
     @ProtoField(id = 24)
     private long lastRetriedTime;
 
+    @ProtoField(id = 25)
+    private Set<String> failedTaskNames = new HashSet<>();
+
     public Workflow() {}
 
     /**
@@ -319,8 +322,16 @@ public class Workflow extends Auditable {
         return failedReferenceTaskNames;
     }
 
-    public void setFailedReferenceTaskNames(Set<String> failedReferenceTaskNames) {
-        this.failedReferenceTaskNames = failedReferenceTaskNames;
+    public void setFailedReferenceTaskNames(Set<String> failedTaskNames) {
+        this.failedReferenceTaskNames = failedTaskNames;
+    }
+
+    public Set<String> getFailedTaskNames() {
+        return failedTaskNames;
+    }
+
+    public void setFailedTaskNames(Set<String> failedTaskNames) {
+        this.failedTaskNames = failedTaskNames;
     }
 
     public WorkflowDef getWorkflowDefinition() {
@@ -484,6 +495,7 @@ public class Workflow extends Auditable {
         copy.setLastRetriedTime(lastRetriedTime);
         copy.setTaskToDomain(taskToDomain);
         copy.setFailedReferenceTaskNames(failedReferenceTaskNames);
+        copy.setFailedTaskNames(failedTaskNames);
         copy.setExternalInputPayloadStoragePath(externalInputPayloadStoragePath);
         copy.setExternalOutputPayloadStoragePath(externalOutputPayloadStoragePath);
         return copy;
@@ -532,6 +544,7 @@ public class Workflow extends Auditable {
                 && Objects.equals(getTaskToDomain(), workflow.getTaskToDomain())
                 && Objects.equals(
                         getFailedReferenceTaskNames(), workflow.getFailedReferenceTaskNames())
+                && Objects.equals(getFailedTaskNames(), workflow.getFailedTaskNames())
                 && Objects.equals(
                         getExternalInputPayloadStoragePath(),
                         workflow.getExternalInputPayloadStoragePath())
@@ -563,6 +576,7 @@ public class Workflow extends Auditable {
                 getEvent(),
                 getTaskToDomain(),
                 getFailedReferenceTaskNames(),
+                getFailedTaskNames(),
                 getWorkflowDefinition(),
                 getExternalInputPayloadStoragePath(),
                 getExternalOutputPayloadStoragePath(),

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -15,6 +15,7 @@ package com.netflix.conductor.common.run;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,9 @@ public class WorkflowSummary {
     @ProtoField(id = 17)
     private int priority;
 
+    @ProtoField(id = 18)
+    private Set<String> failedTaskNames;
+
     public WorkflowSummary() {}
 
     public WorkflowSummary(Workflow workflow) {
@@ -118,6 +122,7 @@ public class WorkflowSummary {
         this.event = workflow.getEvent();
         this.failedReferenceTaskNames =
                 workflow.getFailedReferenceTaskNames().stream().collect(Collectors.joining(","));
+        this.failedTaskNames = workflow.getFailedTaskNames();
         if (StringUtils.isNotBlank(workflow.getExternalInputPayloadStoragePath())) {
             this.externalInputPayloadStoragePath = workflow.getExternalInputPayloadStoragePath();
         }
@@ -238,6 +243,14 @@ public class WorkflowSummary {
 
     public void setFailedReferenceTaskNames(String failedReferenceTaskNames) {
         this.failedReferenceTaskNames = failedReferenceTaskNames;
+    }
+
+    public Set<String> getFailedTaskNames() {
+        return failedTaskNames;
+    }
+
+    public void setFailedTaskNames(Set<String> failedTaskNames) {
+        this.failedTaskNames = failedTaskNames;
     }
 
     public void setWorkflowType(String workflowType) {

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.common.run;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
@@ -85,7 +86,7 @@ public class WorkflowSummary {
     private int priority;
 
     @ProtoField(id = 18)
-    private Set<String> failedTaskNames;
+    private Set<String> failedTaskNames = new HashSet<>();
 
     public WorkflowSummary() {}
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -836,18 +836,25 @@ public class WorkflowExecutor {
 
         workflow.setStatus(WorkflowModel.Status.COMPLETED);
 
-        // update the failed reference task names
-        workflow.getFailedReferenceTaskNames()
-                .addAll(
-                        workflow.getTasks().stream()
-                                .filter(
-                                        t ->
-                                                FAILED.equals(t.getStatus())
-                                                        || FAILED_WITH_TERMINAL_ERROR.equals(
-                                                                t.getStatus()))
-                                .map(TaskModel::getReferenceTaskName)
-                                .collect(Collectors.toSet()));
 
+
+        // update the failed reference task names
+        List<TaskModel> failedTasks = workflow.getTasks().stream()
+                .filter(t -> FAILED.equals(t.getStatus()) || 
+                    FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
+                    .collect(Collectors.toList());
+
+        workflow.getFailedReferenceTaskNames()
+                .addAll(failedTasks.stream()
+                .map(TaskModel::getReferenceTaskName)
+                .collect(Collectors.toSet()));
+
+        workflow.getFailedTaskNames()
+                .addAll(failedTasks.stream()
+                .map(TaskModel::getTaskDefName)
+                .collect(Collectors.toSet()));
+
+      
         executionDAOFacade.updateWorkflow(workflow);
         LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
         workflowStatusListener.onWorkflowCompletedIfEnabled(workflow);
@@ -907,16 +914,21 @@ public class WorkflowExecutor {
             }
 
             // update the failed reference task names
+            List<TaskModel> failedTasks = workflow.getTasks().stream()
+                    .filter(t -> FAILED.equals(t.getStatus()) || 
+                        FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
+                        .collect(Collectors.toList());
+
             workflow.getFailedReferenceTaskNames()
-                    .addAll(
-                            workflow.getTasks().stream()
-                                    .filter(
-                                            t ->
-                                                    FAILED.equals(t.getStatus())
-                                                            || FAILED_WITH_TERMINAL_ERROR.equals(
-                                                                    t.getStatus()))
-                                    .map(TaskModel::getReferenceTaskName)
-                                    .collect(Collectors.toSet()));
+                    .addAll(failedTasks.stream()
+                    .map(TaskModel::getReferenceTaskName)
+                    .collect(Collectors.toSet()));
+
+            workflow.getFailedTaskNames()
+                    .addAll(failedTasks.stream()
+                    .map(TaskModel::getTaskDefName)
+                    .collect(Collectors.toSet()));
+
 
             String workflowId = workflow.getWorkflowId();
             workflow.setReasonForIncompletion(reason);
@@ -1828,6 +1840,8 @@ public class WorkflowExecutor {
             workflow.setReasonForIncompletion(null);
             workflow.setFailedTaskId(null);
             workflow.setFailedReferenceTaskNames(new HashSet<>());
+            workflow.setFailedTaskNames(new HashSet<>());
+
             if (correlationId != null) {
                 workflow.setCorrelationId(correlationId);
             }
@@ -1875,6 +1889,8 @@ public class WorkflowExecutor {
             workflow.setReasonForIncompletion(null);
             workflow.setFailedTaskId(null);
             workflow.setFailedReferenceTaskNames(new HashSet<>());
+            workflow.setFailedTaskNames(new HashSet<>());
+
             if (correlationId != null) {
                 workflow.setCorrelationId(correlationId);
             }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -836,25 +836,27 @@ public class WorkflowExecutor {
 
         workflow.setStatus(WorkflowModel.Status.COMPLETED);
 
-
-
         // update the failed reference task names
-        List<TaskModel> failedTasks = workflow.getTasks().stream()
-                .filter(t -> FAILED.equals(t.getStatus()) || 
-                    FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
-                    .collect(Collectors.toList());
+        List<TaskModel> failedTasks =
+                workflow.getTasks().stream()
+                        .filter(
+                                t ->
+                                        FAILED.equals(t.getStatus())
+                                                || FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
+                        .collect(Collectors.toList());
 
         workflow.getFailedReferenceTaskNames()
-                .addAll(failedTasks.stream()
-                .map(TaskModel::getReferenceTaskName)
-                .collect(Collectors.toSet()));
+                .addAll(
+                        failedTasks.stream()
+                                .map(TaskModel::getReferenceTaskName)
+                                .collect(Collectors.toSet()));
 
         workflow.getFailedTaskNames()
-                .addAll(failedTasks.stream()
-                .map(TaskModel::getTaskDefName)
-                .collect(Collectors.toSet()));
+                .addAll(
+                        failedTasks.stream()
+                                .map(TaskModel::getTaskDefName)
+                                .collect(Collectors.toSet()));
 
-      
         executionDAOFacade.updateWorkflow(workflow);
         LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
         workflowStatusListener.onWorkflowCompletedIfEnabled(workflow);
@@ -914,21 +916,26 @@ public class WorkflowExecutor {
             }
 
             // update the failed reference task names
-            List<TaskModel> failedTasks = workflow.getTasks().stream()
-                    .filter(t -> FAILED.equals(t.getStatus()) || 
-                        FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
-                        .collect(Collectors.toList());
+            List<TaskModel> failedTasks =
+                    workflow.getTasks().stream()
+                            .filter(
+                                    t ->
+                                            FAILED.equals(t.getStatus())
+                                                    || FAILED_WITH_TERMINAL_ERROR.equals(
+                                                            t.getStatus()))
+                            .collect(Collectors.toList());
 
             workflow.getFailedReferenceTaskNames()
-                    .addAll(failedTasks.stream()
-                    .map(TaskModel::getReferenceTaskName)
-                    .collect(Collectors.toSet()));
+                    .addAll(
+                            failedTasks.stream()
+                                    .map(TaskModel::getReferenceTaskName)
+                                    .collect(Collectors.toSet()));
 
             workflow.getFailedTaskNames()
-                    .addAll(failedTasks.stream()
-                    .map(TaskModel::getTaskDefName)
-                    .collect(Collectors.toSet()));
-
+                    .addAll(
+                            failedTasks.stream()
+                                    .map(TaskModel::getTaskDefName)
+                                    .collect(Collectors.toSet()));
 
             String workflowId = workflow.getWorkflowId();
             workflow.setReasonForIncompletion(reason);

--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -78,6 +78,9 @@ public class WorkflowModel {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<String> failedReferenceTaskNames = new HashSet<>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Set<String> failedTaskNames = new HashSet<>();
+
     private WorkflowDef workflowDefinition;
 
     private String externalInputPayloadStoragePath;
@@ -281,6 +284,14 @@ public class WorkflowModel {
 
     public void setFailedReferenceTaskNames(Set<String> failedReferenceTaskNames) {
         this.failedReferenceTaskNames = failedReferenceTaskNames;
+    }
+
+    public Set<String> getFailedTaskNames() {
+        return failedTaskNames;
+    }
+
+    public void setFailedTaskNames(Set<String> failedTaskNames) {
+        this.failedTaskNames = failedTaskNames;
     }
 
     public WorkflowDef getWorkflowDefinition() {
@@ -491,6 +502,7 @@ public class WorkflowModel {
                 && Objects.equals(getEvent(), that.getEvent())
                 && Objects.equals(getTaskToDomain(), that.getTaskToDomain())
                 && Objects.equals(getFailedReferenceTaskNames(), that.getFailedReferenceTaskNames())
+                && Objects.equals(getFailedTaskNames(), that.getFailedTaskNames())
                 && Objects.equals(getWorkflowDefinition(), that.getWorkflowDefinition())
                 && Objects.equals(
                         getExternalInputPayloadStoragePath(),
@@ -523,6 +535,7 @@ public class WorkflowModel {
                 getEvent(),
                 getTaskToDomain(),
                 getFailedReferenceTaskNames(),
+                getFailedTaskNames(),
                 getWorkflowDefinition(),
                 getExternalInputPayloadStoragePath(),
                 getExternalOutputPayloadStoragePath(),

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -1277,6 +1277,12 @@ public class TestWorkflowExecutor {
                         add("task1_ref1");
                     }
                 });
+        workflow.setFailedTaskNames(
+                new HashSet<>() {
+                        {
+                        add("task1");
+                        }
+                });
 
         TaskModel task_1_1 = new TaskModel();
         task_1_1.setTaskId(UUID.randomUUID().toString());
@@ -1317,6 +1323,8 @@ public class TestWorkflowExecutor {
         assertEquals(WorkflowModel.Status.RUNNING, workflow.getStatus());
         assertNull(workflow.getReasonForIncompletion());
         assertEquals(new HashSet<>(), workflow.getFailedReferenceTaskNames());
+        assertEquals(new HashSet<>(), workflow.getFailedTaskNames());
+
     }
 
     @Test
@@ -1426,7 +1434,12 @@ public class TestWorkflowExecutor {
                         add("task1_ref1");
                     }
                 });
-
+        workflow.setFailedTaskNames(
+                new HashSet<>() {
+                        {
+                        add("task1");
+                        }
+                });
         TaskModel task_1_1 = new TaskModel();
         task_1_1.setTaskId(UUID.randomUUID().toString());
         task_1_1.setSeq(20);
@@ -1467,6 +1480,7 @@ public class TestWorkflowExecutor {
         assertEquals(WorkflowModel.Status.RUNNING, workflow.getStatus());
         assertNull(workflow.getReasonForIncompletion());
         assertEquals(new HashSet<>(), workflow.getFailedReferenceTaskNames());
+        assertEquals(new HashSet<>(), workflow.getFailedTaskNames());
     }
 
     @Test
@@ -1509,6 +1523,12 @@ public class TestWorkflowExecutor {
                         add("task2_ref");
                     }
                 });
+        workflow.setFailedTaskNames(
+                new HashSet<>() {
+                        {
+                        add("task2");
+                        }
+                });
         workflow.getTasks().addAll(Arrays.asList(task1, task2));
         // end of setup
 
@@ -1526,6 +1546,7 @@ public class TestWorkflowExecutor {
         assertEquals(WorkflowModel.Status.RUNNING, workflow.getStatus());
         assertNull(workflow.getReasonForIncompletion());
         assertEquals(new HashSet<>(), workflow.getFailedReferenceTaskNames());
+        assertEquals(new HashSet<>(), workflow.getFailedTaskNames());
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -1279,9 +1279,9 @@ public class TestWorkflowExecutor {
                 });
         workflow.setFailedTaskNames(
                 new HashSet<>() {
-                        {
+                    {
                         add("task1");
-                        }
+                    }
                 });
 
         TaskModel task_1_1 = new TaskModel();
@@ -1324,7 +1324,6 @@ public class TestWorkflowExecutor {
         assertNull(workflow.getReasonForIncompletion());
         assertEquals(new HashSet<>(), workflow.getFailedReferenceTaskNames());
         assertEquals(new HashSet<>(), workflow.getFailedTaskNames());
-
     }
 
     @Test
@@ -1436,9 +1435,9 @@ public class TestWorkflowExecutor {
                 });
         workflow.setFailedTaskNames(
                 new HashSet<>() {
-                        {
+                    {
                         add("task1");
-                        }
+                    }
                 });
         TaskModel task_1_1 = new TaskModel();
         task_1_1.setTaskId(UUID.randomUUID().toString());
@@ -1525,9 +1524,9 @@ public class TestWorkflowExecutor {
                 });
         workflow.setFailedTaskNames(
                 new HashSet<>() {
-                        {
+                    {
                         add("task2");
-                        }
+                    }
                 });
         workflow.getTasks().addAll(Arrays.asList(task1, task2));
         // end of setup

--- a/es6-persistence/src/main/resources/mappings_docType_workflow.json
+++ b/es6-persistence/src/main/resources/mappings_docType_workflow.json
@@ -19,6 +19,10 @@
         "type": "text",
         "index": false
       },
+      "failedTaskNames": {
+        "type": "text",
+        "index": true
+      },
       "input": {
         "type": "text",
         "index": true

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
@@ -31,6 +31,7 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.es6.utils.TestUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
 import static org.junit.Assert.assertEquals;
@@ -98,7 +99,7 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
     }
 
     @Test
-    public void shouldIndexWorkflow() {
+    public void shouldIndexWorkflow() throws JsonProcessingException {
         WorkflowSummary workflow = TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
         indexDAO.indexWorkflow(workflow);
 
@@ -146,7 +147,7 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
     }
 
     @Test
-    public void shouldUpdateWorkflow() {
+    public void shouldUpdateWorkflow() throws JsonProcessingException {
         WorkflowSummary workflow = TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
         indexDAO.indexWorkflow(workflow);
 
@@ -332,7 +333,8 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
                 "status=\"" + status + "\" AND workflowType=\"" + workflowName + "\"", "*");
     }
 
-    private void assertWorkflowSummary(String workflowId, WorkflowSummary summary) {
+    private void assertWorkflowSummary(String workflowId, WorkflowSummary summary)
+            throws JsonProcessingException {
         assertEquals(summary.getWorkflowType(), indexDAO.get(workflowId, "workflowType"));
         assertEquals(String.valueOf(summary.getVersion()), indexDAO.get(workflowId, "version"));
         assertEquals(summary.getWorkflowId(), indexDAO.get(workflowId, "workflowId"));
@@ -355,7 +357,7 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
                 indexDAO.get(workflowId, "failedReferenceTaskNames"));
         assertEquals(
                 summary.getFailedTaskNames(),
-                indexDAO.get(workflowId, "failedTaskNames"));
+                objectMapper.readValue(indexDAO.get(workflowId, "failedTaskNames"), Set.class));
     }
 
     private <T> List<T> tryFindResults(Supplier<List<T>> searchFunction) {

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchDAOV6.java
@@ -353,6 +353,9 @@ public class TestElasticSearchDAOV6 extends ElasticSearchDaoBaseTest {
         assertEquals(
                 summary.getFailedReferenceTaskNames(),
                 indexDAO.get(workflowId, "failedReferenceTaskNames"));
+        assertEquals(
+                summary.getFailedTaskNames(),
+                indexDAO.get(workflowId, "failedTaskNames"));
     }
 
     private <T> List<T> tryFindResults(Supplier<List<T>> searchFunction) {

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -34,6 +35,7 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.es6.utils.TestUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
 import static org.junit.Assert.assertEquals;
@@ -89,7 +91,7 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
     }
 
     @Test
-    public void shouldIndexWorkflow() {
+    public void shouldIndexWorkflow() throws JsonProcessingException {
         WorkflowSummary workflowSummary =
                 TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
         indexDAO.indexWorkflow(workflowSummary);
@@ -143,7 +145,7 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
     }
 
     @Test
-    public void shouldUpdateWorkflow() {
+    public void shouldUpdateWorkflow() throws JsonProcessingException {
         WorkflowSummary workflowSummary =
                 TestUtils.loadWorkflowSnapshot(objectMapper, "workflow_summary");
         indexDAO.indexWorkflow(workflowSummary);
@@ -330,7 +332,8 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
                 "status=\"" + status + "\" AND workflowType=\"" + workflowName + "\"", "*");
     }
 
-    private void assertWorkflowSummary(String workflowId, WorkflowSummary summary) {
+    private void assertWorkflowSummary(String workflowId, WorkflowSummary summary)
+            throws JsonProcessingException {
         assertEquals(summary.getWorkflowType(), indexDAO.get(workflowId, "workflowType"));
         assertEquals(String.valueOf(summary.getVersion()), indexDAO.get(workflowId, "version"));
         assertEquals(summary.getWorkflowId(), indexDAO.get(workflowId, "workflowId"));
@@ -353,7 +356,7 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
                 indexDAO.get(workflowId, "failedReferenceTaskNames"));
         assertEquals(
                 summary.getFailedTaskNames(),
-                indexDAO.get(workflowId, "failedTaskNames"));                
+                objectMapper.readValue(indexDAO.get(workflowId, "failedTaskNames"), Set.class));
     }
 
     private <T> List<T> tryFindResults(Supplier<List<T>> searchFunction) {

--- a/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
+++ b/es6-persistence/src/test/java/com/netflix/conductor/es6/dao/index/TestElasticSearchRestDAOV6.java
@@ -351,6 +351,9 @@ public class TestElasticSearchRestDAOV6 extends ElasticSearchRestDaoBaseTest {
         assertEquals(
                 summary.getFailedReferenceTaskNames(),
                 indexDAO.get(workflowId, "failedReferenceTaskNames"));
+        assertEquals(
+                summary.getFailedTaskNames(),
+                indexDAO.get(workflowId, "failedTaskNames"));                
     }
 
     private <T> List<T> tryFindResults(Supplier<List<T>> searchFunction) {

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1013,6 +1013,7 @@ public abstract class AbstractProtoMapper {
             to.putVariables( pair.getKey(), toProto( pair.getValue() ) );
         }
         to.setLastRetriedTime( from.getLastRetriedTime() );
+        to.addAllFailedTaskNames( from.getFailedTaskNames() );
         return to.build();
     }
 
@@ -1052,6 +1053,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setVariables(variablesMap);
         to.setLastRetriedTime( from.getLastRetriedTime() );
+        to.setFailedTaskNames( from.getFailedTaskNamesList().stream().collect(Collectors.toCollection(HashSet::new)) );
         return to;
     }
 
@@ -1240,6 +1242,7 @@ public abstract class AbstractProtoMapper {
             to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         }
         to.setPriority( from.getPriority() );
+        to.addAllFailedTaskNames( from.getFailedTaskNames() );
         return to.build();
     }
 
@@ -1262,6 +1265,7 @@ public abstract class AbstractProtoMapper {
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         to.setPriority( from.getPriority() );
+        to.setFailedTaskNames( from.getFailedTaskNamesList().stream().collect(Collectors.toCollection(HashSet::new)) );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflow.proto
+++ b/grpc/src/main/proto/model/workflow.proto
@@ -38,4 +38,5 @@ message Workflow {
     int32 priority = 22;
     map<string, google.protobuf.Value> variables = 23;
     int64 last_retried_time = 24;
+    repeated string failed_task_names = 25;
 }

--- a/grpc/src/main/proto/model/workflowsummary.proto
+++ b/grpc/src/main/proto/model/workflowsummary.proto
@@ -25,4 +25,5 @@ message WorkflowSummary {
     string external_input_payload_storage_path = 15;
     string external_output_payload_storage_path = 16;
     int32 priority = 17;
+    repeated string failed_task_names = 18;
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
@@ -215,6 +215,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             output['validationErrors'] == 'There was a terminal error'
             getTaskByRefName('t1').retryCount == 0
             failedReferenceTaskNames == ['t1'] as HashSet
+            failedTaskNames == ['integration_task_1'] as HashSet
         }
 
         cleanup:
@@ -599,6 +600,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             tasks[1].taskId == tasks[2].retriedTaskId
             tasks[2].taskId == tasks[3].retriedTaskId
             failedReferenceTaskNames == ['t2'] as HashSet
+            failedTaskNames == ['integration_task_2'] as HashSet
         }
 
         cleanup:
@@ -700,6 +702,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].status == Task.Status.COMPLETED
             failedReferenceTaskNames == ['t1'] as HashSet
+            failedTaskNames == ['integration_task_1'] as HashSet
         }
 
         cleanup:


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Add field `failedTaskNames` to `Workflow` and `WorkflowSummary`, to be indexed in ES enabling workflows to be queried for by the TaskDef names of the failed tasks.

Alternatives considered
----
Modifying 