### PR TITLE
Extract map body from json_jq output

### DIFF
--- a/test-harness/src/test/resources/sequential_json_jq_transform_integration_test.json
+++ b/test-harness/src/test/resources/sequential_json_jq_transform_integration_test.json
@@ -1,0 +1,40 @@
+{
+  "name": "sequential_json_jq_transform_wf",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "default_variables",
+      "taskReferenceName": "default_variables",
+      "description": "default_variables",
+      "inputParameters": {
+        "input": "${workflow.input}",
+        "queryExpression": "{ requestTransform: .input.requestTransform // \".body\"  , responseTransform: .input.responseTransform // \".response.body\", method: .input.method // \"GET\", document: .input.document // \"rgt_results\", successExpression: .input.successExpression // \"true\"   }"
+      },
+      "type": "JSON_JQ_TRANSFORM",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    },
+    {
+      "name": "request_transform",
+      "taskReferenceName": "request_transform",
+      "description": "request_transform",
+      "inputParameters": {
+        "body": "${workflow.input.body}",
+        "queryExpression": "${default_variables.output.result.requestTransform}"
+      },
+      "type": "JSON_JQ_TRANSFORM",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #
Nested json object in taskModel output is not resolved properly [here](https://github.com/Netflix/conductor/blob/33062f3ae506e49947bd11157dce279254f00347/core/src/main/java/com/netflix/conductor/core/utils/ParametersUtils.java#L244), so extract the map body out and put that into taskModel output instead.

Alternatives considered
----

_Describe alternative implementation you have considered_
