### PR TITLE
Adding parameterUtils in do-while task to compute input at each iteration.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -218,8 +218,7 @@ public class DoWhile extends WorkflowSystemTask {
     }
 
     @VisibleForTesting
-    boolean evaluateCondition(WorkflowModel workflow, TaskModel task)
-            throws ScriptException {
+    boolean evaluateCondition(WorkflowModel workflow, TaskModel task) throws ScriptException {
         TaskDef taskDefinition = task.getTaskDefinition().orElse(null);
         // Use paramUtils to compute the task input
         Map<String, Object> conditionInput =

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -131,7 +131,7 @@ public class DoWhile extends WorkflowSystemTask {
         // iteration by evaluating the loopCondition
         boolean shouldContinue;
         try {
-            shouldContinue = evaluateCondition(workflowExecutor, workflow, doWhileTaskModel);
+            shouldContinue = evaluateCondition(workflow, doWhileTaskModel);
             LOGGER.debug(
                     "Task {} condition evaluated to {}",
                     doWhileTaskModel.getTaskId(),
@@ -218,10 +218,9 @@ public class DoWhile extends WorkflowSystemTask {
     }
 
     @VisibleForTesting
-    boolean evaluateCondition(
-            WorkflowExecutor workflowExecutor, WorkflowModel workflow, TaskModel task)
+    boolean evaluateCondition(WorkflowModel workflow, TaskModel task)
             throws ScriptException {
-        TaskDef taskDefinition = workflowExecutor.getTaskDefinition(task);
+        TaskDef taskDefinition = task.getTaskDefinition().orElse(null);
         // Use paramUtils to compute the task input
         Map<String, Object> conditionInput =
                 parametersUtils.getTaskInputV2(

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -17,17 +17,17 @@ import java.util.stream.Collectors;
 
 import javax.script.ScriptException;
 
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
-import com.netflix.conductor.core.utils.ParametersUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.annotations.VisibleForTesting;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.events.ScriptEvaluator;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
@@ -218,7 +218,9 @@ public class DoWhile extends WorkflowSystemTask {
     }
 
     @VisibleForTesting
-    boolean evaluateCondition(WorkflowExecutor workflowExecutor, WorkflowModel workflow, TaskModel task) throws ScriptException {
+    boolean evaluateCondition(
+            WorkflowExecutor workflowExecutor, WorkflowModel workflow, TaskModel task)
+            throws ScriptException {
         TaskDef taskDefinition = workflowExecutor.getTaskDefinition(task);
         // Use paramUtils to compute the task input
         Map<String, Object> conditionInput =

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/tasks/DoWhileSpec.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/tasks/DoWhileSpec.groovy
@@ -34,18 +34,22 @@ class DoWhileSpec extends Specification {
     DoWhile doWhile
 
     WorkflowExecutor workflowExecutor
+    ObjectMapper objectMapper
+    ParametersUtils parametersUtils
     TaskModel doWhileTaskModel
 
     WorkflowTask task1, task2
     TaskModel taskModel1, taskModel2
 
     def setup() {
+        objectMapper = new ObjectMapper();
         workflowExecutor = Mock(WorkflowExecutor.class)
+        parametersUtils = new ParametersUtils(objectMapper)
 
         task1 = new WorkflowTask(name: 'task1', taskReferenceName: 'task1')
         task2 = new WorkflowTask(name: 'task2', taskReferenceName: 'task2')
 
-        doWhile = new DoWhile()
+        doWhile = new DoWhile(parametersUtils)
     }
 
     def "first iteration"() {

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
@@ -36,7 +36,8 @@ class DoWhileSpec extends AbstractSpecification {
                 'do_while_iteration_fix_test.json',
                 "do_while_sub_workflow_integration_test.json",
         "do_while_five_loop_over_integration_test.json",
-        "do_while_system_tasks.json")
+        "do_while_system_tasks.json",
+                "do_while_set_variable_fix.json")
     }
 
     def "Test workflow with 2 iterations of five tasks"() {
@@ -1088,6 +1089,26 @@ class DoWhileSpec extends AbstractSpecification {
             tasks[2].taskType == 'LAMBDA'
             tasks[2].status == Task.Status.COMPLETED
             tasks[2].outputData.get("result") == 1
+        }
+    }
+
+    def "Test workflow with Do While task contains set variable task"() {
+        given: "The loop condition is set to use set variable"
+        def workflowInput = new HashMap()
+        workflowInput['value'] = 2
+
+        when: "A do_while workflow is started"
+        def workflowInstanceId = workflowExecutor.startWorkflow("do_while_Set_variable_fix", 1, "looptest", workflowInput, null, null)
+
+        then: "Verify that the workflow has competed"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            tasks.size() == 2
+            tasks[0].taskType == 'DO_WHILE'
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[1].taskType == 'SET_VARIABLE'
+            tasks[1].status == Task.Status.COMPLETED
+            tasks[1].inputData.get("value") == "0"
         }
     }
 

--- a/test-harness/src/test/resources/do_while_set_variable_fix.json
+++ b/test-harness/src/test/resources/do_while_set_variable_fix.json
@@ -1,0 +1,45 @@
+{
+  "name": "do_while_Set_variable_fix",
+  "description": "do_while with set variable task fix",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "loopTask",
+      "taskReferenceName": "loopTask",
+      "inputParameters": {
+        "value": "${workflow.variables.value}"
+      },
+      "type": "DO_WHILE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopCondition": "if ($.value > 0) { true; } else { false; } ",
+      "loopOver": [
+        {
+          "name": "set_variable",
+          "taskReferenceName": "set_variable",
+          "inputParameters": {
+            "value": "0"
+          },
+          "type": "SET_VARIABLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false
+        }
+      ]
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Do-While condition evaluation flow does not rely on parameterutils so compute the task input. Doing so will result in an inconsistent state when `set_variable` task is used as one of `loopOver` task and its output is used in `loopCondition`.
In fact, in all the tasks we need parameterUtils to be injected/used because any task can use input that relies on workflow variables.
