### PR TITLE
Fix next task not scheduled after switch completes

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -245,7 +245,6 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         forkDynamicTask.setTaskDefName(TaskType.TASK_TYPE_FORK);
         forkDynamicTask.setStartTime(System.currentTimeMillis());
         forkDynamicTask.setEndTime(System.currentTimeMillis());
-        forkDynamicTask.setExecuted(true);
         List<String> forkedTaskNames =
                 dynForkTasks.stream()
                         .map(WorkflowTask::getTaskReferenceName)

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
@@ -78,7 +78,6 @@ public class ForkJoinTaskMapper implements TaskMapper {
         forkTask.setEndTime(epochMillis);
         forkTask.setInputData(taskInput);
         forkTask.setStatus(TaskModel.Status.COMPLETED);
-        forkTask.setExecuted(true);
 
         tasksToBeScheduled.add(forkTask);
         List<List<WorkflowTask>> forkTasks = workflowTask.getForkTasks();

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -96,8 +96,7 @@ public class SwitchTaskMapper implements TaskMapper {
         switchTask.getInputData().put("case", evalResult);
         switchTask.getOutputData().put("evaluationResult", Collections.singletonList(evalResult));
         switchTask.setStartTime(System.currentTimeMillis());
-        switchTask.setStatus(TaskModel.Status.COMPLETED);
-        switchTask.setExecuted(true);
+        switchTask.setStatus(TaskModel.Status.IN_PROGRESS);
         tasksToBeScheduled.add(switchTask);
 
         // get the list of tasks based on the evaluated expression

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -231,7 +231,7 @@ public class TestDeciderOutcomes {
         workflow.getTasks().addAll(outcome.tasksToBeScheduled);
         outcome = deciderService.decide(workflow);
         assertFalse(outcome.isComplete);
-        assertEquals(outcome.tasksToBeUpdated.toString(), 1, outcome.tasksToBeUpdated.size());
+        assertEquals(outcome.tasksToBeUpdated.toString(), 3, outcome.tasksToBeUpdated.size());
         assertEquals(1, outcome.tasksToBeScheduled.size());
         assertEquals("junit_task_3", outcome.tasksToBeScheduled.get(0).getTaskDefName());
     }

--- a/test-harness/src/test/resources/switch_with_no_default_case_integration_test.json
+++ b/test-harness/src/test/resources/switch_with_no_default_case_integration_test.json
@@ -1,0 +1,68 @@
+{
+  "name": "SwitchWithNoDefaultCaseWF",
+  "description": "switch_with_no_default_case",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "switchTask",
+      "taskReferenceName": "switchTask",
+      "inputParameters": {
+        "case": "${workflow.input.case}"
+      },
+      "type": "SWITCH",
+      "evaluatorType": "value-param",
+      "expression": "case",
+      "decisionCases": {
+        "c": [
+          {
+            "name": "integration_task_1",
+            "taskReferenceName": "t1",
+            "inputParameters": {
+              "p1": "${workflow.input.param1}",
+              "p2": "${workflow.input.param2}"
+            },
+            "type": "SIMPLE",
+            "decisionCases": {},
+            "defaultCase": [],
+            "forkTasks": [],
+            "startDelay": 0,
+            "joinOn": [],
+            "optional": false,
+            "defaultExclusiveJoinTask": [],
+            "asyncComplete": false,
+            "loopOver": []
+          }
+        ]
+      },
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    },
+    {
+      "name": "integration_task_2",
+      "taskReferenceName": "t2",
+      "inputParameters": {
+        "p1": "${workflow.input.param1}",
+        "p2": "${workflow.input.param2}"
+      },
+      "type": "SIMPLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Revert changes done to SwitchTaskMapper introduced by [this PR](https://github.com/Netflix/conductor/commit/2d514690eb7a52ec6140677a1bf083f6f940443d#diff-c3a45903d808c1c4aa854c8fd387310c24e9d8fcee276392093ca40168e18f88), and add test case to verify the fix.

_Describe the new behavior from this PR, and why it's needed_
Issue #
https://github.com/Netflix/conductor/issues/3089#issuecomment-1224034537

Alternatives considered
----

_Describe alternative implementation you have considered_
