### PR TITLE
During start, decide is performed inside a lock

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1619,7 +1619,7 @@ public class WorkflowExecutor {
             taskToBeSkipped.setOutputMessage(skipTaskRequest.getTaskOutputMessage());
         }
         executionDAOFacade.createTasks(Collections.singletonList(taskToBeSkipped));
-        decide(workflow);
+        decide(workflow.getWorkflowId());
     }
 
     public WorkflowModel getWorkflow(String workflowId, boolean includeTasks) {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_A recent refactoring caused **decide during startWorkflow** to be performed outside a lock. This caused decide to be performed concurrently on two threads. This typically results in the first task of the workflow to be scheduled twice._


Alternatives considered
----

_None_
