### PR TITLE
Allow updating task status and output via POST call by workflowId and taskRefName

### DIFF
--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -83,6 +83,25 @@ public class TaskResource {
         return taskService.updateTask(taskResult);
     }
 
+    @PostMapping(value = "/{workflowId}/{taskRefName}/{status}", produces = TEXT_PLAIN_VALUE)
+    @Operation(summary = "Update a task By Ref Name")
+    public String updateTask(
+            @PathVariable("workflowId") String workflowId,
+            @PathVariable("taskRefName") String taskRefName,
+            @PathVariable("status") TaskResult.Status status,
+            @RequestBody Map<String, Object> output) {
+
+        Task pending = taskService.getPendingTaskForWorkflow(workflowId, taskRefName);
+        if (pending == null) {
+            return null;
+        }
+
+        TaskResult taskResult = new TaskResult(pending);
+        taskResult.setStatus(status);
+        taskResult.getOutputData().putAll(output);
+        return taskService.updateTask(taskResult);
+    }
+
     @PostMapping("/{taskId}/log")
     @Operation(summary = "Log Task Execution Details")
     public void log(@PathVariable("taskId") String taskId, @RequestBody String log) {


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
Allow updating task status using a POST call for situations where workflowId and taskReferenceName are already known ( before task is assigned a taskId) and sent to some external service which is supposed to update a WAIT task.
