### PR TITLE
Fix missing updateTime because of different field names in WorkflowModel and Workflow

### DIFF
--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -554,6 +554,7 @@ public class WorkflowModel {
         BeanUtils.copyProperties(this, workflow);
         workflow.setStatus(Workflow.WorkflowStatus.valueOf(this.status.name()));
         workflow.setTasks(tasks.stream().map(TaskModel::toTask).collect(Collectors.toList()));
+        workflow.setUpdateTime(this.updatedTime);
 
         // ensure that input/output is properly represented
         if (externalInputPayloadStoragePath != null) {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----

Workflow has a field called updateTime, whereas WorkflowModel has a field called update**d**Time, which is why it isn't copied over when converting, this PR fixes that.