### PR TITLE
Replace Nashorn with GraalVM JS Engine

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
     implementation "com.github.ben-manes.caffeine:caffeine"
 
+    implementation "org.graalvm.js:js:${revGraalVM}"
+    implementation "org.graalvm.js:js-scriptengine:${revGraalVM}"
+
     // JAXB is not bundled with Java 11, dependencies added explicitly
     // These are needed by Apache BVAL
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:${revJAXB}"

--- a/core/src/main/java/com/netflix/conductor/core/events/ScriptEvaluator.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/ScriptEvaluator.java
@@ -19,7 +19,12 @@ import javax.script.ScriptException;
 
 public class ScriptEvaluator {
 
-    private static final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+    private static final ScriptEngine engine =
+            new ScriptEngineManager().getEngineByName("graal.js");
+
+    static {
+        engine.put("polyglot.js.allowHostAccess", true);
+    }
 
     private ScriptEvaluator() {}
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -240,7 +240,7 @@ public class DoWhile extends WorkflowSystemTask {
         boolean result = false;
         if (condition != null) {
             LOGGER.debug("Condition: {} is being evaluated", condition);
-            // Evaluate the expression by using the Nashorn based script evaluator
+            // Evaluate the expression by using the GraalVM based script evaluator
             result = ScriptEvaluator.evalBool(condition, conditionInput);
         }
         return result;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,4 +52,5 @@ ext {
     revSpock = '1.3-groovy-2.5'
     revSpotifyCompletableFutures = '0.3.3'
     revTestContainer = '1.15.3'
+    revGraalVM = '22.2.0'
 }

--- a/docs/docs/reference-docs/do-while-task.md
+++ b/docs/docs/reference-docs/do-while-task.md
@@ -30,10 +30,10 @@ Branching inside loopOver task is supported.
 
 ### Input Parameters:
 
-| name          | type       | description                                                                                                                                                                                                             |
-|---------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| loopCondition | String     | Condition to be evaluated after every iteration. This is a Javascript expression, evaluated using the Nashorn engine. If an exception occurs during evaluation, the DO_WHILE task is set to FAILED_WITH_TERMINAL_ERROR. |
-| loopOver      | List[Task] | List of tasks that needs to be executed as long as the condition is true.                                                                                                                                               |
+| name          | type       | description                                                                                                                                                                                                                |
+|---------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| loopCondition | String     | Condition to be evaluated after every iteration. This is a Javascript expression, evaluated using the GraalVM JS engine. If an exception occurs during evaluation, the DO_WHILE task is set to FAILED_WITH_TERMINAL_ERROR. |
+| loopOver      | List[Task] | List of tasks that needs to be executed as long as the condition is true.                                                                                                                                                  |
 
 ### Output Parameters
 

--- a/java-sdk/build.gradle
+++ b/java-sdk/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation "cglib:cglib:3.3.0"
     implementation "com.sun.jersey:jersey-client:${revJersey}"
 
+    implementation "org.graalvm.js:js:${revGraalVM}"
+    implementation "org.graalvm.js:js-scriptengine:${revGraalVM}"
+
     testImplementation "org.springframework:spring-web"
     testImplementation "org.spockframework:spock-core:${revSpock}"
     testImplementation "org.spockframework:spock-spring:${revSpock}"

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Javascript.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Javascript.java
@@ -43,7 +43,7 @@ public class Javascript extends Task<Javascript> {
 
     private static final String EVALUATOR_TYPE_PARAMETER = "evaluatorType";
 
-    private static final String ENGINE = "nashorn";
+    private static final String ENGINE = "graal.js";
 
     /**
      * Javascript tasks are executed on the Conductor server without having to write worker code
@@ -105,6 +105,7 @@ public class Javascript extends Task<Javascript> {
             LOGGER.error("missing " + ENGINE + " engine.  Ensure you are running supported JVM");
             return this;
         }
+        scriptEngine.put("polyglot.js.allowHostAccess", true);
 
         try {
 
@@ -133,6 +134,7 @@ public class Javascript extends Task<Javascript> {
             LOGGER.error("missing " + ENGINE + " engine.  Ensure you are running supported JVM");
             return this;
         }
+        scriptEngine.put("polyglot.js.allowHostAccess", true);
 
         try {
 


### PR DESCRIPTION
Pull Request type
----

- [x] Feature

Changes in this PR
----
Issue #2312 replace Nashorn with GraalVM JS Engine

Nashorn is deprecated in JDK 11 and removed in JDK 15, resulting in runtime errors (and test failures) on JDK 15+ 
