### PR TITLE
Removed usages of TaskModel#getOutputData().put()

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -157,8 +157,8 @@ public class SimpleActionProcessor implements ActionProcessor {
         taskModel.setStatus(status);
         taskModel.setOutputData(replaced);
         taskModel.setOutputMessage(taskDetails.getOutputMessage());
-        taskModel.getOutputData().put("conductor.event.messageId", messageId);
-        taskModel.getOutputData().put("conductor.event.name", event);
+        taskModel.addOutput("conductor.event.messageId", messageId);
+        taskModel.addOutput("conductor.event.name", event);
 
         try {
             workflowExecutor.updateTask(new TaskResult(taskModel.toTask()));

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -993,7 +993,7 @@ public class WorkflowExecutor {
                                     null,
                                     workflow.getTaskToDomain());
 
-                    workflow.getOutput().put("conductor.failure_workflow", failureWFId);
+                    workflow.addOutput("conductor.failure_workflow", failureWFId);
                 } catch (Exception e) {
                     LOGGER.error("Failed to start error workflow", e);
                     workflow.getOutput()
@@ -1960,10 +1960,9 @@ public class WorkflowExecutor {
             rerunFromTask.setStartTime(0);
             rerunFromTask.setUpdateTime(0);
             rerunFromTask.setEndTime(0);
-            rerunFromTask.getOutputData().clear();
+            rerunFromTask.clearOutput();
             rerunFromTask.setRetried(false);
             rerunFromTask.setExecuted(false);
-            rerunFromTask.setExternalOutputPayloadStoragePath(null);
             if (rerunFromTask.getTaskType().equalsIgnoreCase(TaskType.TASK_TYPE_SUB_WORKFLOW)) {
                 // if task is sub workflow set task as IN_PROGRESS and reset start time
                 rerunFromTask.setStatus(IN_PROGRESS);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -12,7 +12,6 @@
  */
 package com.netflix.conductor.core.execution.mapper;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +93,7 @@ public class SwitchTaskMapper implements TaskMapper {
         switchTask.setTaskType(TaskType.TASK_TYPE_SWITCH);
         switchTask.setTaskDefName(TaskType.TASK_TYPE_SWITCH);
         switchTask.getInputData().put("case", evalResult);
-        switchTask.getOutputData().put("evaluationResult", Collections.singletonList(evalResult));
+        switchTask.addOutput("evaluationResult", List.of(evalResult));
         switchTask.setStartTime(System.currentTimeMillis());
         switchTask.setStatus(TaskModel.Status.IN_PROGRESS);
         tasksToBeScheduled.add(switchTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -104,9 +104,7 @@ public class DoWhile extends WorkflowSystemTask {
                 break;
             }
         }
-        doWhileTaskModel
-                .getOutputData()
-                .put(String.valueOf(doWhileTaskModel.getIteration()), output);
+        doWhileTaskModel.addOutput(String.valueOf(doWhileTaskModel.getIteration()), output);
 
         if (hasFailures) {
             LOGGER.debug(
@@ -133,7 +131,7 @@ public class DoWhile extends WorkflowSystemTask {
                     shouldContinue);
             if (shouldContinue) {
                 doWhileTaskModel.setIteration(doWhileTaskModel.getIteration() + 1);
-                doWhileTaskModel.getOutputData().put("iteration", doWhileTaskModel.getIteration());
+                doWhileTaskModel.addOutput("iteration", doWhileTaskModel.getIteration());
                 return scheduleNextIteration(doWhileTaskModel, workflow, workflowExecutor);
             } else {
                 LOGGER.debug(

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
@@ -64,10 +64,10 @@ public class Event extends WorkflowSystemTask {
         payload.put("correlationId", workflow.getCorrelationId());
 
         task.setStatus(TaskModel.Status.IN_PROGRESS);
-        task.getOutputData().putAll(payload);
+        task.addOutput(payload);
 
         try {
-            task.getOutputData().put(EVENT_PRODUCED, computeQueueName(workflow, task));
+            task.addOutput(EVENT_PRODUCED, computeQueueName(workflow, task));
         } catch (Exception e) {
             task.setStatus(TaskModel.Status.FAILED);
             task.setReasonForIncompletion(e.getMessage());

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Inline.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Inline.java
@@ -70,7 +70,6 @@ public class Inline extends WorkflowSystemTask {
     public boolean execute(
             WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         Map<String, Object> taskInput = task.getInputData();
-        Map<String, Object> taskOutput = task.getOutputData();
         String evaluatorType = (String) taskInput.get(QUERY_EVALUATOR_TYPE);
         String expression = (String) taskInput.get(QUERY_EXPRESSION_PARAMETER);
 
@@ -79,7 +78,7 @@ public class Inline extends WorkflowSystemTask {
             checkExpression(expression);
             Evaluator evaluator = evaluators.get(evaluatorType);
             Object evalResult = evaluator.evaluate(expression, taskInput);
-            taskOutput.put("result", evalResult);
+            task.addOutput("result", evalResult);
             task.setStatus(TaskModel.Status.COMPLETED);
         } catch (Exception e) {
             String errorMessage = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
@@ -95,7 +94,7 @@ public class Inline extends WorkflowSystemTask {
                             ? TaskModel.Status.FAILED_WITH_TERMINAL_ERROR
                             : TaskModel.Status.FAILED);
             task.setReasonForIncompletion(errorMessage);
-            taskOutput.put("error", errorMessage);
+            task.addOutput("error", errorMessage);
         }
 
         return true;

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Lambda.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Lambda.java
@@ -66,7 +66,6 @@ public class Lambda extends WorkflowSystemTask {
     public boolean execute(
             WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         Map<String, Object> taskInput = task.getInputData();
-        Map<String, Object> taskOutput = task.getOutputData();
         String scriptExpression;
         try {
             scriptExpression = (String) taskInput.get(QUERY_EXPRESSION_PARAMETER);
@@ -79,7 +78,7 @@ public class Lambda extends WorkflowSystemTask {
                         scriptExpressionBuilder,
                         task.getTaskId());
                 Object returnValue = ScriptEvaluator.eval(scriptExpressionBuilder, taskInput);
-                taskOutput.put("result", returnValue);
+                task.addOutput("result", returnValue);
                 task.setStatus(TaskModel.Status.COMPLETED);
             } else {
                 LOGGER.error("Empty {} in Lambda task. ", QUERY_EXPRESSION_PARAMETER);
@@ -97,7 +96,7 @@ public class Lambda extends WorkflowSystemTask {
                     e);
             task.setStatus(TaskModel.Status.FAILED);
             task.setReasonForIncompletion(e.getMessage());
-            taskOutput.put(
+            task.addOutput(
                     "error", e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         }
         return true;

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -771,7 +771,8 @@ public class TaskModel {
                 && Objects.equals(getReasonForIncompletion(), taskModel.getReasonForIncompletion())
                 && Objects.equals(getWorkerId(), taskModel.getWorkerId())
                 && Objects.equals(getWaitTimeout(), taskModel.getWaitTimeout())
-                && Objects.equals(getOutputData(), taskModel.getOutputData())
+                && Objects.equals(outputData, taskModel.outputData)
+                && Objects.equals(outputPayload, taskModel.outputPayload)
                 && Objects.equals(getWorkflowTask(), taskModel.getWorkflowTask())
                 && Objects.equals(getDomain(), taskModel.getDomain())
                 && Objects.equals(getInputMessage(), taskModel.getInputMessage())
@@ -816,7 +817,8 @@ public class TaskModel {
                 getCallbackAfterSeconds(),
                 getWorkerId(),
                 getWaitTimeout(),
-                getOutputData(),
+                outputData,
+                outputPayload,
                 getWorkflowTask(),
                 getDomain(),
                 getInputMessage(),
@@ -870,5 +872,11 @@ public class TaskModel {
         if (outputData != null) {
             this.outputData.putAll(outputData);
         }
+    }
+
+    public void clearOutput() {
+        this.outputData.clear();
+        this.outputPayload.clear();
+        this.externalOutputPayloadStoragePath = null;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -511,7 +511,8 @@ public class WorkflowModel {
                 && Objects.equals(getParentWorkflowTaskId(), that.getParentWorkflowTaskId())
                 && Objects.equals(getTasks(), that.getTasks())
                 && Objects.equals(getInput(), that.getInput())
-                && Objects.equals(getOutput(), that.getOutput())
+                && Objects.equals(output, that.output)
+                && Objects.equals(outputPayload, that.outputPayload)
                 && Objects.equals(getCorrelationId(), that.getCorrelationId())
                 && Objects.equals(getReRunFromWorkflowId(), that.getReRunFromWorkflowId())
                 && Objects.equals(getReasonForIncompletion(), that.getReasonForIncompletion())
@@ -544,7 +545,8 @@ public class WorkflowModel {
                 getParentWorkflowTaskId(),
                 getTasks(),
                 getInput(),
-                getOutput(),
+                output,
+                outputPayload,
                 getCorrelationId(),
                 getReRunFromWorkflowId(),
                 getReasonForIncompletion(),
@@ -579,5 +581,25 @@ public class WorkflowModel {
             workflow.setOutput(new HashMap<>());
         }
         return workflow;
+    }
+
+    public void addInput(String key, Object value) {
+        this.input.put(key, value);
+    }
+
+    public void addInput(Map<String, Object> inputData) {
+        if (inputData != null) {
+            this.input.putAll(inputData);
+        }
+    }
+
+    public void addOutput(String key, Object value) {
+        this.output.put(key, value);
+    }
+
+    public void addOutput(Map<String, Object> outputData) {
+        if (outputData != null) {
+            this.output.putAll(outputData);
+        }
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -291,8 +291,8 @@ public class TestDeciderService {
         workflow.getInput().put("requestId", "request id 001");
         TaskModel task = new TaskModel();
         task.setReferenceTaskName("task2");
-        task.getOutputData().put("location", "http://location");
-        task.getOutputData().put("isPersonActive", true);
+        task.addOutput("location", "http://location");
+        task.addOutput("isPersonActive", true);
         workflow.getTasks().add(task);
         Map<String, Object> taskInput = parametersUtils.getTaskInput(ip, workflow, null, null);
 
@@ -324,8 +324,8 @@ public class TestDeciderService {
         workflow.getInput().put("requestId", "request id 001");
         TaskModel task = new TaskModel();
         task.setReferenceTaskName("task2");
-        task.getOutputData().put("location", "http://location");
-        task.getOutputData().put("isPersonActive", true);
+        task.addOutput("location", "http://location");
+        task.addOutput("isPersonActive", true);
         workflow.getTasks().add(task);
         Map<String, Object> taskInput = parametersUtils.getTaskInput(ip, workflow, null, null);
 
@@ -1366,18 +1366,18 @@ public class TestDeciderService {
         names.add(name);
         names.add(name2);
 
-        workflow.getOutput().put("name", name);
-        workflow.getOutput().put("names", names);
-        workflow.getOutput().put("awards", 200);
+        workflow.addOutput("name", name);
+        workflow.addOutput("names", names);
+        workflow.addOutput("awards", 200);
 
         TaskModel task = new TaskModel();
         task.setReferenceTaskName("task2");
-        task.getOutputData().put("location", "http://location");
+        task.addOutput("location", "http://location");
         task.setStatus(TaskModel.Status.COMPLETED);
 
         TaskModel task2 = new TaskModel();
         task2.setReferenceTaskName("task3");
-        task2.getOutputData().put("refId", "abcddef_1234_7890_aaffcc");
+        task2.addOutput("refId", "abcddef_1234_7890_aaffcc");
         task2.setStatus(TaskModel.Status.SCHEDULED);
 
         workflow.getTasks().add(task);

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/EventQueueResolutionTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/EventQueueResolutionTest.java
@@ -78,12 +78,12 @@ public class EventQueueResolutionTest {
 
         TaskModel task1 = new TaskModel();
         task1.setReferenceTaskName("t1");
-        task1.getOutputData().put("q", "t1_queue");
+        task1.addOutput("q", "t1_queue");
         workflow.getTasks().add(task1);
 
         TaskModel task2 = new TaskModel();
         task2.setReferenceTaskName("t2");
-        task2.getOutputData().put("q", "task2_queue");
+        task2.addOutput("q", "task2_queue");
         workflow.getTasks().add(task2);
 
         TaskModel task = new TaskModel();

--- a/core/src/test/java/com/netflix/conductor/dao/ExecutionDAOTest.java
+++ b/core/src/test/java/com/netflix/conductor/dao/ExecutionDAOTest.java
@@ -229,7 +229,7 @@ public abstract class ExecutionDAOTest {
         for (int i = 0; i < 3; i++) {
             TaskModel found = getExecutionDAO().getTask(workflowId + "_t" + i);
             assertNotNull(found);
-            found.getOutputData().put("updated", true);
+            found.addOutput("updated", true);
             found.setStatus(TaskModel.Status.COMPLETED);
             getExecutionDAO().updateTask(found);
         }

--- a/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
+++ b/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
@@ -123,7 +123,7 @@ public class HttpTask extends WorkflowSystemTask {
             }
             //noinspection ConstantConditions
             if (response != null) {
-                task.getOutputData().put("response", response.asMap());
+                task.addOutput("response", response.asMap());
             }
 
         } catch (Exception e) {
@@ -138,7 +138,7 @@ public class HttpTask extends WorkflowSystemTask {
             task.setStatus(TaskModel.Status.FAILED);
             task.setReasonForIncompletion(
                     "Failed to invoke " + getTaskType() + " task due to: " + e);
-            task.getOutputData().put("response", e.toString());
+            task.addOutput("response", e.toString());
         }
     }
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Instead of TaskModel.getOutputData().put(), the code now uses TaskModel.addOutput(). Using "get" methods to mutate a field in the class is unconventional. It makes it hard to track the mutations of that field._
Issue #

Alternatives considered
----

_None_
