### PR TITLE
removing event handlers once it is removed from storage.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
@@ -151,6 +151,22 @@ public class DefaultEventQueueManager extends LifecycleAwareComponent implements
                     .peek(Lifecycle::start)
                     .forEach(this::listen);
 
+            Set<String> removed = new HashSet<>(eventToQueueMap.keySet());
+            removed.removeAll(events);
+            removed.forEach(key -> {
+                ObservableQueue queue = eventToQueueMap.remove(key);
+                try {
+                    queue.stop();
+                } catch (Exception e) {
+                    LOGGER.error("Failed to stop queue: " + queue, e);
+                }
+            });
+
+            LOGGER.debug("Event queues: {}", eventToQueueMap.keySet());
+            LOGGER.debug("Stored queue: {}", events);
+            LOGGER.debug("Removed queue: {}", removed);
+
+
         } catch (Exception e) {
             Monitors.error(getClass().getSimpleName(), "refresh");
             LOGGER.error("refresh event queues failed", e);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----

When conductor event handlers are removed using `DELETE /api/event/<name>`  it is just removed from storage and observable queues are never stopped.

This is a fix stops event handlers and deletes them from in-memory the same way as they are added and started