### PR TITLE
AsyncSystemTaskExecutor uses the correct value for taskType tag

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -109,9 +109,6 @@ public class ConductorProperties {
      */
     private int isolatedSystemTaskWorkerThreadCount = 1;
 
-    /** The max number of system tasks to be polled in a single request. */
-    private int systemTaskMaxPollCount = 1;
-
     /**
      * The duration of workflow execution which qualifies a workflow as a short-running workflow
      * when async indexing to elasticsearch is enabled.
@@ -371,14 +368,6 @@ public class ConductorProperties {
 
     public void setIsolatedSystemTaskWorkerThreadCount(int isolatedSystemTaskWorkerThreadCount) {
         this.isolatedSystemTaskWorkerThreadCount = isolatedSystemTaskWorkerThreadCount;
-    }
-
-    public int getSystemTaskMaxPollCount() {
-        return systemTaskMaxPollCount;
-    }
-
-    public void setSystemTaskMaxPollCount(int systemTaskMaxPollCount) {
-        this.systemTaskMaxPollCount = systemTaskMaxPollCount;
     }
 
     public Duration getAsyncUpdateShortRunningWorkflowDuration() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -135,7 +135,7 @@ public class AsyncSystemTaskExecutor {
 
             if (task.getStatus() == TaskModel.Status.SCHEDULED) {
                 task.setStartTime(System.currentTimeMillis());
-                Monitors.recordQueueWaitTime(task.getTaskDefName(), task.getQueueWaitTime());
+                Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
                 systemTask.start(workflow, task, workflowExecutor);
             } else if (task.getStatus() == TaskModel.Status.IN_PROGRESS) {
                 systemTask.execute(workflow, task, workflowExecutor);

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
@@ -59,7 +59,6 @@ public class TestSystemTaskWorker {
         when(properties.getSystemTaskWorkerThreadCount()).thenReturn(10);
         when(properties.getIsolatedSystemTaskWorkerThreadCount()).thenReturn(10);
         when(properties.getSystemTaskWorkerCallbackDuration()).thenReturn(Duration.ofSeconds(30));
-        when(properties.getSystemTaskMaxPollCount()).thenReturn(1);
         when(properties.getSystemTaskWorkerPollInterval()).thenReturn(Duration.ofSeconds(30));
 
         systemTaskWorker =
@@ -118,7 +117,6 @@ public class TestSystemTaskWorker {
 
     @Test
     public void testBatchPollAndExecuteSystemTask() throws Exception {
-        when(properties.getSystemTaskMaxPollCount()).thenReturn(2);
         when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenReturn(List.of("t1", "t1"));
 
         CountDownLatch latch = new CountDownLatch(2);
@@ -170,7 +168,6 @@ public class TestSystemTaskWorker {
     @Test
     public void testBatchPollException() {
         when(properties.getSystemTaskWorkerThreadCount()).thenReturn(2);
-        when(properties.getSystemTaskMaxPollCount()).thenReturn(2);
         when(queueDAO.pop(anyString(), anyInt(), anyInt())).thenThrow(RuntimeException.class);
 
         systemTaskWorker.pollAndExecute(new TestTask(), TEST_TASK);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_AsyncSystemTaskExecutor used TaskDefName when recording queue wait times. For system tasks, the task def name is meaningless and has high cardinality. To measure and alert on queue delays task type is ideal_


Alternatives considered
----

_None_
