### PR TITLE
re-throw TerminateWorkflowException if payload exceed max threshold s…

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -192,6 +192,8 @@ public class ExternalPayloadStorageUtils {
             }
         } catch (TransientException te) {
             throw te;
+        } catch (TerminateWorkflowException twe) {
+            throw twe;
         } catch (Exception e) {
             LOGGER.error(
                     "Unable to upload payload to external storage for workflow: {}", workflowId, e);

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
@@ -168,4 +168,19 @@ public class MockExternalPayloadStorage implements ExternalPayloadStorage {
         }
         return new HashMap<>();
     }
+
+    public Map<String, Object> createLargePayload(int repeat) {
+        Map<String, Object> largePayload = new HashMap<>();
+        try {
+            InputStream inputStream = readOutputDotJson();
+            Map<String, Object> payload = objectMapper.readValue(inputStream, Map.class);
+            for (int i = 0; i < repeat; i++) {
+                largePayload.put(String.valueOf(i), payload);
+            }
+        } catch (IOException e) {
+            // just handle this exception here and return empty map so that test will fail in case
+            // this exception is thrown
+        }
+        return largePayload;
+    }
 }


### PR DESCRIPTION
…o to fail workflow and task

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Fix the issue that if a task output exceed threshold, the workflow appears to be stuck in RUNNING state.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
