### PR TITLE
Fail workflow if input to dynamic fork join task is invalid

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -195,9 +195,17 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
             }
 
             for (TaskModel forkedTask : forkedTasks) {
-                Map<String, Object> forkedTaskInput =
-                        tasksInput.get(forkedTask.getReferenceTaskName());
-                forkedTask.addInput(forkedTaskInput);
+                try {
+                    Map<String, Object> forkedTaskInput =
+                            tasksInput.get(forkedTask.getReferenceTaskName());
+                    forkedTask.addInput(forkedTaskInput);
+                } catch (Exception e) {
+                    String reason =
+                            String.format(
+                                    "Tasks could not be dynamically forked due to invalid input: %s",
+                                    e.getMessage());
+                    throw new TerminateWorkflowException(reason);
+                }
             }
             mappedTasks.addAll(forkedTasks);
             // Get the last of the dynamic tasks so that the join can be performed once this task is


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Fix the issue that uncaught exception thrown when the task input of FORK_JOIN_DYNAMIC is invalid, and task seem to be stuck. Also startWorkflow will fail with 500 in this case if FORK_JOIN_DYNAMIC task is synchronous evaluated when workflow starts.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
