### PR TITLE
JOIN task is made async

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
@@ -101,7 +101,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
  *   <li>UPDATE conductor.workflows SET payload=? WHERE workflow_id=? AND shard_id=1 AND
  *       entity='workflow' AND task_id='';
  *   <li>UPDATE conductor.workflows SET total_tasks=? WHERE workflow_id=? AND shard_id=?;
- *   <li>UPDATE conductor.workflows SET * total_partitions=?,total_tasks=? WHERE workflow_id=? AND
+ *   <li>UPDATE conductor.workflows SET total_partitions=?,total_tasks=? WHERE workflow_id=? AND
  *       shard_id=1;
  *   <li>UPDATE conductor.task_lookup SET workflow_id=? WHERE task_id=?;
  *   <li>UPDATE conductor.task_def_limit SET workflow_id=? WHERE task_def_name=? AND task_id=?;

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -97,4 +97,8 @@ public class Join extends WorkflowSystemTask {
         }
         return false;
     }
+
+    public boolean isAsync() {
+        return true;
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -190,10 +190,8 @@ public class ExternalPayloadStorageUtils {
                         break;
                 }
             }
-        } catch (TransientException te) {
+        } catch (TransientException | TerminateWorkflowException te) {
             throw te;
-        } catch (TerminateWorkflowException twe) {
-            throw twe;
         } catch (Exception e) {
             LOGGER.error(
                     "Unable to upload payload to external storage for workflow: {}", workflowId, e);
@@ -223,7 +221,6 @@ public class ExternalPayloadStorageUtils {
         } else {
             task.setOutputData(new HashMap<>());
         }
-        throw new TerminateWorkflowException(errorMsg, WorkflowModel.Status.FAILED, task);
     }
 
     @VisibleForTesting

--- a/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
@@ -41,6 +41,8 @@ import com.netflix.conductor.model.WorkflowModel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static com.netflix.conductor.model.TaskModel.Status.FAILED_WITH_TERMINAL_ERROR;
+
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -199,11 +201,11 @@ public class ExternalPayloadStorageUtilsTest {
         TaskModel task = new TaskModel();
         task.setInputData(new HashMap<>());
 
-        expectedException.expect(TerminateWorkflowException.class);
         externalPayloadStorageUtils.failTask(
                 task, ExternalPayloadStorage.PayloadType.TASK_INPUT, "error");
         assertNotNull(task);
         assertTrue(task.getInputData().isEmpty());
+        assertEquals(FAILED_WITH_TERMINAL_ERROR, task.getStatus());
     }
 
     @Test
@@ -211,11 +213,11 @@ public class ExternalPayloadStorageUtilsTest {
         TaskModel task = new TaskModel();
         task.setOutputData(new HashMap<>());
 
-        expectedException.expect(TerminateWorkflowException.class);
         externalPayloadStorageUtils.failTask(
                 task, ExternalPayloadStorage.PayloadType.TASK_OUTPUT, "error");
         assertNotNull(task);
         assertTrue(task.getOutputData().isEmpty());
+        assertEquals(FAILED_WITH_TERMINAL_ERROR, task.getStatus());
     }
 
     @Test

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DecisionTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DecisionTaskSpec.groovy
@@ -12,8 +12,12 @@
  */
 package com.netflix.conductor.test.integration
 
+import org.springframework.beans.factory.annotation.Autowired
+
 import com.netflix.conductor.common.metadata.tasks.Task
 import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.Join
+import com.netflix.conductor.dao.QueueDAO
 import com.netflix.conductor.test.base.AbstractSpecification
 
 import spock.lang.Shared
@@ -22,6 +26,9 @@ import spock.lang.Unroll
 import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
 
 class DecisionTaskSpec extends AbstractSpecification {
+
+    @Autowired
+    Join joinTask
 
     @Shared
     def DECISION_WF = "DecisionWorkflow"
@@ -139,6 +146,7 @@ class DecisionTaskSpec extends AbstractSpecification {
         }
 
         when: "the tasks 'integration_task_1' and 'integration_task_10' are polled and completed"
+        def joinTaskId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("joinTask").taskId
         def polledAndCompletedTask1Try1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker')
         def polledAndCompletedTask10Try1 = workflowTestUtil.pollAndCompleteTask('integration_task_10', 'task1.integration.worker')
 
@@ -189,7 +197,10 @@ class DecisionTaskSpec extends AbstractSpecification {
         then: "verify that the task is completed and acknowledged"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask20Try1)
 
-        and: "verify that the 'integration_task_2' is COMPLETED and the workflow has progressed"
+        when: "JOIN task is polled and executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinTaskId)
+
+        then: "verify that JOIN is COMPLETED and the workflow has progressed"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.COMPLETED
             tasks.size() == 7

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
@@ -18,6 +18,7 @@ import com.netflix.conductor.common.metadata.tasks.Task
 import com.netflix.conductor.common.metadata.tasks.TaskDef
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.common.utils.TaskUtils
+import com.netflix.conductor.core.execution.tasks.Join
 import com.netflix.conductor.core.execution.tasks.SubWorkflow
 import com.netflix.conductor.test.base.AbstractSpecification
 
@@ -26,18 +27,21 @@ import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAc
 class DoWhileSpec extends AbstractSpecification {
 
     @Autowired
+    Join joinTask
+
+    @Autowired
     SubWorkflow subWorkflowTask
 
     def setup() {
-        workflowTestUtil.registerWorkflows("do_while_integration_test.json",
-                "do_while_multiple_integration_test.json",
-                "do_while_as_subtask_integration_test.json",
+        workflowTestUtil.registerWorkflows('do_while_integration_test.json',
+                'do_while_multiple_integration_test.json',
+                'do_while_as_subtask_integration_test.json',
                 'simple_one_task_sub_workflow_integration_test.json',
                 'do_while_iteration_fix_test.json',
-                "do_while_sub_workflow_integration_test.json",
-        "do_while_five_loop_over_integration_test.json",
-        "do_while_system_tasks.json",
-                "do_while_set_variable_fix.json")
+                'do_while_sub_workflow_integration_test.json',
+                'do_while_five_loop_over_integration_test.json',
+                'do_while_system_tasks.json',
+                'do_while_set_variable_fix.json')
     }
 
     def "Test workflow with 2 iterations of five tasks"() {
@@ -275,6 +279,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second task"
+        def joinId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__1").taskId
         Tuple polledAndCompletedTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -299,6 +304,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing third task"
         Tuple polledAndCompletedTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinId)
 
         then: "Verify that the task was polled and acknowledged and workflow is in completed state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)
@@ -363,6 +371,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second task"
+        def joinId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__1").taskId
         Tuple polledAndCompletedTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -387,6 +396,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing third task"
         Tuple polledAndCompletedTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinId)
 
         then: "Verify that the task was polled and acknowledged and workflow is in completed state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)
@@ -528,6 +540,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second task"
+        def join1Id = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__1").taskId
         Tuple polledAndCompletedTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -552,6 +565,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing third task"
         Tuple polledAndCompletedTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, join1Id)
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)
@@ -609,6 +625,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second iteration of second task"
+        def join2Id = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__2").taskId
         Tuple polledAndCompletedSecondIterationTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -643,6 +660,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing second iteration of third task"
         Tuple polledAndCompletedSecondIterationTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, join2Id)
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedSecondIterationTask2)
@@ -796,6 +816,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second task"
+        def joinId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__1").taskId
         Tuple polledAndCompletedTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -822,6 +843,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing third task"
         Tuple polledAndCompletedTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinId)
 
         then: "Verify that the task was polled and acknowledged and workflow is in completed state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)
@@ -920,6 +944,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing second task"
+        def joinId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join__1").taskId
         Tuple polledAndCompletedTask1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -946,6 +971,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         when: "Polling and completing third task"
         Tuple polledAndCompletedTask2 = workflowTestUtil.pollAndCompleteTask('integration_task_2', 'integration.test.worker')
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinId)
 
         then: "Verify that the task was polled and acknowledged and workflow is in completed state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)
@@ -998,6 +1026,7 @@ class DoWhileSpec extends AbstractSpecification {
         }
 
         when: "Polling and completing first task in DO While"
+        def joinId = workflowExecutionService.getExecutionStatus(workflowInstanceId, true).getTaskByRefName("join").taskId
         Tuple polledAndCompletedTask0 = workflowTestUtil.pollAndCompleteTask('integration_task_0', 'integration.test.worker')
 
         then: "Verify that the task was polled and acknowledged and workflow is in running state"
@@ -1048,6 +1077,9 @@ class DoWhileSpec extends AbstractSpecification {
 
         and: "the workflow is evaluated"
         sweep(workflowInstanceId)
+
+        and: "JOIN task is executed"
+        asyncSystemTaskExecutor.execute(joinTask, joinId)
 
         then: "Verify that the task was polled and acknowledged and workflow is in completed state"
         verifyPolledAndAcknowledgedTask(polledAndCompletedTask2)


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
The JOIN task is made async and will be evaluated by the async system task executor and the system task workers off the JOIN task queue. This improves the efficiency of workflow evaluations because the workflow will now be evaluated only after the JOIN task reaches a terminal state rather than for every forked task update leading to empty evaluations.
