### PR TITLE
Set unack/postpone duration based on task state

### DIFF
--- a/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraMetadataDAOSpec.groovy
+++ b/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraMetadataDAOSpec.groovy
@@ -139,6 +139,33 @@ class CassandraMetadataDAOSpec extends CassandraSpec {
         metadataDAO.getTaskDef(task2Name) == null
     }
 
+    def "set default response timeout when not set"() {
+        given:
+        String task1Name = "task1"
+
+        when: // register a task definition
+        TaskDef taskDef = new TaskDef()
+        taskDef.setName(task1Name)
+        taskDef.setResponseTimeoutSeconds(0)
+        metadataDAO.createTaskDef(taskDef)
+        def returnTaskDef = metadataDAO.getTaskDef(task1Name)
+
+        then:
+        returnTaskDef.getResponseTimeoutSeconds() == 3600
+
+        when: // register another task definition
+        taskDef.setTimeoutSeconds(200)
+        taskDef.setResponseTimeoutSeconds(0)
+        metadataDAO.updateTaskDef(taskDef)
+        // fetch all task defs
+        def taskDefList = metadataDAO.getAllTaskDefs()
+
+        then:
+        taskDefList && taskDefList.size() == 1
+        taskDefList.get(0).getResponseTimeoutSeconds() == 199
+
+    }
+
     def "parse index string"() {
         expect:
         def pair = metadataDAO.getWorkflowNameAndVersion(nameVersionStr)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -157,7 +157,9 @@ public class TaskDef extends BaseDef {
         this.ownerEmail = ownerEmail;
         this.retryCount = retryCount;
         this.timeoutSeconds = timeoutSeconds;
-        this.responseTimeoutSeconds = responseTimeoutSeconds;
+        if (responseTimeoutSeconds != 0) {
+            this.responseTimeoutSeconds = responseTimeoutSeconds;
+        }
     }
 
     /**
@@ -291,7 +293,9 @@ public class TaskDef extends BaseDef {
      *     task will be re-queued
      */
     public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
-        this.responseTimeoutSeconds = responseTimeoutSeconds;
+        if (responseTimeoutSeconds != 0) {
+            this.responseTimeoutSeconds = responseTimeoutSeconds;
+        }
     }
 
     /**

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -51,7 +51,7 @@ public class TaskDef extends BaseDef {
         LINEAR_BACKOFF
     }
 
-    private static final int ONE_HOUR = 60 * 60;
+    public static final int ONE_HOUR = 60 * 60;
 
     /** Unique name identifying the task. The name is unique across */
     @NotEmpty(message = "TaskDef name cannot be null or empty")
@@ -157,9 +157,7 @@ public class TaskDef extends BaseDef {
         this.ownerEmail = ownerEmail;
         this.retryCount = retryCount;
         this.timeoutSeconds = timeoutSeconds;
-        if (responseTimeoutSeconds != 0) {
-            this.responseTimeoutSeconds = responseTimeoutSeconds;
-        }
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
     }
 
     /**
@@ -293,9 +291,7 @@ public class TaskDef extends BaseDef {
      *     task will be re-queued
      */
     public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
-        if (responseTimeoutSeconds != 0) {
-            this.responseTimeoutSeconds = responseTimeoutSeconds;
-        }
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import com.netflix.conductor.annotations.VisibleForTesting;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
@@ -103,12 +104,13 @@ public class WorkflowSweeper {
         }
     }
 
+    @VisibleForTesting
     void unack(WorkflowModel workflowModel) {
         long postponeDurationSeconds = 0;
         for (TaskModel taskModel : workflowModel.getTasks()) {
             if (taskModel.getStatus() == Status.IN_PROGRESS) {
-                if (taskModel.getTaskType() == TaskType.TASK_TYPE_WAIT
-                        || taskModel.getTaskType() == TaskType.TASK_TYPE_HUMAN) {
+                if (taskModel.getTaskType().equals(TaskType.TASK_TYPE_WAIT)
+                        || taskModel.getTaskType().equals(TaskType.TASK_TYPE_HUMAN)) {
                     postponeDurationSeconds =
                             (taskModel.getWaitTimeout() != 0)
                                     ? taskModel.getWaitTimeout() + 1
@@ -141,12 +143,13 @@ public class WorkflowSweeper {
                         postponeDurationSeconds =
                                 (workflowModel.getWorkflowDefinition().getTimeoutSeconds() != 0)
                                         ? workflowModel.getWorkflowDefinition().getTimeoutSeconds()
+                                                + 1
                                         : properties.getWorkflowOffsetTimeout().getSeconds();
                     }
                 } else {
                     postponeDurationSeconds =
                             (workflowModel.getWorkflowDefinition().getTimeoutSeconds() != 0)
-                                    ? workflowModel.getWorkflowDefinition().getTimeoutSeconds()
+                                    ? workflowModel.getWorkflowDefinition().getTimeoutSeconds() + 1
                                     : properties.getWorkflowOffsetTimeout().getSeconds();
                 }
                 break;

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.reconciliation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.TaskModel.Status;
+import com.netflix.conductor.model.WorkflowModel;
+
+import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestWorkflowSweeper {
+
+    private ConductorProperties properties;
+    private WorkflowExecutor workflowExecutor;
+    private WorkflowRepairService workflowRepairService;
+    private QueueDAO queueDAO;
+    private WorkflowSweeper workflowSweeper;
+
+    private int defaultPostPoneOffSetSeconds = 1800;
+
+    @Before
+    public void setUp() {
+        properties = mock(ConductorProperties.class);
+        workflowExecutor = mock(WorkflowExecutor.class);
+        queueDAO = mock(QueueDAO.class);
+        workflowRepairService = mock(WorkflowRepairService.class);
+        workflowSweeper =
+                new WorkflowSweeper(
+                        workflowExecutor, Optional.of(workflowRepairService), properties, queueDAO);
+    }
+
+    @Test
+    public void testPostponeDurationForWaitTaskType() {
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_WAIT);
+        taskModel.setStatus(Status.IN_PROGRESS);
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE,
+                        workflowModel.getWorkflowId(),
+                        defaultPostPoneOffSetSeconds * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForWaitTaskTypeWithWaitTime() {
+        long waitTimeout = 180;
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_WAIT);
+        taskModel.setStatus(Status.IN_PROGRESS);
+        taskModel.setWaitTimeout(waitTimeout);
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE, workflowModel.getWorkflowId(), (waitTimeout + 1) * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInProgress() {
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_SIMPLE);
+        taskModel.setStatus(Status.IN_PROGRESS);
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE,
+                        workflowModel.getWorkflowId(),
+                        defaultPostPoneOffSetSeconds * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInProgressWithResponseTimeoutSet() {
+        long responseTimeout = 200;
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_SIMPLE);
+        taskModel.setStatus(Status.IN_PROGRESS);
+        taskModel.setResponseTimeoutSeconds(responseTimeout);
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE, workflowModel.getWorkflowId(), (responseTimeout + 1) * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduled() {
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowModel.setWorkflowDefinition(workflowDef);
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_SIMPLE);
+        taskModel.setStatus(Status.SCHEDULED);
+        taskModel.setReferenceTaskName("task1");
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE,
+                        workflowModel.getWorkflowId(),
+                        defaultPostPoneOffSetSeconds * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduledWithWorkflowTimeoutSet() {
+        long workflowTimeout = 1800;
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setTimeoutSeconds(workflowTimeout);
+        workflowModel.setWorkflowDefinition(workflowDef);
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId("task1");
+        taskModel.setTaskType(TaskType.TASK_TYPE_SIMPLE);
+        taskModel.setStatus(Status.SCHEDULED);
+        workflowModel.setTasks(List.of(taskModel));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE, workflowModel.getWorkflowId(), (workflowTimeout + 1) * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduledWithWorkflowTimeoutSetAndNoPollTimeout() {
+        long workflowTimeout = 1800;
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setTimeoutSeconds(workflowTimeout);
+        workflowModel.setWorkflowDefinition(workflowDef);
+        TaskDef taskDef = new TaskDef();
+        TaskModel taskModel = mock(TaskModel.class);
+        workflowModel.setTasks(List.of(taskModel));
+        when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
+        when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE, workflowModel.getWorkflowId(), (workflowTimeout + 1) * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduledWithNoWorkflowTimeoutSetAndNoPollTimeout() {
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowModel.setWorkflowDefinition(workflowDef);
+        TaskDef taskDef = new TaskDef();
+        TaskModel taskModel = mock(TaskModel.class);
+        workflowModel.setTasks(List.of(taskModel));
+        when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
+        when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE,
+                        workflowModel.getWorkflowId(),
+                        defaultPostPoneOffSetSeconds * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduledWithNoPollTimeoutSet() {
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskDef taskDef = new TaskDef();
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowModel.setWorkflowDefinition(workflowDef);
+        TaskModel taskModel = mock(TaskModel.class);
+        workflowModel.setTasks(List.of(taskModel));
+        when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
+        when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE,
+                        workflowModel.getWorkflowId(),
+                        defaultPostPoneOffSetSeconds * 1000);
+    }
+
+    @Test
+    public void testPostponeDurationForTaskInScheduledWithPollTimeoutSet() {
+        int pollTimeout = 200;
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowId("1");
+        TaskDef taskDef = new TaskDef();
+        taskDef.setPollTimeoutSeconds(pollTimeout);
+        TaskModel taskModel = mock(TaskModel.class);
+        ;
+        workflowModel.setTasks(List.of(taskModel));
+        when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
+        when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
+        when(properties.getWorkflowOffsetTimeout())
+                .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
+        workflowSweeper.unack(workflowModel);
+        verify(queueDAO)
+                .setUnackTimeout(
+                        DECIDER_QUEUE, workflowModel.getWorkflowId(), (pollTimeout + 1) * 1000);
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -129,6 +129,25 @@ public class MetadataServiceTest {
     }
 
     @Test(expected = ConstraintViolationException.class)
+    public void testRegisterTaskDefNoResponseTimeout() {
+        try {
+            TaskDef taskDef = new TaskDef();
+            taskDef.setName("somename");
+            taskDef.setOwnerEmail("sample@test.com");
+            taskDef.setResponseTimeoutSeconds(0);
+            metadataService.registerTaskDef(Collections.singletonList(taskDef));
+        } catch (ConstraintViolationException ex) {
+            assertEquals(1, ex.getConstraintViolations().size());
+            Set<String> messages = getConstraintViolationMessages(ex.getConstraintViolations());
+            assertTrue(
+                    messages.contains(
+                            "TaskDef responseTimeoutSeconds: 0 should be minimum 1 second"));
+            throw ex;
+        }
+        fail("metadataService.registerTaskDef did not throw ConstraintViolationException !");
+    }
+
+    @Test(expected = ConstraintViolationException.class)
     public void testUpdateTaskDefNameNull() {
         try {
             TaskDef taskDef = new TaskDef();

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -129,25 +129,6 @@ public class MetadataServiceTest {
     }
 
     @Test(expected = ConstraintViolationException.class)
-    public void testRegisterTaskDefNoResponseTimeout() {
-        try {
-            TaskDef taskDef = new TaskDef();
-            taskDef.setName("somename");
-            taskDef.setOwnerEmail("sample@test.com");
-            taskDef.setResponseTimeoutSeconds(0);
-            metadataService.registerTaskDef(Collections.singletonList(taskDef));
-        } catch (ConstraintViolationException ex) {
-            assertEquals(1, ex.getConstraintViolations().size());
-            Set<String> messages = getConstraintViolationMessages(ex.getConstraintViolations());
-            assertTrue(
-                    messages.contains(
-                            "TaskDef responseTimeoutSeconds: 0 should be minimum 1 second"));
-            throw ex;
-        }
-        fail("metadataService.registerTaskDef did not throw ConstraintViolationException !");
-    }
-
-    @Test(expected = ConstraintViolationException.class)
     public void testUpdateTaskDefNameNull() {
         try {
             TaskDef taskDef = new TaskDef();

--- a/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisMetadataDAOTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisMetadataDAOTest.java
@@ -225,4 +225,34 @@ public class RedisMetadataDAOTest {
     public void testRemoveTaskDef() {
         redisMetadataDAO.removeTaskDef("test" + UUID.randomUUID());
     }
+
+    @Test
+    public void testDefaultsAreSetForResponseTimeout() {
+        TaskDef def = new TaskDef("taskA");
+        def.setDescription("description");
+        def.setCreatedBy("unit_test");
+        def.setCreateTime(1L);
+        def.setInputKeys(Arrays.asList("a", "b", "c"));
+        def.setOutputKeys(Arrays.asList("01", "o2"));
+        def.setOwnerApp("ownerApp");
+        def.setRetryCount(3);
+        def.setRetryDelaySeconds(100);
+        def.setRetryLogic(RetryLogic.FIXED);
+        def.setTimeoutPolicy(TimeoutPolicy.ALERT_ONLY);
+        def.setUpdatedBy("unit_test2");
+        def.setUpdateTime(2L);
+        def.setRateLimitPerFrequency(50);
+        def.setRateLimitFrequencyInSeconds(1);
+        def.setResponseTimeoutSeconds(0);
+
+        redisMetadataDAO.createTaskDef(def);
+
+        TaskDef found = redisMetadataDAO.getTaskDef(def.getName());
+        assertEquals(found.getResponseTimeoutSeconds(), 3600);
+        found.setTimeoutSeconds(200);
+        found.setResponseTimeoutSeconds(0);
+        redisMetadataDAO.updateTaskDef(found);
+        TaskDef foundNew = redisMetadataDAO.getTaskDef(def.getName());
+        assertEquals(foundNew.getResponseTimeoutSeconds(), 199);
+    }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Set unack/postpone duration based on task state. 

_Describe the new behavior from this PR, and why it's needed_
For workflows with a task in IN_PROGRESS state, the postpone duration is set as (responseTimeoutSeconds + 1). Multiple tasks in IN_PROGRESS state, use the first task. If responseTimeoutSeconds is 0, use a default non-zero value as postpone duration.

For workflows with a task in SCHEDULED state, the postpone duration is set as (pollTimeoutSeconds + 1). If pollTimeoutSeconds is not set, the workflowDef.timeoutSeconds is used for postponeDuration. If the workflowDef.timeoutSeconds is not set, a default non-zero value is used the postpone duration. Multiple tasks in SCHEDULED state, use the first task's value. For deducing the default value, the queue_wait_time metric can be used.

For workflows with a WAIT task in IN_PROGRESS state, the postpone duration is set as the wait timeout seconds computed on the task. If wait timeout is not set, this task is waiting for an external trigger to complete the task. In such cases, the postpone duration will be a default non-zero value.

Alternatives considered
----

_Describe alternative implementation you have considered_
