### PR TITLE
Updated serverAndUI Dockerfile to set the correct startup script

### DIFF
--- a/docker/serverAndUI/Dockerfile
+++ b/docker/serverAndUI/Dockerfile
@@ -44,8 +44,8 @@ LABEL maintainer="Netflix OSS <conductor@netflix.com>"
 RUN mkdir -p /app/config /app/logs /app/libs
 
 # Copy the compiled output to new image
-COPY --from=builder /conductor/docker/server/bin /app
-COPY --from=builder /conductor/docker/server/config /app/config
+COPY --from=builder /conductor/docker/serverAndUI/bin /app
+COPY --from=builder /conductor/docker/serverAndUI/config /app/config
 COPY --from=builder /conductor/server/build/libs/conductor-server-*-boot.jar /app/libs
 
 # Copy compiled UI assets to nginx www directory

--- a/docs/docs/gettingstarted/docker.md
+++ b/docs/docs/gettingstarted/docker.md
@@ -111,7 +111,10 @@ Go to [http://127.0.0.1:9090](http://127.0.0.1:9090).
 This image at `/docker/serverAndUI` is provided to illustrate starting both the server & UI within the same container. The UI is hosted using nginx.
 
 ### Building the combined image
-`docker build -t conductor:serverAndUI .`
+From the `docker` directory,
+```
+docker build -t conductor:serverAndUI -f serverAndUI/Dockerfile ../
+```
 
 ### Running the combined image
  - With interal DB: `docker run -p 8080:8080 -p 80:5000 -d -t conductor:serverAndUI`


### PR DESCRIPTION
Set the correct startup script so that the UI is served.

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Updated the Dockerfile for the combined server and UI combined image.

_Describe the new behavior from this PR, and why it's needed_
The front end was not being served. The Dockerfile now uses the correct startup script.

Alternatives considered
----

_Describe alternative implementation you have considered_
