### PR TITLE
Add constructor for ManagedChannelBuilder in grpc client

### DIFF
--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/EventClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/EventClient.java
@@ -23,6 +23,7 @@ import com.netflix.conductor.proto.EventHandlerPb;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
+import io.grpc.ManagedChannelBuilder;
 
 public class EventClient extends ClientBase {
 
@@ -30,6 +31,11 @@ public class EventClient extends ClientBase {
 
     public EventClient(String address, int port) {
         super(address, port);
+        this.stub = EventServiceGrpc.newBlockingStub(this.channel);
+    }
+
+    public EventClient(ManagedChannelBuilder<?> builder) {
+        super(builder);
         this.stub = EventServiceGrpc.newBlockingStub(this.channel);
     }
 

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/MetadataClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/MetadataClient.java
@@ -24,6 +24,7 @@ import com.netflix.conductor.grpc.MetadataServiceGrpc;
 import com.netflix.conductor.grpc.MetadataServicePb;
 
 import com.google.common.base.Preconditions;
+import io.grpc.ManagedChannelBuilder;
 
 public class MetadataClient extends ClientBase {
 
@@ -31,6 +32,11 @@ public class MetadataClient extends ClientBase {
 
     public MetadataClient(String address, int port) {
         super(address, port);
+        this.stub = MetadataServiceGrpc.newBlockingStub(this.channel);
+    }
+
+    public MetadataClient(ManagedChannelBuilder<?> builder) {
+        super(builder);
         this.stub = MetadataServiceGrpc.newBlockingStub(this.channel);
     }
 

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/TaskClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/TaskClient.java
@@ -33,6 +33,7 @@ import com.netflix.conductor.proto.TaskPb;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import io.grpc.ManagedChannelBuilder;
 
 public class TaskClient extends ClientBase {
 
@@ -40,6 +41,11 @@ public class TaskClient extends ClientBase {
 
     public TaskClient(String address, int port) {
         super(address, port);
+        this.stub = TaskServiceGrpc.newBlockingStub(this.channel);
+    }
+
+    public TaskClient(ManagedChannelBuilder<?> builder) {
+        super(builder);
         this.stub = TaskServiceGrpc.newBlockingStub(this.channel);
     }
 

--- a/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
+++ b/grpc-client/src/main/java/com/netflix/conductor/client/grpc/WorkflowClient.java
@@ -31,6 +31,7 @@ import com.netflix.conductor.grpc.WorkflowServicePb;
 import com.netflix.conductor.proto.WorkflowPb;
 
 import com.google.common.base.Preconditions;
+import io.grpc.ManagedChannelBuilder;
 
 public class WorkflowClient extends ClientBase {
 
@@ -38,6 +39,11 @@ public class WorkflowClient extends ClientBase {
 
     public WorkflowClient(String address, int port) {
         super(address, port);
+        this.stub = WorkflowServiceGrpc.newBlockingStub(this.channel);
+    }
+
+    public WorkflowClient(ManagedChannelBuilder<?> builder) {
+        super(builder);
         this.stub = WorkflowServiceGrpc.newBlockingStub(this.channel);
     }
 

--- a/grpc-client/src/test/java/com/netflix/conductor/client/grpc/EventClientTest.java
+++ b/grpc-client/src/test/java/com/netflix/conductor/client/grpc/EventClientTest.java
@@ -99,9 +99,25 @@ public class EventClientTest {
 
     @Test
     public void testUnregisterEventHandler() {
+        EventClient eventClient = createClientWithManagedChannel();
         EventServicePb.RemoveEventHandlerRequest request =
                 EventServicePb.RemoveEventHandlerRequest.newBuilder().setName("test").build();
         eventClient.unregisterEventHandler("test");
         verify(mockedStub, times(1)).removeEventHandler(request);
+    }
+
+    @Test
+    public void testUnregisterEventHandlerWithManagedChannel() {
+        EventServicePb.RemoveEventHandlerRequest request =
+                EventServicePb.RemoveEventHandlerRequest.newBuilder().setName("test").build();
+        eventClient.unregisterEventHandler("test");
+        verify(mockedStub, times(1)).removeEventHandler(request);
+    }
+
+    public EventClient createClientWithManagedChannel() {
+        EventClient eventClient = new EventClient("test", 0);
+        ReflectionTestUtils.setField(eventClient, "stub", mockedStub);
+        ReflectionTestUtils.setField(eventClient, "protoMapper", mockedProtoMapper);
+        return eventClient;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue # Added a new constructor in grpc clients to pass ManagedChannelBuilder<?> object, which will enable different configurations, such as TLs, keepalive extension. 

Alternatives considered
----
N.A.
_Describe alternative implementation you have considered_

N.A.
