### PR TITLE
Add jitter to workflowoffset time

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -154,6 +154,13 @@ public class WorkflowSweeper {
                 DECIDER_QUEUE, workflowModel.getWorkflowId(), postponeDurationSeconds * 1000);
     }
 
+    /**
+     * jitter will be +- (1/3) workflowOffsetTimeout for example, if workflowOffsetTimeout is 45
+     * seconds, this function returns values between [30-60] seconds
+     *
+     * @param workflowOffsetTimeout
+     * @return
+     */
     @VisibleForTesting
     long workflowOffsetWithJitter(long workflowOffsetTimeout) {
         long range = workflowOffsetTimeout / 3;

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -394,6 +394,11 @@ public class Monitors {
                 .record(duration, TimeUnit.MILLISECONDS);
     }
 
+    public static void recordUnackTime(String workflowType, long duration) {
+        getTimer(classQualifier, "workflow_unack", "workflowName", workflowType)
+                .record(duration, TimeUnit.MILLISECONDS);
+    }
+
     public static void recordTaskRateLimited(String taskDefName, int limit) {
         gauge(classQualifier, "task_rate_limited", limit, "taskType", taskDefName);
     }

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
@@ -31,6 +31,7 @@ import com.netflix.conductor.model.WorkflowModel;
 
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,7 +68,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE,
@@ -88,7 +89,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE, workflowModel.getWorkflowId(), (waitTimeout + 1) * 1000);
@@ -105,7 +106,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE,
@@ -126,7 +127,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE, workflowModel.getWorkflowId(), (responseTimeout + 1) * 1000);
@@ -146,7 +147,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE,
@@ -169,7 +170,7 @@ public class TestWorkflowSweeper {
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE, workflowModel.getWorkflowId(), (workflowTimeout + 1) * 1000);
@@ -190,7 +191,7 @@ public class TestWorkflowSweeper {
         when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE, workflowModel.getWorkflowId(), (workflowTimeout + 1) * 1000);
@@ -209,7 +210,7 @@ public class TestWorkflowSweeper {
         when(taskModel.getStatus()).thenReturn(Status.SCHEDULED);
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE,
@@ -230,7 +231,7 @@ public class TestWorkflowSweeper {
         when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE,
@@ -252,9 +253,19 @@ public class TestWorkflowSweeper {
         when(taskModel.getTaskDefinition()).thenReturn(Optional.of(taskDef));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
-        workflowSweeper.unack(workflowModel);
+        workflowSweeper.unack(workflowModel, defaultPostPoneOffSetSeconds);
         verify(queueDAO)
                 .setUnackTimeout(
                         DECIDER_QUEUE, workflowModel.getWorkflowId(), (pollTimeout + 1) * 1000);
+    }
+
+    @Test
+    public void testWorkflowOffsetJitter() {
+        long offset = 45;
+        for (int i = 0; i < 10; i++) {
+            long offsetWithJitter = workflowSweeper.workflowOffsetWithJitter(offset);
+            assertTrue(offsetWithJitter >= 30);
+            assertTrue(offsetWithJitter <= 60);
+        }
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Add a jitter to the default wokflowOffsettime to spread out the load on the queue.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
