### PR TITLE
Check loop task delimiter in filter

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
@@ -14,7 +14,7 @@ package com.netflix.conductor.common.utils;
 
 public class TaskUtils {
 
-    private static final String LOOP_TASK_DELIMITER = "__";
+    public static final String LOOP_TASK_DELIMITER = "__";
 
     public static String appendIteration(String name, int iteration) {
         return name + LOOP_TASK_DELIMITER + iteration;

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -133,9 +133,11 @@ public class SimpleActionProcessor implements ActionProcessor {
                     workflow.getTasks().stream()
                             .filter(
                                     t ->
-                                            TaskUtils.removeIterationFromTaskRefName(
-                                                            t.getReferenceTaskName())
-                                                    .equals(taskRefName))
+                                            t.getReferenceTaskName()
+                                                            .contains(TaskUtils.LOOP_TASK_DELIMITER)
+                                                    && TaskUtils.removeIterationFromTaskRefName(
+                                                                    t.getReferenceTaskName())
+                                                            .equals(taskRefName))
                             .collect(Collectors.toList());
             if (!loopOverTaskList.isEmpty()) {
                 // Find loopover task with the highest iteration value


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

All tasks under a task reference name is check as a loop over task when it does not contain the delimiter. This add the check to ensure only what seems to be a loop over task based on the delimiter will be worked on.
Issue #3309