### PR TITLE
set optional SUB_WORKFLOW task to COMPLETED_WITH_ERRORS when the sub-…

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.execution.tasks;
 
 import java.util.Map;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,7 +177,13 @@ public class SubWorkflow extends WorkflowSystemTask {
                 task.setStatus(TaskModel.Status.COMPLETED);
                 break;
             case FAILED:
-                task.setStatus(TaskModel.Status.FAILED);
+                WorkflowTask workflowTask = task.getWorkflowTask();
+                if(workflowTask != null && workflowTask.isOptional()){
+                    task.setStatus(TaskModel.Status.COMPLETED_WITH_ERRORS);
+                }else {
+                    task.setStatus(TaskModel.Status.FAILED);
+                }
+
                 break;
             case TERMINATED:
                 task.setStatus(TaskModel.Status.CANCELED);

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
@@ -15,6 +15,8 @@ package com.netflix.conductor.core.execution.tasks;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -300,6 +302,9 @@ public class TestSubWorkflow {
         Map<String, Object> outputData = new HashMap<>();
         task.setOutputData(outputData);
         task.setSubWorkflowId("sub-workflow-id");
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setOptional(false);
+        task.setWorkflowTask(workflowTask);
 
         Map<String, Object> inputData = new HashMap<>();
         inputData.put("subWorkflowName", "UnitWorkFlow");
@@ -337,6 +342,13 @@ public class TestSubWorkflow {
         assertTrue(subWorkflow.execute(workflowInstance, task, workflowExecutor));
         assertEquals(TaskModel.Status.FAILED, task.getStatus());
         assertTrue(task.getReasonForIncompletion().contains("unit1"));
+
+        subWorkflowInstance.setStatus(WorkflowModel.Status.FAILED);
+        subWorkflowInstance.setReasonForIncompletion("optional failure");
+        workflowTask.setOptional(true);
+        assertTrue(subWorkflow.execute(workflowInstance, task, workflowExecutor));
+        assertEquals(TaskModel.Status.COMPLETED_WITH_ERRORS, task.getStatus());
+        workflowTask.setOptional(false);
 
         subWorkflowInstance.setStatus(WorkflowModel.Status.TIMED_OUT);
         subWorkflowInstance.setReasonForIncompletion("unit2");


### PR DESCRIPTION
…workflow failed

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

set the status of sub_workflow task correctly when it is optional
Issue #3293

Alternatives considered
----

_Describe alternative implementation you have considered_
