### PR TITLE
Event task retry fix.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -132,7 +132,7 @@ public class SimpleActionProcessor implements ActionProcessor {
             List<TaskModel> loopOverTaskList =
                     workflow.getTasks().stream()
                             .filter(
-                                    t ->
+                                    t -> t.isLoopOverTask() &&
                                             TaskUtils.removeIterationFromTaskRefName(
                                                             t.getReferenceTaskName())
                                                     .equals(taskRefName))

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -132,10 +132,11 @@ public class SimpleActionProcessor implements ActionProcessor {
             List<TaskModel> loopOverTaskList =
                     workflow.getTasks().stream()
                             .filter(
-                                    t -> t.isLoopOverTask() &&
-                                            TaskUtils.removeIterationFromTaskRefName(
-                                                            t.getReferenceTaskName())
-                                                    .equals(taskRefName))
+                                    t ->
+                                            t.isLoopOverTask()
+                                                    && TaskUtils.removeIterationFromTaskRefName(
+                                                                    t.getReferenceTaskName())
+                                                            .equals(taskRefName))
                             .collect(Collectors.toList());
             if (!loopOverTaskList.isEmpty()) {
                 // Find loopover task with the highest iteration value

--- a/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
@@ -255,6 +255,52 @@ public class TestSimpleActionProcessor {
     }
 
     @Test
+    public void testCompleteSimpleTask() throws Exception {
+        TaskDetails taskDetails = new TaskDetails();
+        taskDetails.setWorkflowId("${workflowId}");
+        taskDetails.setTaskRefName("testTask");
+        taskDetails.getOutput().put("someNEKey", "${Message.someNEKey}");
+        taskDetails.getOutput().put("someKey", "${Message.someKey}");
+        taskDetails.getOutput().put("someNullKey", "${Message.someNullKey}");
+
+        Action action = new Action();
+        action.setAction(Type.complete_task);
+        action.setComplete_task(taskDetails);
+
+        String payloadJson =
+                "{\"workflowId\":\"workflow_1\",  \"taskRefName\":\"testTask\", \"Message\":{\"someKey\":\"someData\",\"someNullKey\":null}}";
+        Object payload = objectMapper.readValue(payloadJson, Object.class);
+
+        TaskModel task = new TaskModel();
+        task.setReferenceTaskName("testTask");
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.getTasks().add(task);
+
+        when(workflowExecutor.getWorkflow(eq("workflow_1"), anyBoolean())).thenReturn(workflow);
+        doNothing().when(externalPayloadStorageUtils).verifyAndUpload(any(), any());
+
+        actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        ArgumentCaptor<TaskResult> argumentCaptor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(workflowExecutor).updateTask(argumentCaptor.capture());
+        assertEquals(Status.COMPLETED, argumentCaptor.getValue().getStatus());
+        assertEquals(
+                "testMessage",
+                argumentCaptor.getValue().getOutputData().get("conductor.event.messageId"));
+        assertEquals(
+                "testEvent", argumentCaptor.getValue().getOutputData().get("conductor.event.name"));
+        assertEquals("workflow_1", argumentCaptor.getValue().getOutputData().get("workflowId"));
+        assertEquals("testTask", argumentCaptor.getValue().getOutputData().get("taskRefName"));
+        assertEquals("someData", argumentCaptor.getValue().getOutputData().get("someKey"));
+        // Assert values not in message are evaluated to null
+        assertTrue("testTask", argumentCaptor.getValue().getOutputData().containsKey("someNEKey"));
+        // Assert null values from message are kept
+        assertTrue(
+                "testTask", argumentCaptor.getValue().getOutputData().containsKey("someNullKey"));
+        assertNull("testTask", argumentCaptor.getValue().getOutputData().get("someNullKey"));
+    }
+
+    @Test
     public void testCompleteTaskByTaskId() throws Exception {
         TaskDetails taskDetails = new TaskDetails();
         taskDetails.setWorkflowId("${workflowId}");


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

Changes in this PR
----
If the task is not loopOver task then it should not compute the taskRefName removing the iteration value.

_Describe the new behavior from this PR, and why it's needed_
Issue # https://github.com/Netflix/conductor/issues/3309

