### PR TITLE
Fixing the Xstream Library Security leak.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
 	repositories {
         jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -26,10 +27,11 @@ allprojects {
 
     repositories {
         jcenter()
+        mavenCentral()
 
         // oss-candidate for -rc.* verions:
         maven {
-            url "https://dl.bintray.com/netflixoss/oss-candidate"
+            url "https://mvnrepository.com/artifact"
         }
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.github.vmg.protogen:protogen-codegen:${revProtogenCodegen}"

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     compile project(':conductor-common')
     compile project(':conductor-core')
 
-    protobuf 'io.chaossystems.grpc:grpc-healthcheck:1.0.+:protos'
     compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
     compile "io.grpc:grpc-protobuf:${revGrpc}"
     compile "io.grpc:grpc-stub:${revGrpc}"

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -14,7 +14,7 @@ ext {
     revElasticSearch5 = '5.6.8'
     revElasticSearch5Client = '5.6.8'
     revElasticSearch6 = '6.8.12'
-    revEurekaClient = '1.8.7'
+    revEurekaClient = '1.10.17'
     revFlywayCore ='4.0.3'
     revGrpc = '1.14.+'
     revGuavaRetrying = '2.0.0'


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Included the Netflix Eureka library which contains the security leak fix for potential RCE threat.
Since this version of conductor is very old and dl.bintray no longer exists, updated the library source to maven.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
