### PR TITLE
Java-SDK: Fix NPE when `@InputParam` is of type List in `AnnotatedWorker`

### DIFF
--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -15,6 +15,7 @@ package com.netflix.conductor.sdk.workflow.executor.task;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class AnnotatedWorker implements Worker {
 
     @Override
     public TaskResult execute(Task task) {
-        TaskResult result = new TaskResult(task);
+        TaskResult result;
         try {
             Object[] parameters = getInvocationParameters(task);
             Object invocationResult = workerMethod.invoke(obj, parameters);
@@ -65,11 +66,11 @@ public class AnnotatedWorker implements Worker {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+
         return result;
     }
 
     private Object[] getInvocationParameters(Task task) {
-
         Class<?>[] parameterTypes = workerMethod.getParameterTypes();
         Parameter[] parameters = workerMethod.getParameters();
 
@@ -79,40 +80,65 @@ public class AnnotatedWorker implements Worker {
             return new Object[] {task.getInputData()};
         }
 
+        return getParameters(task, parameterTypes, parameters);
+    }
+
+    private Object[] getParameters(Task task, Class<?>[] parameterTypes, Parameter[] parameters) {
         Annotation[][] parameterAnnotations = workerMethod.getParameterAnnotations();
         Object[] values = new Object[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
             Annotation[] paramAnnotation = parameterAnnotations[i];
             if (paramAnnotation != null && paramAnnotation.length > 0) {
-                for (Annotation ann : paramAnnotation) {
-                    if (ann.annotationType().equals(InputParam.class)) {
-                        InputParam ip = (InputParam) ann;
-                        String name = ip.value();
-                        Object value = task.getInputData().get(name);
-                        if (List.class.isAssignableFrom(parameterTypes[i])) {
-                            Type type = parameters[i].getParameterizedType();
-                            if (type instanceof ParameterizedType) {
-                                ParameterizedType parameterizedType = (ParameterizedType) type;
-                                Class typeOfParameter =
-                                        (Class) parameterizedType.getActualTypeArguments()[0];
-                                List<?> list = om.convertValue(value, List.class);
-                                List parameterizedList = new ArrayList<>();
-                                for (Object item : list) {
-                                    parameterizedList.add(om.convertValue(item, typeOfParameter));
-                                }
-                                values[i] = parameterizedList;
-                            }
-                        } else {
-                            values[i] = om.convertValue(value, parameterTypes[i]);
-                        }
-                    }
-                }
+                Type type = parameters[i].getParameterizedType();
+                Class<?> parameterType = parameterTypes[i];
+                values[i] = getInputValue(task, parameterType, type, paramAnnotation);
             } else {
-                Object input = om.convertValue(task.getInputData(), parameterTypes[i]);
-                values[i] = input;
+                values[i] = om.convertValue(task.getInputData(), parameterTypes[i]);
             }
         }
+
         return values;
+    }
+
+    private Object getInputValue(
+            Task task, Class<?> parameterType, Type type, Annotation[] paramAnnotation) {
+        InputParam ip = findInputParamAnnotation(paramAnnotation);
+
+        if (ip == null) {
+            return om.convertValue(task.getInputData(), parameterType);
+        }
+
+        final String name = ip.value();
+        final Object value = task.getInputData().get(name);
+        if (value == null) {
+            return null;
+        }
+
+        if (List.class.isAssignableFrom(parameterType)) {
+            List<?> list = om.convertValue(value, List.class);
+            if (type instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) type;
+                Class<?> typeOfParameter = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+                List<Object> parameterizedList = new ArrayList<>();
+                for (Object item : list) {
+                    parameterizedList.add(om.convertValue(item, typeOfParameter));
+                }
+
+                return parameterizedList;
+            } else {
+                return list;
+            }
+        } else {
+            return om.convertValue(value, parameterType);
+        }
+    }
+
+    private static InputParam findInputParamAnnotation(Annotation[] paramAnnotation) {
+        return (InputParam)
+                Arrays.stream(paramAnnotation)
+                        .filter(ann -> ann.annotationType().equals(InputParam.class))
+                        .findFirst()
+                        .orElse(null);
     }
 
     private TaskResult setValue(Object invocationResult, Task task) {

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.executor.task;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.sdk.workflow.task.InputParam;
+import com.netflix.conductor.sdk.workflow.task.OutputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AnnotatedWorkerTests {
+
+    static class Car {
+        String brand;
+
+        String getBrand() {
+            return brand;
+        }
+
+        void setBrand(String brand) {
+            this.brand = brand;
+        }
+    }
+
+    static class Bike {
+        String brand;
+
+        String getBrand() {
+            return brand;
+        }
+
+        void setBrand(String brand) {
+            this.brand = brand;
+        }
+    }
+
+    static class CarWorker {
+        @WorkerTask("test_1")
+        public @OutputParam("result") List<Car> doWork(@InputParam("input") List<Car> input) {
+            return input;
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle null values when InputParam is a List")
+    void nullListAsInputParam() throws NoSuchMethodException {
+        var worker = new CarWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", List.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+        assertNull(outputData.get("result"));
+    }
+
+    @Test
+    @DisplayName("it should handle an empty List as InputParam")
+    void emptyListAsInputParam() throws NoSuchMethodException {
+        var worker = new CarWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", List.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(Map.of("input", List.of()));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+
+        @SuppressWarnings("unchecked")
+        List<Car> result = (List<Car>) outputData.get("result");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("it should handle a non empty List as InputParam")
+    void nonEmptyListAsInputParam() throws NoSuchMethodException {
+        var worker = new CarWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", List.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(Map.of("input", List.of(Map.of("brand", "BMW"))));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+
+        @SuppressWarnings("unchecked")
+        List<Car> result = (List<Car>) outputData.get("result");
+        assertEquals(1, result.size());
+
+        Car car = result.get(0);
+        assertEquals("BMW", car.getBrand());
+    }
+
+    @SuppressWarnings("rawtypes")
+    static class RawListInput {
+        @WorkerTask("test_1")
+        public @OutputParam("result") List doWork(@InputParam("input") List input) {
+            return input;
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle a Raw List Type as InputParam")
+    void rawListAsInputParam() throws NoSuchMethodException {
+        var worker = new RawListInput();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", List.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(Map.of("input", List.of(Map.of("brand", "BMW"))));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+        assertEquals(task.getInputData().get("input"), outputData.get("result"));
+    }
+
+    static class MapInput {
+        @WorkerTask("test_1")
+        public @OutputParam("result") Map<String, Object> doWork(Map<String, Object> input) {
+            return input;
+        }
+    }
+
+    @Test
+    @DisplayName("it should accept a not annotated Map as input")
+    void mapAsInputParam() throws NoSuchMethodException {
+        var worker = new MapInput();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", Map.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(Map.of("input", List.of(Map.of("brand", "BMW"))));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+        assertEquals(task.getInputData(), outputData.get("result"));
+    }
+
+    static class TaskInput {
+        @WorkerTask("test_1")
+        public @OutputParam("result") Task doWork(Task input) {
+            return input;
+        }
+    }
+
+    @Test
+    @DisplayName("it should accept a Task as input")
+    void taskAsInputParam() throws NoSuchMethodException {
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+        task.setInputData(Map.of("input", List.of(Map.of("brand", "BMW"))));
+
+        var worker = new TaskInput();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", Task.class), worker);
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+        var result = (Task) outputData.get("result");
+        assertEquals(result.getTaskId(), task.getTaskId());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface AnotherAnnotation {}
+
+    static class AnotherAnnotationInput {
+        @WorkerTask("test_1")
+        public @OutputParam("result") Bike doWork(@AnotherAnnotation Bike input) {
+            return input;
+        }
+    }
+
+    @Test
+    @DisplayName(
+            "it should convert to the correct type even if there's no @InputParam and parameters are annotated with other annotations")
+    void annotatedWithAnotherAnnotation() throws NoSuchMethodException {
+        var worker = new AnotherAnnotationInput();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1", worker.getClass().getMethod("doWork", Bike.class), worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+        task.setInputData(Map.of("brand", "Trek"));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+        var bike = (Bike) outputData.get("result");
+        assertEquals("Trek", bike.getBrand());
+    }
+
+    static class MultipleInputParams {
+        @WorkerTask("test_1")
+        public Map<String, Object> doWork(
+                @InputParam("bike") Bike bike, @InputParam("car") Car car) {
+            return Map.of("bike", bike, "car", car);
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle multiple input params")
+    void multipleInputParams() throws NoSuchMethodException {
+        var worker = new MultipleInputParams();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1",
+                        worker.getClass().getMethod("doWork", Bike.class, Car.class),
+                        worker);
+
+        var task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+        task.setInputData(Map.of("bike", Map.of("brand", "Trek"), "car", Map.of("brand", "BMW")));
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+
+        var bike = (Bike) outputData.get("bike");
+        assertEquals("Trek", bike.getBrand());
+
+        var car = (Car) outputData.get("car");
+        assertEquals("BMW", car.getBrand());
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- Fixes NPE in `AnnotatedWorker` when the `@InputParam` is a List and its value in the Task's input data is `null`.
- Added tests + refactored code in `AnnotatedWorker` that gets the invocation parameters to reduce code nesting.

