### PR TITLE
Do not fail workflow but populate task definition as defaut

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -14,7 +14,6 @@ package com.netflix.conductor.core.execution.mapper;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,8 +68,11 @@ public class SimpleTaskMapper implements TaskMapper {
         int retryCount = taskMapperContext.getRetryCount();
         String retriedTaskId = taskMapperContext.getRetryTaskId();
         TaskDef taskDefinition = workflowTask.getTaskDefinition();
-        if(taskDefinition == null) {
-            String reason = String.format("Invalid task. Task %s does not have a definition", workflowTask.getName());
+        if (taskDefinition == null) {
+            String reason =
+                    String.format(
+                            "Invalid task. Task %s does not have a definition",
+                            workflowTask.getName());
             LOGGER.warn(reason);
             taskDefinition = new TaskDef(workflowTask.getName());
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -68,18 +68,12 @@ public class SimpleTaskMapper implements TaskMapper {
         WorkflowModel workflowModel = taskMapperContext.getWorkflowModel();
         int retryCount = taskMapperContext.getRetryCount();
         String retriedTaskId = taskMapperContext.getRetryTaskId();
-
-        TaskDef taskDefinition =
-                Optional.ofNullable(workflowTask.getTaskDefinition())
-                        .orElseThrow(
-                                () -> {
-                                    String reason =
-                                            String.format(
-                                                    "Invalid task. Task %s does not have a definition",
-                                                    workflowTask.getName());
-                                    return new TerminateWorkflowException(reason);
-                                });
-
+        TaskDef taskDefinition = workflowTask.getTaskDefinition();
+        if(taskDefinition == null) {
+            String reason = String.format("Invalid task. Task %s does not have a definition", workflowTask.getName());
+            LOGGER.warn(reason);
+            taskDefinition = new TaskDef(workflowTask.getName());
+        }
         Map<String, Object> input =
                 parametersUtils.getTaskInput(
                         workflowTask.getInputParameters(),


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [X] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Currently, the workflow is terminated if the task definition is missing in the workflow.  The task definitions are populated at the time of starting a workflow, this fix handles the case where the task was not populated correctly and workflow fails.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
