### PR TITLE
Call execute in case JQ execution failed to start

### DIFF
--- a/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
+++ b/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
@@ -112,6 +112,12 @@ public class JsonJqTransform extends WorkflowSystemTask {
                 .build(loader);
     }
 
+    @Override
+    public boolean execute(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
+        this.start(workflow, task, workflowExecutor);
+        return true;
+    }
+
     private String extractFirstValidMessage(final Exception e) {
         Throwable currentStack = e;
         final List<String> messages = new ArrayList<>();

--- a/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
+++ b/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
@@ -113,7 +113,8 @@ public class JsonJqTransform extends WorkflowSystemTask {
     }
 
     @Override
-    public boolean execute(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
+    public boolean execute(
+            WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         this.start(workflow, task, workflowExecutor);
         return true;
     }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [x] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
System tasks that are executed synchronously, should have `execute` method implemented to start them if it failed previously.

We noticed that during unclean shutdown of the servers, at times JQ task could get terminated and remains in progress without completion. 

This fix addresses that case and `restarts` the task, which should be safe to do since JQ is idempotent.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
