### PR TITLE
feature: Add option to add payloadBytes into getLocation method

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -47,6 +47,23 @@ public interface ExternalPayloadStorage {
     ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
     /**
+     * Obtain an uri used to store/access a json payload in external storage with deduplication of
+     * data based on payloadBytes digest.
+     *
+     * @param operation the type of {@link Operation} to be performed with the uri
+     * @param payloadType the {@link PayloadType} that is being accessed at the uri
+     * @param path (optional) the relative path for which the external storage location object is to
+     *     be populated. If path is not specified, it will be computed and populated.
+     * @param payloadBytes for calculating digest which is used for objectKey
+     * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the
+     *     json payload
+     */
+    default ExternalStorageLocation getLocation(
+            Operation operation, PayloadType payloadType, String path, byte[] payloadBytes) {
+        return getLocation(operation, payloadType, path);
+    }
+
+    /**
      * Upload a json payload to the specified external storage location.
      *
      * @param path the location to which the object is to be uploaded

--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -205,7 +205,7 @@ public class ExternalPayloadStorageUtils {
             byte[] payloadBytes, long payloadSize, ExternalPayloadStorage.PayloadType payloadType) {
         ExternalStorageLocation location =
                 externalPayloadStorage.getLocation(
-                        ExternalPayloadStorage.Operation.WRITE, payloadType, "");
+                        ExternalPayloadStorage.Operation.WRITE, payloadType, "", payloadBytes);
         externalPayloadStorage.upload(
                 location.getPath(), new ByteArrayInputStream(payloadBytes), payloadSize);
         return location.getPath();

--- a/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtilsTest.java
@@ -113,10 +113,12 @@ public class ExternalPayloadStorageUtilsTest {
                         .getResourceAsStream("/payload.json");
         Map<String, Object> payload = objectMapper.readValue(stream, Map.class);
 
+        byte[] payloadBytes = objectMapper.writeValueAsString(payload).getBytes();
         when(externalPayloadStorage.getLocation(
                         ExternalPayloadStorage.Operation.WRITE,
                         ExternalPayloadStorage.PayloadType.TASK_INPUT,
-                        ""))
+                        "",
+                        payloadBytes))
                 .thenReturn(location);
         doAnswer(
                         invocation -> {
@@ -146,10 +148,12 @@ public class ExternalPayloadStorageUtilsTest {
                         .getResourceAsStream("/payload.json");
         Map<String, Object> payload = objectMapper.readValue(stream, Map.class);
 
+        byte[] payloadBytes = objectMapper.writeValueAsString(payload).getBytes();
         when(externalPayloadStorage.getLocation(
                         ExternalPayloadStorage.Operation.WRITE,
                         ExternalPayloadStorage.PayloadType.WORKFLOW_OUTPUT,
-                        ""))
+                        "",
+                        payloadBytes))
                 .thenReturn(location);
         doAnswer(
                         invocation -> {
@@ -180,7 +184,7 @@ public class ExternalPayloadStorageUtilsTest {
         ExternalStorageLocation location = new ExternalStorageLocation();
         location.setPath(path);
 
-        when(externalPayloadStorage.getLocation(any(), any(), any())).thenReturn(location);
+        when(externalPayloadStorage.getLocation(any(), any(), any(), any())).thenReturn(location);
         doAnswer(
                         invocation -> {
                             uploadCount.incrementAndGet();


### PR DESCRIPTION
Signed-off-by: Simon Misencik <simon.misencik@gmail.com>

Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Discussion: https://github.com/Netflix/conductor/discussions/3384

This PR adds an option to add payloadBytes variable into the getLocation method. These payloadBytes are then used in externalStorage to calculate the digest. This digest is then used to determine whether the same data is already stored in the database.

Alternatives considered
----

_Describe alternative implementation you have considered_
