### PR TITLE
wip: Allow overriding correlationId in SUB_WORKFLOW task

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -72,7 +72,11 @@ public class SubWorkflow extends WorkflowSystemTask {
         if (wfInput == null || wfInput.isEmpty()) {
             wfInput = input;
         }
+
         String correlationId = workflow.getCorrelationId();
+        if (input.get("correlationId") != null) {
+            correlationId = (String) input.get("correlationId");
+        }
 
         try {
             StartWorkflowInput startWorkflowInput = new StartWorkflowInput();

--- a/test-harness/src/test/resources/workflow_with_sub_workflow_correlation_id.json
+++ b/test-harness/src/test/resources/workflow_with_sub_workflow_correlation_id.json
@@ -1,0 +1,40 @@
+{
+  "name": "workflow_with_sub_workflow_correlation_id",
+  "description": "integration_test_wf_with_sub_wf",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "sub_workflow_task",
+      "taskReferenceName": "task_1",
+      "inputParameters": {
+        "subwf": "${workflow.input.subwf}",
+        "correlationId": "${workflow.input.subWfCorrelationId}"
+      },
+      "type": "SUB_WORKFLOW",
+      "subWorkflowParam": {
+        "name": "${workflow.input.subwf}",
+        "version": 1
+      },
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "retryCount": 0
+    }
+  ],
+  "inputParameters": [
+    "param1",
+    "param2"
+  ],
+  "inputTemplate": {
+    "subWfCorrelationId": "example-sbwf-correlation-id"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
⚠️ This is a WIP/RFC PR and is not yet mergeable ⚠️ 
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

I have several use cases that involve a parent workflow that spins up several sub workflows. One of those workflows creates _another_ 50k sub workflows. This means that using the `correlated` API returns not only the "high level" workflows but also the 50k sub workflows.

```
# entry point
- initial_workflow
   |- prepare_batches
      |- batch_workflow
         |- (50k * batch_item_sub_workflow)
```

I want `initial_workflow`, `prepare_batches`, and `batch_workflow` but do not want any of the `batch_item_sub_workflow`s. 

In reality, `batch_item_sub_workflow` is associated with another ID (I have the concept of a `batch` and it is much more useful for me to operate on the workflows related to that batch.


Changes in this PR
----

This allows a sub workflow task to pass accept a `correlationId` param to use instead of the parent's `correlationId`. If no `correlationId` param is provided, it defauls back to the parent.


Alternatives considered
----

- Creating a task to manually run `START_WORKLFLOW` with a different correlationId
    - This is possible but a bit awkward, since it's essentially re-writing `SUB_WORKFLOW` to get at the API I really want
- Filtering out `batch_item_sub_workflow` through custom search
   - This breaks a lot of default functionality that the conduct-ui and a separate UI that I maintain have. Namely, that `correlated` returns useful and correlated items.
