### PR TITLE
[#3442] fix: can't click task card to open the right panel while using FireFox

### DIFF
--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -338,8 +338,21 @@ class WorkflowGraph extends React.Component {
     inner.selectAll("g.node").on("click", this.handleClick);
   };
 
+  /**
+   * Get the taskRef id base on browsers
+   * @param e
+   * @returns {string | undefined} The id of the task ref
+   */
+  getTaskRef = (e) => {
+    const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+    if (isFirefox) {
+      return e.target?.parentNode?.id;
+    }
+    return e?.path[1]?.id || e?.path[2]?.id; // could be 2 layers down
+  };
+
   handleClick = (e) => {
-    const taskRef = e.path[1].id || e.path[2].id; // could be 2 layers down
+    const taskRef = this.getTaskRef(e);
     const node = this.graph.node(taskRef);
     if (node.type === "DF_TASK_PLACEHOLDER") {
       if (this.props.onClick) this.props.onClick({ ref: node.firstDfRef });


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix


Changes in this PR
----

Issue #3442

User can't click on task at flow diagram to open the right side panel while using FireFox browser.


https://user-images.githubusercontent.com/83625759/212276351-150a8a03-3f0f-4772-b79f-003b7c49e8c4.mov


