### PR TITLE
fixed task card open in Chrome and Firefox

### DIFF
--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -338,8 +338,21 @@ class WorkflowGraph extends React.Component {
     inner.selectAll("g.node").on("click", this.handleClick);
   };
 
+  /**
+   * Get the taskRef id base on browsers
+   * @param e
+   * @returns {string | undefined} The id of the task ref
+   */
+  getTaskRef = (e) => {
+    const flag = navigator.userAgent.toLowerCase().indexOf("firefox") > -1 || navigator.userAgent.toLowerCase().indexOf("chrome") > -1;
+    if (flag) {
+      return e.target?.parentNode?.id;
+    }
+    return e?.path[1]?.id || e?.path[2]?.id; // could be 2 layers down
+  };
+
   handleClick = (e) => {
-    const taskRef = e.path[1].id || e.path[2].id; // could be 2 layers down
+    const taskRef = this.getTaskRef(e);
     const node = this.graph.node(taskRef);
     if (node.type === "DF_TASK_PLACEHOLDER") {
       if (this.props.onClick) this.props.onClick({ ref: node.firstDfRef });
@@ -667,7 +680,7 @@ function barRenderer(parent, bbox, node) {
     return {
       x:
         (node.fanDir === "down" && point.y > node.y) ||
-        (node.fanDir === "up" && point.y < node.y)
+          (node.fanDir === "up" && point.y < node.y)
           ? point.x
           : intersect.rect(node, point).x,
       y: point.y < node.y ? node.y - bbox.height / 2 : node.y + bbox.height / 2,
@@ -687,8 +700,7 @@ function stackRenderer(parent, bbox, node) {
     .attr("height", bbox.height)
     .attr(
       "transform",
-      `translate(${-bbox.width / 2 - STACK_OFFSET * 2}, ${
-        -bbox.height / 2 - STACK_OFFSET * 2
+      `translate(${-bbox.width / 2 - STACK_OFFSET * 2}, ${-bbox.height / 2 - STACK_OFFSET * 2
       })`
     );
   group
@@ -697,8 +709,7 @@ function stackRenderer(parent, bbox, node) {
     .attr("height", bbox.height)
     .attr(
       "transform",
-      `translate(${-bbox.width / 2 - STACK_OFFSET}, ${
-        -bbox.height / 2 - STACK_OFFSET
+      `translate(${-bbox.width / 2 - STACK_OFFSET}, ${-bbox.height / 2 - STACK_OFFSET
       })`
     );
   group


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix

Changes in this PR
----
Issue #3442 
Users can't click on the task at the flow diagram to open the right-side panel while using Firefox or Chrome browser.

_Describe the new behavior from this PR, and why it's needed_
Issue #3442 - Updated the code base to fix the task.
