### PR TITLE
Task details not showing in UI

### DIFF
--- a/ui/src/components/diagram/WorkflowGraph.jsx
+++ b/ui/src/components/diagram/WorkflowGraph.jsx
@@ -339,7 +339,7 @@ class WorkflowGraph extends React.Component {
   };
 
   handleClick = (e) => {
-    const taskRef = e.path[1].id || e.path[2].id; // could be 2 layers down
+    const taskRef = e.composedPath()[1].id || e.composedPath()[2].id; // could be 2 layers down
     const node = this.graph.node(taskRef);
     if (node.type === "DF_TASK_PLACEHOLDER") {
       if (this.props.onClick) this.props.onClick({ ref: node.firstDfRef });


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Event.path is deprecated in chrome as of the last update https://chromestatus.com/feature/5726124632965120. This is causing a bug when clicking on a task in the UI. This is also see in safari: https://github.com/Netflix/conductor/issues/3330. Updating to use composedPath() instead per guidance.

This is compatible with all browsers:
https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath

See the error we are seeing in the Chrome UI below

<img width="1044" alt="Screen Shot 2023-01-20 at 5 56 09 PM" src="https://user-images.githubusercontent.com/91626223/214075415-ce6a5cfc-3671-4f06-b4a5-4e67ea8f3907.png">


_Describe the new behavior from this PR, and why it's needed_
Issue #
https://github.com/Netflix/conductor/issues/3330
