### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+          cache: 'gradle'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         if: github.ref != 'refs/heads/main'
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,15 +19,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Publish candidate
         if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc.')
         run: ./gradlew -Prelease.useLastTag=true candidate --scan


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [x] Other (please describe): GitHub Actions

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

## Description

Updated workflows to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

**AS-IS**

```yaml
- name: Set up Zulu JDK 11
  uses: actions/setup-java@v3
  with:
    distribution: 'zulu'
    java-version: '11'

- name: Cache Gradle packages
  uses: actions/cache@v3
  with:
    path: |
      ~/.gradle/caches
      ~/.gradle/wrapper
    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
    restore-keys: ${{ runner.os }}-gradle-
```

**TO-BE**

```yaml
- name: Set up Zulu JDK 11
  uses: actions/setup-java@v3
  with:
    distribution: 'zulu'
    java-version: '11'
    cache: 'gradle'
```

> It’s literally a one line change to pass the `cache: 'gradle'` input parameter.

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)