### PR TITLE
Add in a default AWS credentials provider

### DIFF
--- a/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/config/SQSEventQueueConfiguration.java
+++ b/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/config/SQSEventQueueConfiguration.java
@@ -32,6 +32,7 @@ import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.sqs.eventqueue.SQSObservableQueue.Builder;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
@@ -45,6 +46,11 @@ public class SQSEventQueueConfiguration {
     @Autowired private SQSEventQueueProperties sqsProperties;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SQSEventQueueConfiguration.class);
+
+    @Bean
+    AWSCredentialsProvider createAWSCredentialsProvider() {
+        return new DefaultAWSCredentialsProviderChain();
+    }
 
     @ConditionalOnMissingBean
     @Bean


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
When using SQS it's necessary to add an AWS Credentials Provider to the queue configuration. It seemed sensible to do this by default since most people will need this and they can modify it if necessary. It also means that if you build the server from the community repository, which imports the exported packages from the conductor core, it will now work, whereas previously it failed to start the server, rendering SQS unusable from the community server.
