### PR TITLE
Add spring support for annotated workers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,11 +164,11 @@ allprojects {
     }
 }
 
-// all client and their related modules are published with Java 8 compatibility
+// all client and their related modules are published with Java 11 compatibility
 ["annotations", "common", "client", "client-spring", "grpc", "grpc-client"].each {
     project(":conductor-$it") {
         compileJava {
-            options.release = 8
+            options.release = 11
         }
     }
 }

--- a/client-spring/build.gradle
+++ b/client-spring/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     implementation project(':conductor-common')
     api project(':conductor-client')
+    api project(':conductor-java-sdk')
 
     implementation "com.netflix.eureka:eureka-client:${revEurekaClient}"
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorClientAutoConfiguration.java
+++ b/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorClientAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import com.netflix.conductor.client.automator.TaskRunnerConfigurer;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
+import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
 import com.netflix.discovery.EurekaClient;
 
 @Configuration(proxyBeanMethods = false)
@@ -42,6 +43,12 @@ public class ConductorClientAutoConfiguration {
         TaskClient taskClient = new TaskClient();
         taskClient.setRootURI(clientProperties.getRootUri());
         return taskClient;
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public AnnotatedWorkerExecutor annotatedWorkerExecutor(TaskClient taskClient) {
+        return new AnnotatedWorkerExecutor(taskClient);
     }
 
     @ConditionalOnMissingBean

--- a/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorWorkerAutoConfiguration.java
+++ b/client-spring/src/main/java/com/netflix/conductor/client/spring/ConductorWorkerAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.spring;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.client.http.TaskClient;
+import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
+import com.netflix.conductor.sdk.workflow.executor.task.WorkerConfiguration;
+
+@Component
+public class ConductorWorkerAutoConfiguration
+        implements ApplicationListener<ContextRefreshedEvent> {
+
+    @Autowired private TaskClient taskClient;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent refreshedEvent) {
+        ApplicationContext applicationContext = refreshedEvent.getApplicationContext();
+        Environment environment = applicationContext.getEnvironment();
+        WorkerConfiguration configuration = new SpringWorkerConfiguration(environment);
+        AnnotatedWorkerExecutor annotatedWorkerExecutor =
+                new AnnotatedWorkerExecutor(taskClient, configuration);
+
+        Map<String, Object> beans = applicationContext.getBeansWithAnnotation(Component.class);
+        beans.values()
+                .forEach(
+                        bean -> {
+                            annotatedWorkerExecutor.addBean(bean);
+                        });
+        annotatedWorkerExecutor.startPolling();
+    }
+}

--- a/client-spring/src/main/java/com/netflix/conductor/client/spring/SpringWorkerConfiguration.java
+++ b/client-spring/src/main/java/com/netflix/conductor/client/spring/SpringWorkerConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.spring;
+
+import org.springframework.core.env.Environment;
+
+import com.netflix.conductor.sdk.workflow.executor.task.WorkerConfiguration;
+
+public class SpringWorkerConfiguration extends WorkerConfiguration {
+
+    private final Environment environment;
+
+    public SpringWorkerConfiguration(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public int getPollingInterval(String taskName) {
+        String key = "conductor.worker." + taskName + ".pollingInterval";
+        return environment.getProperty(key, Integer.class, 0);
+    }
+
+    @Override
+    public int getThreadCount(String taskName) {
+        String key = "conductor.worker." + taskName + ".threadCount";
+        return environment.getProperty(key, Integer.class, 0);
+    }
+}

--- a/client-spring/src/test/java/com/netflix/conductor/client/spring/Workers.java
+++ b/client-spring/src/test/java/com/netflix/conductor/client/spring/Workers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.spring;
+
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
+import com.netflix.conductor.sdk.workflow.task.InputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+@Component
+public class Workers {
+
+    @WorkerTask(value = "hello", threadCount = 3)
+    public String helloWorld(@InputParam("name") String name) {
+        TaskContext context = TaskContext.get();
+        System.out.println(new Date() + ":: Poll count: " + context.getPollCount());
+        if (context.getPollCount() < 5) {
+            context.addLog("Not ready yet, poll count is only " + context.getPollCount());
+            context.setCallbackAfter(1);
+        }
+
+        return "Hello, " + name;
+    }
+
+    @WorkerTask(value = "hello_again", pollingInterval = 333)
+    public String helloAgain(@InputParam("name") String name) {
+        TaskContext context = TaskContext.get();
+        System.out.println(new Date() + ":: Poll count: " + context.getPollCount());
+        if (context.getPollCount() < 5) {
+            context.addLog("Not ready yet, poll count is only " + context.getPollCount());
+            context.setCallbackAfter(1);
+        }
+
+        return "Hello (again), " + name;
+    }
+}

--- a/client-spring/src/test/resources/application.properties
+++ b/client-spring/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+conductor.client.rootUri=http://localhost:8080/api/
+conductor.worker.hello.threadCount=100

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -113,6 +113,7 @@ public class WorkflowExecutor {
                         Workflow workflow = workflowClient.getWorkflow(workflowId, true);
                         if (workflow.getStatus().isTerminal()) {
                             future.complete(workflow);
+                            runningWorkflowFutures.remove(workflowId);
                         }
                     }
                 },
@@ -140,6 +141,7 @@ public class WorkflowExecutor {
                         Workflow workflow = workflowClient.getWorkflow(workflowId, true);
                         if (workflow.getStatus().isTerminal()) {
                             future.complete(workflow);
+                            runningWorkflowFutures.remove(workflowId);
                         }
                     }
                 },

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -14,10 +14,7 @@ package com.netflix.conductor.sdk.workflow.executor.task;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -44,6 +41,9 @@ public class AnnotatedWorker implements Worker {
 
     private int pollingInterval = 100;
 
+    private Set<TaskResult.Status> failedStatuses =
+            Set.of(TaskResult.Status.FAILED, TaskResult.Status.FAILED_WITH_TERMINAL_ERROR);
+
     public AnnotatedWorker(String name, Method workerMethod, Object obj) {
         this.name = name;
         this.workerMethod = workerMethod;
@@ -58,11 +58,40 @@ public class AnnotatedWorker implements Worker {
 
     @Override
     public TaskResult execute(Task task) {
-        TaskResult result;
+        TaskResult result = null;
         try {
+            TaskContext context = TaskContext.set(task);
             Object[] parameters = getInvocationParameters(task);
             Object invocationResult = workerMethod.invoke(obj, parameters);
-            result = setValue(invocationResult, task);
+            result = setValue(invocationResult, context.getTaskResult());
+            if (!failedStatuses.contains(result.getStatus())
+                    && result.getCallbackAfterSeconds() > 0) {
+                result.setStatus(TaskResult.Status.IN_PROGRESS);
+            }
+        } catch (InvocationTargetException invocationTargetException) {
+            if (result == null) {
+                result = new TaskResult(task);
+            }
+            Throwable e = invocationTargetException.getCause();
+            e.printStackTrace();
+            if (e instanceof NonRetryableException) {
+                result.setStatus(TaskResult.Status.FAILED_WITH_TERMINAL_ERROR);
+            } else {
+                result.setStatus(TaskResult.Status.FAILED);
+            }
+
+            result.setReasonForIncompletion(e.getMessage());
+            StringBuilder stackTrace = new StringBuilder();
+            for (StackTraceElement stackTraceElement : e.getStackTrace()) {
+                String className = stackTraceElement.getClassName();
+                if (className.startsWith("jdk.")
+                        || className.startsWith(AnnotatedWorker.class.getName())) {
+                    break;
+                }
+                stackTrace.append(stackTraceElement);
+                stackTrace.append("\n");
+            }
+            result.log(stackTrace.toString());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -141,11 +170,11 @@ public class AnnotatedWorker implements Worker {
                         .orElse(null);
     }
 
-    private TaskResult setValue(Object invocationResult, Task task) {
+    private TaskResult setValue(Object invocationResult, TaskResult result) {
 
         if (invocationResult == null) {
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
         }
 
         OutputParam opAnnotation =
@@ -153,9 +182,9 @@ public class AnnotatedWorker implements Worker {
         if (opAnnotation != null) {
 
             String name = opAnnotation.value();
-            task.getOutputData().put(name, invocationResult);
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().put(name, invocationResult);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
 
         } else if (invocationResult instanceof TaskResult) {
 
@@ -163,21 +192,21 @@ public class AnnotatedWorker implements Worker {
 
         } else if (invocationResult instanceof Map) {
             Map resultAsMap = (Map) invocationResult;
-            task.getOutputData().putAll(resultAsMap);
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().putAll(resultAsMap);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
         } else if (invocationResult instanceof String
                 || invocationResult instanceof Number
                 || invocationResult instanceof Boolean) {
-            task.getOutputData().put("result", invocationResult);
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().put("result", invocationResult);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
         } else if (invocationResult instanceof List) {
 
             List resultAsList = om.convertValue(invocationResult, List.class);
-            task.getOutputData().put("result", resultAsList);
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().put("result", resultAsList);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
 
         } else if (invocationResult instanceof DynamicForkInput) {
             DynamicForkInput forkInput = (DynamicForkInput) invocationResult;
@@ -186,25 +215,28 @@ public class AnnotatedWorker implements Worker {
             for (com.netflix.conductor.sdk.workflow.def.tasks.Task<?> sdkTask : tasks) {
                 workflowTasks.addAll(sdkTask.getWorkflowDefTasks());
             }
-            task.getOutputData().put(DynamicFork.FORK_TASK_PARAM, workflowTasks);
-            task.getOutputData().put(DynamicFork.FORK_TASK_INPUT_PARAM, forkInput.getInputs());
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().put(DynamicFork.FORK_TASK_PARAM, workflowTasks);
+            result.getOutputData().put(DynamicFork.FORK_TASK_INPUT_PARAM, forkInput.getInputs());
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
 
         } else {
             Map resultAsMap = om.convertValue(invocationResult, Map.class);
-            task.getOutputData().putAll(resultAsMap);
-            task.setStatus(Task.Status.COMPLETED);
-            return new TaskResult(task);
+            result.getOutputData().putAll(resultAsMap);
+            result.setStatus(TaskResult.Status.COMPLETED);
+            return result;
         }
     }
 
     public void setPollingInterval(int pollingInterval) {
+        System.out.println(
+                "Setting the polling interval for " + getTaskDefName() + ", to " + pollingInterval);
         this.pollingInterval = pollingInterval;
     }
 
     @Override
     public int getPollingInterval() {
+        System.out.println("Sending the polling interval to " + pollingInterval);
         return pollingInterval;
     }
 }

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -23,6 +23,7 @@ import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.ClassPath;
 
 public class AnnotatedWorkerExecutor {
@@ -33,23 +34,33 @@ public class AnnotatedWorkerExecutor {
 
     private TaskRunnerConfigurer taskRunner;
 
+    private List<Worker> executors = new ArrayList<>();
+
     private Map<String, Method> workerExecutors = new HashMap<>();
 
     private Map<String, Integer> workerToThreadCount = new HashMap<>();
+
+    private Map<String, Integer> workerToPollingInterval = new HashMap<>();
 
     private Map<String, Object> workerClassObjs = new HashMap<>();
 
     private static Set<String> scannedPackages = new HashSet<>();
 
-    private int pollingInteralInMS = 100;
+    private WorkerConfiguration workerConfiguration;
 
     public AnnotatedWorkerExecutor(TaskClient taskClient) {
         this.taskClient = taskClient;
+        this.workerConfiguration = new WorkerConfiguration();
     }
 
-    public AnnotatedWorkerExecutor(TaskClient taskClient, int pollingInteralInMS) {
+    public AnnotatedWorkerExecutor(TaskClient taskClient, int pollingIntervalInMillis) {
         this.taskClient = taskClient;
-        this.pollingInteralInMS = pollingInteralInMS;
+        this.workerConfiguration = new WorkerConfiguration(pollingIntervalInMillis);
+    }
+
+    public AnnotatedWorkerExecutor(TaskClient taskClient, WorkerConfiguration workerConfiguration) {
+        this.taskClient = taskClient;
+        this.workerConfiguration = workerConfiguration;
     }
 
     /**
@@ -100,7 +111,7 @@ public class AnnotatedWorkerExecutor {
                                 try {
                                     Class<?> clazz = classMeta.load();
                                     Object obj = clazz.getConstructor().newInstance();
-                                    scanClass(clazz, obj);
+                                    addBean(obj);
                                 } catch (Throwable t) {
                                     // trace because many classes won't have a default no-args
                                     // constructor and will fail
@@ -126,28 +137,48 @@ public class AnnotatedWorkerExecutor {
         return false;
     }
 
-    private void scanClass(Class<?> clazz, Object obj) {
+    public void addBean(Object bean) {
+        Class<?> clazz = bean.getClass();
         for (Method method : clazz.getMethods()) {
             WorkerTask annotation = method.getAnnotation(WorkerTask.class);
             if (annotation == null) {
                 continue;
             }
-            String name = annotation.value();
-            int threadCount = annotation.threadCount();
-            workerExecutors.put(name, method);
-            workerToThreadCount.put(name, threadCount);
-            workerClassObjs.put(name, obj);
-            LOGGER.info("Adding worker for task {}, method {}", name, method);
+            addMethod(annotation, method, bean);
         }
     }
 
-    private void startPolling() {
-        List<Worker> executors = new ArrayList<>();
+    private void addMethod(WorkerTask annotation, Method method, Object bean) {
+        String name = annotation.value();
+
+        int threadCount = workerConfiguration.getThreadCount(name);
+        if (threadCount == 0) {
+            threadCount = annotation.threadCount();
+        }
+        workerToThreadCount.put(name, threadCount);
+
+        int pollingInterval = workerConfiguration.getPollingInterval(name);
+        if (pollingInterval == 0) {
+            pollingInterval = annotation.pollingInterval();
+        }
+        workerToPollingInterval.put(name, pollingInterval);
+
+        workerClassObjs.put(name, bean);
+        workerExecutors.put(name, method);
+        LOGGER.info(
+                "Adding worker for task {}, method {} with threadCount {} and polling interval set to {} ms",
+                name,
+                method,
+                threadCount,
+                pollingInterval);
+    }
+
+    public void startPolling() {
         workerExecutors.forEach(
                 (taskName, method) -> {
                     Object obj = workerClassObjs.get(taskName);
                     AnnotatedWorker executor = new AnnotatedWorker(taskName, method, obj);
-                    executor.setPollingInterval(pollingInteralInMS);
+                    executor.setPollingInterval(workerToPollingInterval.get(taskName));
                     executors.add(executor);
                 });
 
@@ -163,5 +194,15 @@ public class AnnotatedWorkerExecutor {
                         .build();
 
         taskRunner.init();
+    }
+
+    @VisibleForTesting
+    List<Worker> getExecutors() {
+        return executors;
+    }
+
+    @VisibleForTesting
+    TaskRunnerConfigurer getTaskRunner() {
+        return taskRunner;
     }
 }

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/NonRetryableException.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/NonRetryableException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.executor.task;
+
+/**
+ * Runtime exception indicating the non-retriable error with the task execution. If thrown, the task
+ * will fail with FAILED_WITH_TERMINAL_ERROR and will not kick off retries.
+ */
+public class NonRetryableException extends RuntimeException {
+
+    public NonRetryableException(String message) {
+        super(message);
+    }
+
+    public NonRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NonRetryableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/TaskContext.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/TaskContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.executor.task;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+
+/** Context for the task */
+public class TaskContext {
+
+    public static final ThreadLocal<TaskContext> TASK_CONTEXT_INHERITABLE_THREAD_LOCAL =
+            InheritableThreadLocal.withInitial(() -> null);
+
+    public TaskContext(Task task, TaskResult taskResult) {
+        this.task = task;
+        this.taskResult = taskResult;
+    }
+
+    public static TaskContext get() {
+        return TASK_CONTEXT_INHERITABLE_THREAD_LOCAL.get();
+    }
+
+    public static TaskContext set(Task task) {
+        TaskResult result = new TaskResult(task);
+        TaskContext context = new TaskContext(task, result);
+        TASK_CONTEXT_INHERITABLE_THREAD_LOCAL.set(context);
+        return context;
+    }
+
+    private final Task task;
+
+    private final TaskResult taskResult;
+
+    public String getWorkflowInstanceId() {
+        return task.getWorkflowInstanceId();
+    }
+
+    public String getTaskId() {
+        return task.getTaskId();
+    }
+
+    public int getRetryCount() {
+        return task.getRetryCount();
+    }
+
+    public int getPollCount() {
+        return task.getPollCount();
+    }
+
+    public long getCallbackAfterSeconds() {
+        return task.getCallbackAfterSeconds();
+    }
+
+    public void addLog(String log) {
+        this.taskResult.log(log);
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public TaskResult getTaskResult() {
+        return taskResult;
+    }
+
+    public void setCallbackAfter(int seconds) {
+        this.taskResult.setCallbackAfterSeconds(seconds);
+    }
+}

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/WorkerConfiguration.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/WorkerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2023 Netflix, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,21 +10,23 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.sdk.workflow.task;
+package com.netflix.conductor.sdk.workflow.executor.task;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public class WorkerConfiguration {
 
-/** Identifies a simple worker task. */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
-public @interface WorkerTask {
-    String value();
+    private int defaultPollingInterval = 0;
 
-    // No. of threads to use for executing the task
-    int threadCount() default 1;
+    public WorkerConfiguration(int defaultPollingInterval) {
+        this.defaultPollingInterval = defaultPollingInterval;
+    }
 
-    int pollingInterval() default 100;
+    public WorkerConfiguration() {}
+
+    public int getPollingInterval(String taskName) {
+        return defaultPollingInterval;
+    }
+
+    public int getThreadCount(String taskName) {
+        return 0;
+    }
 }

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/TestWorkerConfig.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/TestWorkerConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.executor.task;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestWorkerConfig extends WorkerConfiguration {
+
+    private Map<String, Integer> pollingIntervals = new HashMap<>();
+
+    private Map<String, Integer> threadCounts = new HashMap<>();
+
+    @Override
+    public int getPollingInterval(String taskName) {
+        return pollingIntervals.getOrDefault(taskName, 0);
+    }
+
+    public void setPollingInterval(String taskName, int interval) {
+        pollingIntervals.put(taskName, interval);
+    }
+
+    public void setThreadCount(String taskName, int threadCount) {
+        threadCounts.put(taskName, threadCount);
+    }
+
+    @Override
+    public int getThreadCount(String taskName) {
+        return threadCounts.getOrDefault(taskName, 0);
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
1. Make it possible to add `@Component` to the classes that has worker methods and they will get auto-initialized.
2. Allow more control in the annotated workers so users can use `callbackAfter` for long running tasks
3. New exception that allows user to indicate the task has failed and should not be retried
4. Ability to control polling interval - useful for long running tasks
5.  `TaskContext` allows getting access to the task and task result for inspecting task level information

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
