### PR TITLE
Add `ownerEmail` to eventhandlers.md

### DIFF
--- a/docs/docs/labs/eventhandlers.md
+++ b/docs/docs/labs/eventhandlers.md
@@ -43,7 +43,8 @@ Send `POST` requests to `/metadata/workflow` endpoint with below payloads:
       "taskReferenceName": "test_task_tobe_completed_by_eventHandler",
       "type": "WAIT"
     }
-  ]
+  ],
+  "ownerEmail": "example@email.com"
 }
 ```
 
@@ -62,7 +63,8 @@ Send `POST` requests to `/metadata/workflow` endpoint with below payloads:
       "type": "EVENT",
       "sink": "conductor"
     }
-  ]
+  ],
+  "ownerEmail": "example@email.com"
 }
 ```
 


### PR DESCRIPTION
An `ownerEmail` field is required to successfully submit the workflow to the API.

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

The workflow definitions in this tutorial fail due to an `ownerEmail` field not being present. The API will return a 400 with this error if it is currently submitted in the format defined in the documentation.

Alternatives considered
----

N/A
