### PR TITLE
ci: use Temurin distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Zulu JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up Zulu JDK 11
+      - name: Set up Temurin JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Zulu JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     name: Gradle Build and Publish
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Zulu JDK 11
+      - name: Set up Temurin JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Zulu JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Zulu JDK 11
+      - name: Set up Temurin JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
Host runners include Temurin by default as part of the [hosted tool cache ](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache)

Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.