### PR TITLE
SBN 3.x support

### DIFF
--- a/client-spring/src/main/resources/META-INF/spring.factories
+++ b/client-spring/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
+# Please keep org.springframework.boot.autoconfigure.EnableAutoConfiguration list up to date at all times with org.springframework.boot.autoconfigure.AutoConfiguration.imports.
+# As of spring boot 2.7 EnableAutoConfiguration is deprecated. Please consider removing this section when Spring Boot 2.7 is the minimum supported version.
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.netflix.conductor.client.spring.ConductorClientAutoConfiguration

--- a/client-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/client-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+# Please keep this list up to date with org.springframework.boot.autoconfigure.EnableAutoConfiguration in spring.factories 
+# until minimum supported spring boot version is 2.7+
+com.netflix.conductor.client.spring.ConductorClientAutoConfiguration


### PR DESCRIPTION
As of spring boot 2.7, autoconfiguration registration has a new home.  This allows this library to run in early version of spring boot as well as the latest spring boot 3.x.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Adding new autoconfiguration registration introduced in Spring Boot 2.7.
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration

The older spring.factories has been deprecated in spring boot 3.0, so the new file needs to exist for conductor to work with spring boot 3.0 apps.
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files

Both files can exist and older and newer versions of spring will happily load from the expected registration files.  

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
