### PR TITLE
Add Redis Cluster connection properties for Locking

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -12,9 +12,8 @@
  */
 package com.netflix.conductor.redislock.config;
 
-import com.netflix.conductor.core.sync.Lock;
-import com.netflix.conductor.redislock.config.RedisLockProperties.REDIS_SERVER_TYPE;
-import com.netflix.conductor.redislock.lock.RedisLock;
+import java.util.Arrays;
+
 import org.redisson.Redisson;
 import org.redisson.config.Config;
 import org.slf4j.Logger;
@@ -24,7 +23,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Arrays;
+import com.netflix.conductor.core.sync.Lock;
+import com.netflix.conductor.redislock.config.RedisLockProperties.REDIS_SERVER_TYPE;
+import com.netflix.conductor.redislock.lock.RedisLock;
 
 @Configuration
 @EnableConfigurationProperties(RedisLockProperties.class)
@@ -74,10 +75,14 @@ public class RedisLockConfiguration {
                         .addNodeAddress(redisServerAddress.split(","))
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout)
-                        .setSlaveConnectionMinimumIdleSize(properties.getClusterReplicaConnectionMinIdleSize())
-                        .setSlaveConnectionPoolSize(properties.getClusterReplicaConnectionPoolSize())
-                        .setMasterConnectionMinimumIdleSize(properties.getClusterPrimaryConnectionMinIdleSize())
-                        .setMasterConnectionPoolSize(properties.getClusterPrimaryConnectionPoolSize());
+                        .setSlaveConnectionMinimumIdleSize(
+                                properties.getClusterReplicaConnectionMinIdleSize())
+                        .setSlaveConnectionPoolSize(
+                                properties.getClusterReplicaConnectionPoolSize())
+                        .setMasterConnectionMinimumIdleSize(
+                                properties.getClusterPrimaryConnectionMinIdleSize())
+                        .setMasterConnectionPoolSize(
+                                properties.getClusterPrimaryConnectionPoolSize());
                 break;
             case SENTINEL:
                 LOGGER.info("Setting up Redis Sentinel Servers for RedisLockConfiguration");

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -32,6 +32,21 @@ public class RedisLockProperties {
     /** The namespace to use to prepend keys used for locking in redis */
     private String namespace = "";
 
+    /** The number of natty threads to use */
+    private Integer numNettyThreads;
+
+    /** If using Cluster Mode, you can use this to set num of min idle connections for replica */
+    private int clusterReplicaConnectionMinIdleSize = 24;
+
+    /** If using Cluster Mode, you can use this to set num of min idle connections for replica */
+    private int clusterReplicaConnectionPoolSize = 64;
+
+    /** If using Cluster Mode, you can use this to set num of min idle connections for replica */
+    private int clusterPrimaryConnectionMinIdleSize = 24;
+
+    /** If using Cluster Mode, you can use this to set num of min idle connections for replica */
+    private int clusterPrimaryConnectionPoolSize = 64;
+
     /**
      * Enable to otionally continue without a lock to not block executions until the locking service
      * becomes available
@@ -84,6 +99,46 @@ public class RedisLockProperties {
 
     public void setIgnoreLockingExceptions(boolean ignoreLockingExceptions) {
         this.ignoreLockingExceptions = ignoreLockingExceptions;
+    }
+
+    public Integer getNumNettyThreads() {
+        return numNettyThreads;
+    }
+
+    public void setNumNettyThreads(Integer numNettyThreads) {
+        this.numNettyThreads = numNettyThreads;
+    }
+
+    public Integer getClusterReplicaConnectionMinIdleSize() {
+        return clusterReplicaConnectionMinIdleSize;
+    }
+
+    public void setClusterReplicaConnectionMinIdleSize(Integer clusterReplicaConnectionMinIdleSize) {
+        this.clusterReplicaConnectionMinIdleSize = clusterReplicaConnectionMinIdleSize;
+    }
+
+    public Integer getClusterReplicaConnectionPoolSize() {
+        return clusterReplicaConnectionPoolSize;
+    }
+
+    public void setClusterReplicaConnectionPoolSize(Integer clusterReplicaConnectionPoolSize) {
+        this.clusterReplicaConnectionPoolSize = clusterReplicaConnectionPoolSize;
+    }
+
+    public Integer getClusterPrimaryConnectionMinIdleSize() {
+        return clusterPrimaryConnectionMinIdleSize;
+    }
+
+    public void setClusterPrimaryConnectionMinIdleSize(Integer clusterPrimaryConnectionMinIdleSize) {
+        this.clusterPrimaryConnectionMinIdleSize = clusterPrimaryConnectionMinIdleSize;
+    }
+
+    public Integer getClusterPrimaryConnectionPoolSize() {
+        return clusterPrimaryConnectionPoolSize;
+    }
+
+    public void setClusterPrimaryConnectionPoolSize(Integer clusterPrimaryConnectionPoolSize) {
+        this.clusterPrimaryConnectionPoolSize = clusterPrimaryConnectionPoolSize;
     }
 
     public enum REDIS_SERVER_TYPE {

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -113,7 +113,8 @@ public class RedisLockProperties {
         return clusterReplicaConnectionMinIdleSize;
     }
 
-    public void setClusterReplicaConnectionMinIdleSize(Integer clusterReplicaConnectionMinIdleSize) {
+    public void setClusterReplicaConnectionMinIdleSize(
+            Integer clusterReplicaConnectionMinIdleSize) {
         this.clusterReplicaConnectionMinIdleSize = clusterReplicaConnectionMinIdleSize;
     }
 
@@ -129,7 +130,8 @@ public class RedisLockProperties {
         return clusterPrimaryConnectionMinIdleSize;
     }
 
-    public void setClusterPrimaryConnectionMinIdleSize(Integer clusterPrimaryConnectionMinIdleSize) {
+    public void setClusterPrimaryConnectionMinIdleSize(
+            Integer clusterPrimaryConnectionMinIdleSize) {
         this.clusterPrimaryConnectionMinIdleSize = clusterPrimaryConnectionMinIdleSize;
     }
 


### PR DESCRIPTION
Pull Request type
----
- [ X ] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
We found it necessary for us to be able to change the connection allocation for our Redis Cluster Locking. This adds configurable properties so you can change Cluster connection settings through Redisson. The defaults are the defaults used by Redisson. 