### PR TITLE
Pass complete workflow as input to failure workflow.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -651,6 +651,7 @@ public class WorkflowExecutor {
                 if (workflow.getFailedTaskId() != null) {
                     input.put("failureTaskId", workflow.getFailedTaskId());
                 }
+                input.put("failedWorkflow", workflow);
 
                 try {
                     String failureWFId = idGenerator.generate();

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2103,7 +2103,7 @@ public class TestWorkflowExecutor {
                 failedTask.getTaskId(), startWorkflowInput.getWorkflowInput().get("failureTaskId"));
         assertNotNull(
                 failedTask.getTaskId(),
-                argumentCaptor.getAllValues().get(0).getInput().get("failedWorkflow"));
+                startWorkflowInput.getWorkflowInput().get("failedWorkflow"));
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2101,6 +2101,9 @@ public class TestWorkflowExecutor {
                 workflow.getWorkflowId(), startWorkflowInput.getWorkflowInput().get("workflowId"));
         assertEquals(
                 failedTask.getTaskId(), startWorkflowInput.getWorkflowInput().get("failureTaskId"));
+        assertNotNull(
+                failedTask.getTaskId(),
+                argumentCaptor.getAllValues().get(0).getInput().get("failedWorkflow"));
     }
 
     @Test

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/FailureWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/FailureWorkflowSpec.groovy
@@ -73,6 +73,7 @@ class FailureWorkflowSpec extends AbstractSpecification {
                 input['failureTaskId'] == workflowFailureTaskId
                 tasks.size() == 1
                 tasks[0].taskType == 'LAMBDA'
+                input['failedWorkflow'] != null
             }
         }
     }
@@ -140,6 +141,7 @@ class FailureWorkflowSpec extends AbstractSpecification {
                 input['failureTaskId'] == workflowFailureTaskId
                 tasks.size() == 1
                 tasks[0].taskType == 'LAMBDA'
+                input['failedWorkflow'] != null
             }
         }
     }


### PR DESCRIPTION
Pull Request type

- [X] Refactoring (no functional changes, no api changes)

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
1. Pass complete failedWorkflow as input to failure workflow so that it does not require to have extra API calls to know more about the failure.
2. There will be a duplicate set of attributes since we were passing a few attributes already. They are kept as-is because if they are removed then it will require for workflow definition to change.

