### PR TITLE
fix docker-compose up fails on Mac M1 (https://github.com/Netflix/conductor/issues/2975)

### DIFF
--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -69,9 +69,11 @@ services:
       test: [ "CMD", "redis-cli","ping" ]
 
   elasticsearch:
-    image: elasticsearch:6.8.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
     container_name: elasticsearch
     environment:
+      #https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_call_filter_check.html
+      - bootstrap.system_call_filter=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
       - transport.host=0.0.0.0
       - discovery.type=single-node

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -43,6 +43,9 @@ services:
     networks:
       - internal
     ports:
+      # if you are on macOS 12(Monterey) or higher you may want to choose another port
+      # or turn off AirPlay Receiver to freeup port 5000 
+      # https://developer.apple.com/forums/thread/682332
       - 5000:5000
     links:
       - conductor-server
@@ -60,9 +63,11 @@ services:
       test: [ "CMD", "redis-cli","ping" ]
 
   elasticsearch:
-    image: elasticsearch:6.8.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
     container_name: elasticsearch
     environment:
+      #https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_call_filter_check.html
+      - bootstrap.system_call_filter=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
       - transport.host=0.0.0.0
       - discovery.type=single-node

--- a/docker/grpc/docker-compose.yaml
+++ b/docker/grpc/docker-compose.yaml
@@ -32,6 +32,9 @@ services:
     networks:
       - internal
     ports:
+       # if you are on macOS 12(Monterey) or higher you may want to choose another port
+       # or turn off AirPlay Receiver to free up port 5000
+       # https://developer.apple.com/forums/thread/682332
       - 5000:5000
     depends_on:
       - conductor-server
@@ -58,8 +61,10 @@ services:
       retries: 12
 
   elasticsearch:
-    image: elasticsearch:6.8.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
     environment:
+      #https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_call_filter_check.html
+      - bootstrap.system_call_filter=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
       - transport.host=0.0.0.0
       - discovery.type=single-node


### PR DESCRIPTION
Pull Request type
----
- [ x] Bugfix (https://github.com/Netflix/conductor/issues/2975)



Changes in this PR
----
See https://github.com/Netflix/conductor/issues/2975
The old image won't be republished https://github.com/elastic/elasticsearch/issues/95560#issuecomment-1523044496.
The new image at docker.elastic.co support M1.  Use docker.elastic.co/elasticsearch/elasticsearch in docker compose instead of elasticsearch from docker hub. 

Issue #
<img width="630" alt="Screenshot 2023-04-21 at 6 44 48 pm" src="https://user-images.githubusercontent.com/5586453/233595341-4e7817b5-5a83-427f-a4bc-1b10353c5d4f.png">


<img width="1093" alt="Screenshot 2023-04-21 at 7 06 46 pm" src="https://user-images.githubusercontent.com/5586453/233595527-bbe1cfff-1807-43ec-aa6c-72eaab3a8ef2.png">

<img width="1275" alt="Screenshot 2023-04-21 at 7 43 04 pm" src="https://user-images.githubusercontent.com/5586453/233604218-24659d66-85f0-42f5-a306-c5ca44417e63.png">


