### PR TITLE
Avoid exception message set to 'null'

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
@@ -30,6 +30,7 @@ import com.sun.jersey.api.client.filter.ClientFilter;
 public class EventClient extends ClientBase {
     private static final GenericType<List<EventHandler>> eventHandlerList =
             new GenericType<List<EventHandler>>() {};
+
     /** Creates a default metadata client */
     public EventClient() {
         this(new DefaultClientConfig(), new DefaultConductorClientConfiguration(), null);

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -545,7 +545,11 @@ public class DeciderService {
                     break;
             }
             updateWorkflowOutput(workflow, task);
-            throw new TerminateWorkflowException(task.getReasonForIncompletion(), status, task);
+            final String errMsg =
+                    String.format(
+                            "Task %s failed with status: %s and reason: '%s'",
+                            task.getTaskId(), status, task.getReasonForIncompletion());
+            throw new TerminateWorkflowException(errMsg, status, task);
         }
 
         // retry... - but not immediately - put a delay...

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
@@ -65,6 +65,7 @@ public class LocalServerRunner {
     public String getServerAPIUrl() {
         return this.serverURL + "api/";
     }
+
     /**
      * Starts the local server. Downloads the latest conductor build from the maven repo If you want
      * to start the server from a specific download location, set `repositoryURL` system property

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
@@ -210,10 +210,12 @@ class SimpleWorkflowSpec extends AbstractSpecification {
         and: "verify that the workflow is in a failed state"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.FAILED
-            reasonForIncompletion == 'NON TRANSIENT ERROR OCCURRED: An integration point required to complete the task is down'
+            def t1 = getTaskByRefName('t1')
+            reasonForIncompletion == "Task ${t1.taskId} failed with status: FAILED and reason: " +
+                    "'NON TRANSIENT ERROR OCCURRED: An integration point required to complete the task is down'"
             output['o1'] == 'p1 value'
             output['validationErrors'] == 'There was a terminal error'
-            getTaskByRefName('t1').retryCount == 0
+            t1.retryCount == 0
             failedReferenceTaskNames == ['t1'] as HashSet
             failedTaskNames == ['integration_task_1'] as HashSet
         }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

In case reason for in-completion of a terminated task was null. Exception message would be set to null producing confusing entry in the log (just stating "null"). This commit makes it clearer what happened from the logs.

Alternatives considered
----


