### PR TITLE
Ensure that JOIN tasks wait for all retries before terminating

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -56,7 +56,11 @@ public class Join extends WorkflowSystemTask {
                 break;
             }
             TaskModel.Status taskStatus = forkedTask.getStatus();
-            hasFailures = !taskStatus.isSuccessful() && !forkedTask.getWorkflowTask().isOptional();
+            hasFailures =
+                    !forkedTask.isStillInNeedOfProcessing()
+                            && !taskStatus.isSuccessful()
+                            && !forkedTask.getWorkflowTask().isOptional();
+
             if (hasFailures) {
                 failureReason.append(forkedTask.getReasonForIncompletion()).append(" ");
             }
@@ -64,7 +68,7 @@ public class Join extends WorkflowSystemTask {
             if (!forkedTask.getOutputData().isEmpty()) {
                 task.addOutput(joinOnRef, forkedTask.getOutputData());
             }
-            if (!taskStatus.isTerminal()) {
+            if (forkedTask.isStillInNeedOfProcessing()) {
                 allDone = false;
             }
             if (hasFailures) {

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -588,6 +588,18 @@ public class TaskModel {
     }
 
     /**
+     * If the task is in a failed state, we need to make sure that all retries have been attempted
+     * for the task. If not, then the task is not in a "final" terminal state yet.
+     */
+    public boolean isStillInNeedOfProcessing() {
+        if (Status.FAILED.equals(getStatus())) {
+            final int taskDefRetryCount = getTaskDefinition().map(TaskDef::getRetryCount).orElse(0);
+            return getRetryCount() < taskDefRetryCount;
+        }
+        return !getStatus().isTerminal();
+    }
+
+    /**
      * @return the queueWaitTime
      */
     public long getQueueWaitTime() {

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -591,6 +591,7 @@ public class TaskModel {
      * If the task is in a failed state, we need to make sure that all retries have been attempted
      * for the task. If not, then the task is not in a "final" terminal state yet.
      */
+    @JsonIgnore
     public boolean isStillInNeedOfProcessing() {
         if (Status.FAILED.equals(getStatus())) {
             final int taskDefRetryCount = getTaskDefinition().map(TaskDef::getRetryCount).orElse(0);


### PR DESCRIPTION
Credit to @james-deee who authored the patch that this PR implements.

This fixes the bug where a JOIN wasn't waiting for all of the retries for a task to have been performed

Pull Request type
----
- [x] Bugfix

Changes in this PR
----
This fixes the bug where a JOIN wasn't waiting for all of the retries for a task to have been performed
