### PR TITLE
removing dead tasks from queue message

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -64,6 +64,12 @@ public class AsyncSystemTaskExecutor {
         TaskModel task = loadTaskQuietly(taskId);
         if (task == null) {
             LOGGER.error("TaskId: {} could not be found while executing {}", taskId, systemTask);
+            try {
+                LOGGER.debug("Cleaning up dead task from queue message: taskQueue={}, taskId={}", systemTask.getTaskType(), taskId);
+                queueDAO.remove(systemTask.getTaskType(), taskId);
+            } catch (Exception e) {
+                LOGGER.error("Failed to remove dead task from queue message: taskQueue={}, taskId={}", systemTask.getTaskType(), taskId);
+            }
             return;
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -65,10 +65,16 @@ public class AsyncSystemTaskExecutor {
         if (task == null) {
             LOGGER.error("TaskId: {} could not be found while executing {}", taskId, systemTask);
             try {
-                LOGGER.debug("Cleaning up dead task from queue message: taskQueue={}, taskId={}", systemTask.getTaskType(), taskId);
+                LOGGER.debug(
+                        "Cleaning up dead task from queue message: taskQueue={}, taskId={}",
+                        systemTask.getTaskType(),
+                        taskId);
                 queueDAO.remove(systemTask.getTaskType(), taskId);
             } catch (Exception e) {
-                LOGGER.error("Failed to remove dead task from queue message: taskQueue={}, taskId={}", systemTask.getTaskType(), taskId);
+                LOGGER.error(
+                        "Failed to remove dead task from queue message: taskQueue={}, taskId={}",
+                        systemTask.getTaskType(),
+                        taskId);
             }
             return;
         }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
Removing dead messages from queue for non-existing tasks

Issue #3022

It'd be nice to understand why that happens, when everything is setup (lock). We have several evns and errors about non-existing tasks appeared after we updated conductor (it restarted).
```
ERROR|2023-06-08T06:41:41.822Z|[system-task-worker-8]|||c.n.c.c.e.AsyncSystemTaskExecutor.execute|TaskId: c52b3a28-c53a-4acf-8bff-d558d2ab7f8d could not be found while executing HTTP
```
