### PR TITLE
Add support for subworkflow tasks which have SubworkflowParam's workflowDef inline

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/EventClient.java
@@ -30,6 +30,7 @@ import com.sun.jersey.api.client.filter.ClientFilter;
 public class EventClient extends ClientBase {
     private static final GenericType<List<EventHandler>> eventHandlerList =
             new GenericType<List<EventHandler>>() {};
+
     /** Creates a default metadata client */
     public EventClient() {
         this(new DefaultClientConfig(), new DefaultConductorClientConfiguration(), null);

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -25,6 +25,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.PositiveOrZero;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -399,6 +401,10 @@ public class WorkflowTask {
      * @param subWorkflow the subWorkflowParam to set
      */
     public void setSubWorkflowParam(SubWorkflowParams subWorkflow) {
+        if (subWorkflow.getWorkflowDefinition() == null
+                && (StringUtils.isBlank(subWorkflow.getName()))) {
+            throw new IllegalArgumentException("SubWorkflowParams name cannot be null or empty");
+        }
         this.subWorkflowParam = subWorkflow;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
@@ -12,7 +12,13 @@
  */
 package com.netflix.conductor.common.utils;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class TaskUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String LOOP_TASK_DELIMITER = "__";
 
@@ -27,5 +33,9 @@ public class TaskUtils {
     public static String removeIterationFromTaskRefName(String referenceTaskName) {
         String[] tokens = referenceTaskName.split(TaskUtils.LOOP_TASK_DELIMITER);
         return tokens.length > 0 ? tokens[0] : referenceTaskName;
+    }
+
+    public static WorkflowDef convertToWorkflowDef(Object workflowDef) {
+        return objectMapper.convertValue(workflowDef, WorkflowDef.class);
     }
 }

--- a/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
@@ -12,16 +12,8 @@
  */
 package com.netflix.conductor.common.workflow;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(classes = {TestObjectMapperConfiguration.class})
 @RunWith(SpringRunner.class)
@@ -47,20 +38,12 @@ public class SubWorkflowParamsTest {
 
     @Autowired private ObjectMapper objectMapper;
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWorkflowTaskName() {
-        SubWorkflowParams subWorkflowParams = new SubWorkflowParams(); // name is null
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        Validator validator = factory.getValidator();
-
-        Set<ConstraintViolation<Object>> result = validator.validate(subWorkflowParams);
-        assertEquals(2, result.size());
-
-        List<String> validationErrors = new ArrayList<>();
-        result.forEach(e -> validationErrors.add(e.getMessage()));
-
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be null"));
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be empty"));
+        WorkflowTask t = new WorkflowTask();
+        SubWorkflowParams subWorkflowParams =
+                new SubWorkflowParams(); // name is null, definition is null
+        t.setSubWorkflowParam(subWorkflowParams);
     }
 
     @Test
@@ -92,7 +75,6 @@ public class SubWorkflowParamsTest {
         def.getTasks().add(task);
         subWorkflowParams.setWorkflowDefinition(def);
         assertEquals(def, subWorkflowParams.getWorkflowDefinition());
-        assertEquals(def, subWorkflowParams.getWorkflowDef());
     }
 
     @Test
@@ -117,6 +99,7 @@ public class SubWorkflowParamsTest {
         SubWorkflowParams deserializedParams =
                 objectMapper.readValue(serializedParams, SubWorkflowParams.class);
         assertEquals(def, deserializedParams.getWorkflowDefinition());
-        assertEquals(def, deserializedParams.getWorkflowDef());
+        var x = (WorkflowDef) deserializedParams.getWorkflowDefinition();
+        assertEquals(def, x);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.core.execution.tasks;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.exception.TransientException;
 import com.netflix.conductor.core.execution.StartWorkflowInput;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
@@ -51,8 +53,8 @@ public class SubWorkflow extends WorkflowSystemTask {
     @Override
     public void start(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         Map<String, Object> input = task.getInputData();
-        String name = input.get("subWorkflowName").toString();
-        int version = (int) input.get("subWorkflowVersion");
+        String name = null;
+        Integer version = null;
 
         WorkflowDef workflowDefinition = null;
         if (input.get("subWorkflowDefinition") != null) {
@@ -61,6 +63,16 @@ public class SubWorkflow extends WorkflowSystemTask {
                     objectMapper.convertValue(
                             input.get("subWorkflowDefinition"), WorkflowDef.class);
             name = workflowDefinition.getName();
+        } else {
+            name =
+                    Optional.ofNullable(input.get("subWorkflowName"))
+                            .map(Object::toString)
+                            .orElse(null);
+            version = (Integer) input.get("subWorkflowVersion");
+            if (name == null) {
+                throw new TerminateWorkflowException(
+                        "SubWorkflow name is null, but no workflowDefinition supplied");
+            }
         }
 
         Map<String, String> taskToDomain = workflow.getTaskToDomain();

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSubWorkflow.java
@@ -38,8 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -443,7 +442,9 @@ public class TestSubWorkflow {
         startWorkflowInput.setWorkflowDefinition(subWorkflowDef);
         startWorkflowInput.setTaskToDomain(workflowInstance.getTaskToDomain());
 
-        when(startWorkflowOperation.execute(startWorkflowInput)).thenReturn("workflow_1");
+        when(startWorkflowOperation.execute(
+                        argThat(s -> s.getWorkflowDefinition().equals(subWorkflowDef))))
+                .thenReturn("workflow_1");
 
         subWorkflow.start(workflowInstance, task, workflowExecutor);
         assertEquals("workflow_1", task.getSubWorkflowId());

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -405,23 +405,13 @@ public class WorkflowTaskTypeConstraintTest {
                         "subWorkflowParam field is required for taskType: SUB_WORKFLOW taskName: encode"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWorkflowTaskTypeSubworkflow() {
         WorkflowTask workflowTask = createSampleWorkflowTask();
         workflowTask.setType("SUB_WORKFLOW");
 
         SubWorkflowParams subWorkflowTask = new SubWorkflowParams();
         workflowTask.setSubWorkflowParam(subWorkflowTask);
-
-        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
-        assertEquals(2, result.size());
-
-        List<String> validationErrors = new ArrayList<>();
-
-        result.forEach(e -> validationErrors.add(e.getMessage()));
-
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be null"));
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be empty"));
     }
 
     @Test

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
@@ -65,6 +65,7 @@ public class LocalServerRunner {
     public String getServerAPIUrl() {
         return this.serverURL + "api/";
     }
+
     /**
      * Starts the local server. Downloads the latest conductor build from the maven repo If you want
      * to start the server from a specific download location, set `repositoryURL` system property

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.sdk.workflow.def.tasks;
 
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.SubWorkflowParams;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.sdk.workflow.def.ConductorWorkflow;
 
@@ -54,9 +55,11 @@ public class SubWorkflow extends Task<SubWorkflow> {
         SubWorkflowParams subworkflowParam = workflowTask.getSubWorkflowParam();
         this.workflowName = subworkflowParam.getName();
         this.workflowVersion = subworkflowParam.getVersion();
-        if (subworkflowParam.getWorkflowDef() != null) {
+        if (subworkflowParam.getWorkflowDefinition() != null
+                && subworkflowParam.getWorkflowDefinition() instanceof WorkflowDef) {
             this.conductorWorkflow =
-                    ConductorWorkflow.fromWorkflowDef(subworkflowParam.getWorkflowDef());
+                    ConductorWorkflow.fromWorkflowDef(
+                            (WorkflowDef) subworkflowParam.getWorkflowDefinition());
         }
     }
 
@@ -77,7 +80,7 @@ public class SubWorkflow extends Task<SubWorkflow> {
         SubWorkflowParams subWorkflowParam = new SubWorkflowParams();
 
         if (conductorWorkflow != null) {
-            subWorkflowParam.setWorkflowDef(conductorWorkflow.toWorkflowDef());
+            subWorkflowParam.setWorkflowDefinition(conductorWorkflow.toWorkflowDef());
         } else {
             subWorkflowParam.setName(workflowName);
             subWorkflowParam.setVersion(workflowVersion);

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
@@ -137,7 +137,7 @@ public class MockExternalPayloadStorage implements ExternalPayloadStorage {
             SubWorkflowParams subWorkflowParams = new SubWorkflowParams();
             subWorkflowParams.setName("one_task_workflow");
             subWorkflowParams.setVersion(1);
-            subWorkflowParams.setWorkflowDef(subWorkflowDef);
+            subWorkflowParams.setWorkflowDefinition(subWorkflowDef);
 
             WorkflowTask subWorkflowTask = new WorkflowTask();
             subWorkflowTask.setName("large_payload_subworkflow");


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Currently unsupported.
Issue [#1982](https://github.com/Netflix/conductor/issues/1982)
This PR will allow setting subWorkflowParams like this:
```
"subWorkflowParam": {
        "workflowDefinition": "${workflow.input.tst}"
      }
```
so that parameter resolution will happen, and workflowDefinition, if available, will take priority over name.

Alternatives considered
----

The alternative was to keep everything in place, but alter SubWorkflowTaskMapper and SubWorkflow so that name/version/definition resolution actually comes from task input instead of `subWorkflowParams`.
