### PR TITLE
Lazy evaluate workflow only in case of task is successful. 

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -925,10 +925,10 @@ public class WorkflowExecutor {
                         .collect(Collectors.toList());
 
         if (forkTasks.stream().anyMatch(fork -> fork.has(taskRefName))) {
-            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName));
+            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName)) && task.getStatus().isSuccessful();
         }
 
-        return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName));
+        return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName)) && task.getStatus().isSuccessful();
     }
 
     public TaskModel getTask(String taskId) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -925,10 +925,12 @@ public class WorkflowExecutor {
                         .collect(Collectors.toList());
 
         if (forkTasks.stream().anyMatch(fork -> fork.has(taskRefName))) {
-            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName)) && task.getStatus().isSuccessful();
+            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName))
+                    && task.getStatus().isSuccessful();
         }
 
-        return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName)) && task.getStatus().isSuccessful();
+        return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName))
+                && task.getStatus().isSuccessful();
     }
 
     public TaskModel getTask(String taskId) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2487,6 +2487,7 @@ public class TestWorkflowExecutor {
         workflowDef.getTasks().addAll(List.of(simpleTask, forkTask, joinTask, doWhile));
 
         TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.COMPLETED);
 
         // when:
         task.setReferenceTaskName("dynamic");
@@ -2503,6 +2504,10 @@ public class TestWorkflowExecutor {
 
         task.setReferenceTaskName("loopTask__1");
         task.setIteration(1);
+        assertFalse(workflowExecutor.isLazyEvaluateWorkflow(workflowDef, task));
+
+        task.setReferenceTaskName("branchTask1");
+        task.setStatus(TaskModel.Status.FAILED);
         assertFalse(workflowExecutor.isLazyEvaluateWorkflow(workflowDef, task));
     }
 


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
When the task is updated we have put a performance improvement where we lazy evaluate the workflow state. This change was introduced in #3146 . Now when one of the forked tasks fails we should evaluate the workflow state immediately since the task can have a retry which is not exhausted. 

_Describe the new behavior from this PR, and why it's needed_
Issue #
Lazily evaluate workflow only in case the task is successful.

Alternatives considered
----

_Describe alternative implementation you have considered_
Alternative #3640  was raised