### PR TITLE
Fix workflow evaluation on task updates

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -872,12 +872,7 @@ public class WorkflowExecutor {
                     task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
 
-        // sync evaluate workflow only if the task is not within a forked branch
-        if (isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
-            expediteLazyWorkflowEvaluation(workflowId);
-        } else {
-            decide(workflowId);
-        }
+        decide(workflowId);
     }
 
     private void notifyTaskStatusListener(TaskModel task) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -872,7 +872,10 @@ public class WorkflowExecutor {
                     task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
 
-        if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
+        // sync evaluate workflow only if the task is not within a forked branch
+        if (isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
+            expediteLazyWorkflowEvaluation(workflowId);
+        } else {
             decide(workflowId);
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -872,7 +872,9 @@ public class WorkflowExecutor {
                     task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
 
-        decide(workflowId);
+        if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task) || task.getStatus().isTerminal()) {
+            decide(workflowId);
+        }
     }
 
     private void notifyTaskStatusListener(TaskModel task) {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behaviour from this PR, and why it's needed_
This PR is fixing a bug that prevented not Lazy Evaluated Workflows from being evaluated. This feature was removed [here](https://github.com/Netflix/conductor/pull/3284/files#r1224272385) and as such, workflows were not being evaluated properly.
