### PR TITLE
Added the ability to inject a custom AmazonS3 client

### DIFF
--- a/awss3-storage/src/main/java/com/netflix/conductor/s3/config/S3Configuration.java
+++ b/awss3-storage/src/main/java/com/netflix/conductor/s3/config/S3Configuration.java
@@ -40,7 +40,7 @@ public class S3Configuration {
             havingValue = "true",
             matchIfMissing = true)
     @Bean
-    public AmazonS3 amazonS3() {
-        return AmazonS3ClientBuilder.standard().withRegion(region).build();
+    public AmazonS3 amazonS3(S3Properties properties) {
+        return AmazonS3ClientBuilder.standard().withRegion(properties.getRegion()).build();
     }
 }

--- a/awss3-storage/src/main/java/com/netflix/conductor/s3/config/S3Configuration.java
+++ b/awss3-storage/src/main/java/com/netflix/conductor/s3/config/S3Configuration.java
@@ -21,6 +21,9 @@ import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.s3.storage.S3PayloadStorage;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
 @ConditionalOnProperty(name = "conductor.external-payload-storage.type", havingValue = "s3")
@@ -28,7 +31,16 @@ public class S3Configuration {
 
     @Bean
     public ExternalPayloadStorage s3ExternalPayloadStorage(
-            IDGenerator idGenerator, S3Properties properties) {
-        return new S3PayloadStorage(idGenerator, properties);
+            IDGenerator idGenerator, S3Properties properties, AmazonS3 s3Client) {
+        return new S3PayloadStorage(idGenerator, properties, s3Client);
+    }
+
+    @ConditionalOnProperty(
+            name = "conductor.external-payload-storage.s3.use_default_client",
+            havingValue = "true",
+            matchIfMissing = true)
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard().withRegion(region).build();
     }
 }

--- a/awss3-storage/src/main/java/com/netflix/conductor/s3/storage/S3PayloadStorage.java
+++ b/awss3-storage/src/main/java/com/netflix/conductor/s3/storage/S3PayloadStorage.java
@@ -30,7 +30,6 @@ import com.netflix.conductor.s3.config.S3Properties;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.*;
 
 /**
@@ -52,12 +51,12 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
     private final String bucketName;
     private final long expirationSec;
 
-    public S3PayloadStorage(IDGenerator idGenerator, S3Properties properties) {
+    public S3PayloadStorage(IDGenerator idGenerator, S3Properties properties, AmazonS3 s3Client) {
         this.idGenerator = idGenerator;
+        this.s3Client = s3Client;
         bucketName = properties.getBucketName();
         expirationSec = properties.getSignedUrlExpirationDuration().getSeconds();
         String region = properties.getRegion();
-        s3Client = AmazonS3ClientBuilder.standard().withRegion(region).build();
     }
 
     /**

--- a/awss3-storage/src/main/java/com/netflix/conductor/s3/storage/S3PayloadStorage.java
+++ b/awss3-storage/src/main/java/com/netflix/conductor/s3/storage/S3PayloadStorage.java
@@ -56,7 +56,6 @@ public class S3PayloadStorage implements ExternalPayloadStorage {
         this.s3Client = s3Client;
         bucketName = properties.getBucketName();
         expirationSec = properties.getSignedUrlExpirationDuration().getSeconds();
-        String region = properties.getRegion();
     }
 
     /**


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)
- [x] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_I've added ability to initialize AmazonS3 Client  as a separate Bean._ 

If someone use a S3 compatible storage (e.g. [Pure Storage](https://support.purestorage.com/FlashBlade/Purity_FB/PurityFB_REST_API/S3_Object_Store_REST_API/FlashBlade_S3_Object_Store_Documentation)), they will be able to initialize AmazonS3 in their @Configuration like in the example below and this client will be used for initializing [S3PayloadStorage](https://github.com/Netflix/conductor/blob/v3.13.7/awss3-storage/src/main/java/com/netflix/conductor/s3/storage/S3PayloadStorage.java#L55)

**Disable default client:** 
```yml
conductor.external-payload-storage.s3.use_default_client: false
```

**Initialisation my own client:**
```java
    @Bean
    public AmazonS3 amazonS3Client(S3StorageProperties s3StorageProperties) {
        AWSCredentials credentials = new BasicAWSCredentials(s3StorageProperties.getAccessKey(), s3StorageProperties.getSecretKey());

        return AmazonS3ClientBuilder
            .standard()
            .withCredentials(new AWSStaticCredentialsProvider(credentials))
            .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(s3StorageProperties.getEndpoint(), s3StorageProperties.getRegion()))
            .withPathStyleAccessEnabled(s3StorageProperties.getPathStyleEnabled())
            .withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTPS))
            .build();
    }

```

Discussion: [#3693](https://github.com/Netflix/conductor/discussions/3693)

Alternatives considered
----

_Describe alternative implementation you have considered_
