### PR TITLE
Added support for building and running docker image for windows in documentation.

### DIFF
--- a/docs/docs/gettingstarted/docker.md
+++ b/docs/docs/gettingstarted/docker.md
@@ -153,6 +153,11 @@ Reference: [Issue 2262][issue2262]
 #### Changes in config-*.properties do not take effect
 Config is copy into image during docker build. You have to rebuild the image or better, link a volume to it to reflect new changes.
 
+#### ./gradlew: not found when running on Windows 
+Switch the line endings to "LF" from "CLRF" in gradlew file. 
+In IntelliJ - From the main menu, select File | File Properties | Line Separators, and then select LF - Unix and MacOS(\n).
+In Eclipse - Go to Window | Preferences | General | Workspace | New Text file line delimiter -> Other -> Unix
+
 #### To troubleshoot a failed startup
 Check the log of the server, which is located at `/app/logs` (default directory in dockerfile)
 

--- a/docs/docs/gettingstarted/docker.md
+++ b/docs/docs/gettingstarted/docker.md
@@ -15,7 +15,11 @@ The docker compose will bring up the following:
 ## Steps
 
 ### 1. Clone the Conductor Code
-
+> **NOTE for Windows users**: If you are using Windows OS then run these git commands to change line separator from CRLF to LF and then clone the project: 
+```shell
+git config --global core.autocrlf false;
+git config --global core.eol lf; #(Small l and f)
+```
 ```shell
 $ git clone https://github.com/Netflix/conductor.git
 ```
@@ -152,15 +156,6 @@ Reference: [Issue 2262][issue2262]
 
 #### Changes in config-*.properties do not take effect
 Config is copy into image during docker build. You have to rebuild the image or better, link a volume to it to reflect new changes.
-
-#### ./gradlew: not found when running on Windows 
-1. Switch the line endings to "LF" from "CLRF" in gradlew file. 
-In IntelliJ - From the main menu, select File | File Properties | Line Separators, and then select LF - Unix and MacOS(\n).
-In Eclipse - Go to Window | Preferences | General | Workspace | New Text file line delimiter -> Other -> Unix
-2. From the `docker` directory,
-    ```
-    docker build --no-cache -t conductor:server -f server/Dockerfile ../
-    ```
 
 #### To troubleshoot a failed startup
 Check the log of the server, which is located at `/app/logs` (default directory in dockerfile)

--- a/docs/docs/gettingstarted/docker.md
+++ b/docs/docs/gettingstarted/docker.md
@@ -154,9 +154,13 @@ Reference: [Issue 2262][issue2262]
 Config is copy into image during docker build. You have to rebuild the image or better, link a volume to it to reflect new changes.
 
 #### ./gradlew: not found when running on Windows 
-Switch the line endings to "LF" from "CLRF" in gradlew file. 
+1. Switch the line endings to "LF" from "CLRF" in gradlew file. 
 In IntelliJ - From the main menu, select File | File Properties | Line Separators, and then select LF - Unix and MacOS(\n).
 In Eclipse - Go to Window | Preferences | General | Workspace | New Text file line delimiter -> Other -> Unix
+2. From the `docker` directory,
+    ```
+    docker build --no-cache -t conductor:server -f server/Dockerfile ../
+    ```
 
 #### To troubleshoot a failed startup
 Check the log of the server, which is located at `/app/logs` (default directory in dockerfile)


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix and Documentation for Windows

Changes in this PR
----
Added support for windows in documentation 

_Describe the new behavior from this PR, and why it's needed_
Issue #3741
./gradlew: not found error when trying to build docker compose on Windows 
