### PR TITLE
feature support nested jsonpath expressions

### DIFF
--- a/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
@@ -234,6 +234,30 @@ public class ParametersUtilsTest {
     }
 
     @Test
+    public void testNestedPathExpressions() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", "conductor");
+        map.put("index", 1);
+        map.put("mapValue", "a");
+        map.put("recordIds", List.of(1, 2, 3));
+        map.put("map", Map.of("a", List.of(1, 2, 3), "b", List.of(2, 4, 5), "c", List.of(3, 7, 8)));
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("k1", "${recordIds[${index}]}");
+        input.put("k2", "${map.${mapValue}[${index}]}");
+        input.put("k3", "${map.b[${map.${mapValue}[${index}]}]}");
+
+        Object jsonObj = objectMapper.readValue(objectMapper.writeValueAsString(map), Object.class);
+
+        Map<String, Object> replaced = parametersUtils.replace(input, jsonObj);
+        assertNotNull(replaced);
+
+        assertEquals(2, replaced.get("k1"));
+        assertEquals(2, replaced.get("k2"));
+        assertEquals(5, replaced.get("k3"));
+    }
+
+    @Test
     public void testReplaceWithEscapedTags() throws Exception {
         Map<String, Object> map = new HashMap<>();
         map.put("someString", "conductor");


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
https://github.com/Netflix/conductor/discussions/3760

_Describe the new behavior from this PR, and why it's needed_
Issue # If part of the path is another input, there is no way to use that currently. Specifically for array values. Instead of making a inline function that extracts out an item from an array. It would be nice todo this with just an Jsonpath expression.

Alternatives considered
----

_Describe alternative implementation you have considered_
