### PR TITLE
Fix: terminateReason in TERMINATE Task can use JSONPath expression to extract value

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -458,14 +458,12 @@ public class WorkflowExecutor {
             String terminationStatus =
                     (String)
                             terminateTask
-                                    .getWorkflowTask()
-                                    .getInputParameters()
+                                    .getInputData()
                                     .get(Terminate.getTerminationStatusParameter());
             String reason =
                     (String)
                             terminateTask
-                                    .getWorkflowTask()
-                                    .getInputParameters()
+                                    .getInputData()
                                     .get(Terminate.getTerminationReasonParameter());
             if (StringUtils.isBlank(reason)) {
                 reason =


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Make terminateReason in TERMINATE Task can use JSONPath expression to extract value.
![conductor-terminate](https://github.com/Netflix/conductor/assets/40934357/50b97954-c114-4d6e-9382-ffa0416bc651)

_Describe the new behavior from this PR, and why it's needed_
Issue #3048

Alternatives considered
----

_Describe alternative implementation you have considered_

