### PR TITLE
Unlock Common and Client from the log4j2 version locking for Consumers

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -15,6 +15,16 @@ configurations.all {
     exclude group: 'amazon', module: 'aws-java-sdk'
 }
 
+dependencyLock {
+    skippedDependencies = [
+            "org.apache.logging.log4j:log4j-api",
+            "org.apache.logging.log4j:log4j-core",
+            "org.apache.logging.log4j:log4j-jul",
+            "org.apache.logging.log4j:log4j-slf4j-impl",
+            "org.apache.logging.log4j:log4j-web",
+    ]
+}
+
 dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
 

--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -35,21 +35,6 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
         },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.17.2"
-        },
         "org.glassfish.jersey.core:jersey-common": {
             "locked": "2.22.2"
         },
@@ -130,41 +115,6 @@
             ],
             "locked": "3.12.0"
         },
-        "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
         "org.glassfish.jersey.core:jersey-common": {
             "locked": "2.22.2"
         },
@@ -205,21 +155,6 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.17.2"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"
@@ -324,41 +259,6 @@
                 "com.netflix.conductor:conductor-common"
             ],
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-common"
-            ],
-            "locked": "2.17.2"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.5.13"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,6 +2,16 @@ configurations {
     annotationsProcessorCodegen
 }
 
+dependencyLock {
+    skippedDependencies = [
+            "org.apache.logging.log4j:log4j-api",
+            "org.apache.logging.log4j:log4j-core",
+            "org.apache.logging.log4j:log4j-jul",
+            "org.apache.logging.log4j:log4j-slf4j-impl",
+            "org.apache.logging.log4j:log4j-web",
+    ]
+}
+
 dependencies {
     implementation project(':conductor-annotations')
     annotationsProcessorCodegen project(':conductor-annotations-processor')

--- a/common/dependencies.lock
+++ b/common/dependencies.lock
@@ -43,41 +43,6 @@
                 "com.netflix.conductor:conductor-annotations-processor"
             ],
             "locked": "1.3.2"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations",
-                "com.netflix.conductor:conductor-annotations-processor"
-            ],
-            "locked": "2.17.2"
         }
     },
     "compileClasspath": {
@@ -101,21 +66,6 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.17.2"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "locked": "1.6.15"
@@ -148,36 +98,6 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
         }
     },
     "testCompileClasspath": {
@@ -204,21 +124,6 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "locked": "2.17.2"
         },
         "org.junit.vintage:junit-vintage-engine": {
             "locked": "5.8.2"
@@ -257,36 +162,6 @@
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
-        },
-        "org.apache.logging.log4j:log4j-api": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-core": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-jul": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
-        },
-        "org.apache.logging.log4j:log4j-web": {
-            "firstLevelTransitive": [
-                "com.netflix.conductor:conductor-annotations"
-            ],
-            "locked": "2.17.2"
         },
         "org.junit.vintage:junit-vintage-engine": {
             "locked": "5.8.2"


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [X] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This does a couple of things. First, it runs an update on the locks, which upgraded a couple of other items. Next, it removes the lock of log4j for both the conductor-client and conductor-common modules. These are used by consumers, and can cause all sorts of havoc if we lock a version. Consumers should be able to upgrade log4j as they see fit, and I believe that this will still keep the strictly restriction in place for Conductor itself, so no one would be able to set a version below 2.17.2 in Conductor itself. 