### PR TITLE
Fix validation error handling in workflow/task editor

### DIFF
--- a/ui/src/pages/definition/SaveTaskDialog.jsx
+++ b/ui/src/pages/definition/SaveTaskDialog.jsx
@@ -49,11 +49,12 @@ export default function SaveTaskDialog({ onSuccess, onCancel, document }) {
     },
     onError: (err) => {
       console.log("onerror", err);
-      let errStr = _.isString(err.body)
-        ? err.body
-        : JSON.stringify(err.body, null, 2);
+      const errObj = JSON.parse(err);
+      let errStr = errObj.validationErrors && errObj.validationErrors.length > 0
+        ? `${errObj.validationErrors[0].message}: ${errObj.validationErrors[0].path}`
+        : errObj.message;
       setErrorMsg({
-        message: `${TASK_SAVE_FAILED}: ${errStr}`,
+        message: `${TASK_SAVE_FAILED} ${errStr}`,
         dismissible: true,
       });
     },

--- a/ui/src/pages/definition/SaveWorkflowDialog.jsx
+++ b/ui/src/pages/definition/SaveWorkflowDialog.jsx
@@ -81,10 +81,11 @@ export default function SaveWorkflowDialog({ onSuccess, onCancel, document }) {
     },
     onError: (err) => {
       console.log("onerror", err);
-      let errStr = _.isString(err.body)
-        ? err.body
-        : JSON.stringify(err.body, null, 2);
-      setErrorMsg(`${WORKFLOW_SAVE_FAILED}: ${errStr}`);
+      const errObj = JSON.parse(err);
+      let errStr = errObj.validationErrors && errObj.validationErrors.length > 0
+        ? `${errObj.validationErrors[0].message}: ${errObj.validationErrors[0].path}`
+        : errObj.message;
+      setErrorMsg(`${WORKFLOW_SAVE_FAILED} ${errStr}`);
     },
   });
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

In workflow/task editor, the UI does not display the error message well when saving fails.
![image](https://github.com/Netflix/conductor/assets/40934357/46c8ac25-2ea4-4b05-b7aa-49fa0a4d61f7)

After fixing the bug, the UI can display detailed error message:
![image](https://github.com/Netflix/conductor/assets/40934357/63b7d360-9075-4626-aa58-439023f11ff6)

![image](https://github.com/Netflix/conductor/assets/40934357/ffd42d19-efca-45d8-bf5b-6b550ebdce5c)


Alternatives considered
----

_Describe alternative implementation you have considered_
