### PR TITLE
Fix taskToDomain field not being echoed

### DIFF
--- a/ui/src/pages/workbench/WorkbenchForm.jsx
+++ b/ui/src/pages/workbench/WorkbenchForm.jsx
@@ -201,6 +201,7 @@ function WorkbenchForm(props) {
 
         <FormikJsonInput
           className={classes.field}
+          reinitialize
           height={200}
           label="Task to Domain (JSON)"
           name="taskToDomain"


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

On the Workflow Workbench page, when the 'Task to Domain (JSON)' field of Run History has a value filled in, the field is not echoed after refreshing the page.
![taskToDomain](https://github.com/Netflix/conductor/assets/40934357/5366bf98-7095-44d3-aa11-e2686ade27e2)

Alternatives considered
----

_Describe alternative implementation you have considered_
