### PR TITLE
Fix JSONPath replace failed with line terminator

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/utils/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ParametersUtils.java
@@ -48,7 +48,8 @@ public class ParametersUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ParametersUtils.class);
     private static final Pattern PATTERN =
             Pattern.compile(
-                    "(?=(?<!\\$)\\$\\{)(?:(?=.*?\\{(?!.*?\\1)(.*\\}(?!.*\\2).*))(?=.*?\\}(?!.*?\\2)(.*)).)+?.*?(?=\\1)[^{]*(?=\\2$)");
+                    "(?=(?<!\\$)\\$\\{)(?:(?=.*?\\{(?!.*?\\1)(.*\\}(?!.*\\2).*))(?=.*?\\}(?!.*?\\2)(.*)).)+?.*?(?=\\1)[^{]*(?=\\2$)",
+                    Pattern.DOTALL);
 
     private final ObjectMapper objectMapper;
     private final TypeReference<Map<String, Object>> map = new TypeReference<>() {};

--- a/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/ParametersUtilsTest.java
@@ -258,6 +258,30 @@ public class ParametersUtilsTest {
     }
 
     @Test
+    public void testReplaceWithLineTerminators() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", "conductor");
+        map.put("version", 2);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("k1", "Name: ${name}; Version: ${version};");
+        input.put("k2", "Name: ${name};\nVersion: ${version};");
+        input.put("k3", "Name: ${name};\rVersion: ${version};");
+        input.put("k4", "Name: ${name};\r\nVersion: ${version};");
+
+        Object jsonObj = objectMapper.readValue(objectMapper.writeValueAsString(map), Object.class);
+
+        Map<String, Object> replaced = parametersUtils.replace(input, jsonObj);
+
+        assertNotNull(replaced);
+
+        assertEquals("Name: conductor; Version: 2;", replaced.get("k1"));
+        assertEquals("Name: conductor;\nVersion: 2;", replaced.get("k2"));
+        assertEquals("Name: conductor;\rVersion: 2;", replaced.get("k3"));
+        assertEquals("Name: conductor;\r\nVersion: 2;", replaced.get("k4"));
+    }
+
+    @Test
     public void testReplaceWithEscapedTags() throws Exception {
         Map<String, Object> map = new HashMap<>();
         map.put("someString", "conductor");


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #3804
This is because by default, the regular expression . matches any character except the line terminator: https://github.com/openjdk/jdk/blob/2edf9c3f1e968779c6e92b3e25d780db68ace5cc/src/java.base/share/classes/java/util/regex/Pattern.java#L890

Alternatives considered
----

_Describe alternative implementation you have considered_
