### PR TITLE
Update links in README to match conductor-docs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ The modules contributed by the community are housed at [conductor-community](htt
 
 ## Getting Started - Building & Running Conductor
 ###  Using Docker:
-The easiest way to get started is with Docker containers. Please follow the instructions [here](https://conductor.netflix.com/gettingstarted/docker.html). 
+The easiest way to get started is with Docker containers. Please follow the instructions [here](https://conductor.netflix.com/devguide/running/docker.html). 
 
 ###  From Source:
-Conductor Server is a [Spring Boot](https://spring.io/projects/spring-boot) project and follows all applicable conventions. See instructions [here](http://conductor.netflix.com/gettingstarted/source.html).
+Conductor Server is a [Spring Boot](https://spring.io/projects/spring-boot) project and follows all applicable conventions. See instructions [here](https://conductor.netflix.com/devguide/running/source.html).
 
 ## Published Artifacts
-Binaries are available from [Netflix OSS Maven](https://artifacts.netflix.net/netflixoss/com/netflix/conductor/) repository, or the [Maven Central Repository](https://search.maven.org/search?q=g:com.netflix.conductor).
+Binaries are available from the [Maven Central Repository](https://search.maven.org/search?q=g:com.netflix.conductor).
 
 | Artifact                        | Description                                                                                     |
 |---------------------------------|-------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [X] Other (please describe): minor doc change

Changes in this PR
----
Updated 2 links in README to match the new https://conductor.netflix.com/ URLs caused by the split of docs into the conductor-docs repo.

Also removes the link to https://artifacts.netflix.net/ since the site is no longer available.

This change is needed because broken links make for a poor onboarding experience.
