### PR TITLE
Optimizing reading from datastore during WorkflowSweeper#sweep

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1028,8 +1028,8 @@ public class WorkflowExecutor {
     }
 
     /**
-     * This method overloads the {@link #decide(String)}.
-     * It will acquire a lock and evaluate the state of the workflow.
+     * This method overloads the {@link #decide(String)}. It will acquire a lock and evaluate the
+     * state of the workflow.
      *
      * @param workflow the workflow to evaluate the state for
      * @return the workflow

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1027,6 +1027,13 @@ public class WorkflowExecutor {
         }
     }
 
+    /**
+     * This method overloads the com.netflix.conductor.core.execution.WorkflowExecutor#decide(java.lang.String).
+     * It will acquire a lock and evaluate the state of the workflow.
+     *
+     * @param workflow the workflow to evaluate the state for
+     * @return the workflow
+     */
     public WorkflowModel decideWithLock(WorkflowModel workflow) {
         if (workflow == null) {
             return null;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1028,7 +1028,7 @@ public class WorkflowExecutor {
     }
 
     /**
-     * This method overloads the com.netflix.conductor.core.execution.WorkflowExecutor#decide(java.lang.String).
+     * This method overloads the {@link #decide(String)}.
      * It will acquire a lock and evaluate the state of the workflow.
      *
      * @param workflow the workflow to evaluate the state for

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
@@ -109,6 +109,11 @@ public class WorkflowRepairService {
                                 () ->
                                         new NotFoundException(
                                                 "Could not find workflow: " + workflowId));
+        verifyAndRepairWorkflowTasks(workflow);
+    }
+
+    /** Verify and repair tasks in a workflow. */
+    public void verifyAndRepairWorkflowTasks(WorkflowModel workflow) {
         workflow.getTasks().forEach(this::verifyAndRepairTask);
         // repair the parent workflow if needed
         verifyAndRepairWorkflow(workflow.getParentWorkflowId());

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
@@ -23,6 +23,7 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.model.TaskModel;
@@ -42,6 +43,7 @@ public class TestWorkflowSweeper {
     private WorkflowExecutor workflowExecutor;
     private WorkflowRepairService workflowRepairService;
     private QueueDAO queueDAO;
+    private ExecutionDAOFacade executionDAOFacade;
     private WorkflowSweeper workflowSweeper;
 
     private int defaultPostPoneOffSetSeconds = 1800;
@@ -52,9 +54,14 @@ public class TestWorkflowSweeper {
         workflowExecutor = mock(WorkflowExecutor.class);
         queueDAO = mock(QueueDAO.class);
         workflowRepairService = mock(WorkflowRepairService.class);
+        executionDAOFacade = mock(ExecutionDAOFacade.class);
         workflowSweeper =
                 new WorkflowSweeper(
-                        workflowExecutor, Optional.of(workflowRepairService), properties, queueDAO);
+                        workflowExecutor,
+                        Optional.of(workflowRepairService),
+                        properties,
+                        queueDAO,
+                        executionDAOFacade);
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix/Optimization
- [x] Refactoring (no functional changes, no api changes)

Changes in this PR
----
Added a dependency to executorDaoFacade in WorkflowSweeper.
Added overloaded method in WorkflowRepairService - verifyAndRepairWorkflowTasks(WorkflowModel workflow)
Added overloaded method in WorkflowExecutor - decideWithLock(WorkflowModel workflow)
WorkflowSweeper now calls executorDaoFacade to get the workflow once and then passes is to the overloaded methods.

_Describe the new behavior from this PR, and why it's needed_
The new behaviour reduces the stress on the datastore during heavy loads. We have observed absurd loads on our redis instance comming from constant sweeping from the workflowSweeper ( more than 10GBps )
