### PR TITLE
Add support for building on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
+gradlew eol=lf
+*.gradle eol=lf
+*.java eol=lf
+*.groovy eol=lf
+spring.factories eol=lf
+*.sh eol=lf
+
 docs/* linguist-documentation
 server/src/main/resources/swagger-ui/* linguist-vendored
 


### PR DESCRIPTION
Pull Request type
----
- [ x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ x] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
When pulling the repository to a windows machine git will automatically convert the files line ending to windows format (CRLF). This however is not compatible with Gradle. To prevent git from automatically changing these when the repository is pulled, the .gitattribute file has been updated and the below lines have been added.

```gradlew eol=lf
*.gradle eol=lf
*.java eol=lf
*.groovy eol=lf
spring.factories eol=lf
*.sh eol=lf
```

Alternatives considered
----

_Describe alternative implementation you have considered_
