### PR TITLE
Failure Join Node IN_PROGESS Does Not Change

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -336,6 +336,15 @@ public class WorkflowExecutor {
         for (TaskModel task : workflow.getTasks()) {
             switch (task.getStatus()) {
                 case FAILED:
+                    if (task.getTaskType().equalsIgnoreCase(TaskType.JOIN.toString())) {
+                        task.setStatus(IN_PROGRESS);
+                        addTaskToQueue(task);
+                        // Task doesn't have to be updated yet. Will be updated along with other
+                        // Workflow tasks downstream.
+                    } else {
+                        retriableMap.put(task.getReferenceTaskName(), task);
+                    }
+                    break;
                 case FAILED_WITH_TERMINAL_ERROR:
                 case TIMED_OUT:
                     retriableMap.put(task.getReferenceTaskName(), task);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

* Change to IN_PROGRESS state when the join node is in a failed state rather than a cancelled state.

_Describe the new behavior from this PR, and why it's needed_
Issue #3630
Issue #3609

Two situations occurred when a Fork-Join node internal fail node occurred. If a fail node existed immediately before the join node, the join node was changed to fail. However, if the Fail node is not immediately before the Join node, it has changed to the Cancel state. Both situations must be considered. I attached the reference picture below.

![image](https://github.com/Netflix/conductor/assets/68694844/4fd61d93-c3cd-47a1-befe-ef3b6fc87476)
![image](https://github.com/Netflix/conductor/assets/68694844/7ab586cf-a467-4c18-a529-bf1fa3438bd0)

Alternatives considered
----

None