### PR TITLE
Bugfix/Data inconsistency caused by updateEventHandler

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisEventHandlerDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisEventHandlerDAO.java
@@ -72,7 +72,7 @@ public class RedisEventHandlerDAO extends BaseDynoDAO implements EventHandlerDAO
             throw new NotFoundException(
                     "EventHandler with name %s not found!", eventHandler.getName());
         }
-        if(!existing.getEvent().equals(eventHandler.getEvent())){
+        if (!existing.getEvent().equals(eventHandler.getEvent())) {
             removeIndex(existing);
         }
         index(eventHandler);

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisEventHandlerDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisEventHandlerDAO.java
@@ -72,6 +72,9 @@ public class RedisEventHandlerDAO extends BaseDynoDAO implements EventHandlerDAO
             throw new NotFoundException(
                     "EventHandler with name %s not found!", eventHandler.getName());
         }
+        if(!existing.getEvent().equals(eventHandler.getEvent())){
+            removeIndex(existing);
+        }
         index(eventHandler);
         jedisProxy.hset(nsKey(EVENT_HANDLERS), eventHandler.getName(), toJson(eventHandler));
         recordRedisDaoRequests("updateEventHandler");


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
1. If one event handler gets updated to listen on a new event, remove its previous index of event handlers by events


_Describe the new behavior from this PR, and why it's needed_
To resolve #3842

Alternatives considered
----

_Describe alternative implementation you have considered_
