### PR TITLE
Fix typo in build-a-golang-task-worker.md

### DIFF
--- a/docs/docs/how-tos/Workers/build-a-golang-task-worker.md
+++ b/docs/docs/how-tos/Workers/build-a-golang-task-worker.md
@@ -11,7 +11,7 @@ go get github.com/netflix/conductor/client/go
 This will create a Go project under $GOPATH/src and download any dependencies.
 
 ## Implementing a Task a Worker
-`task`package provies the types used to implement the worker.  Here is a reference worker implementation:
+`task`package provides the types used to implement the worker.  Here is a reference worker implementation:
 
 ```go
 package task


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [x] Other (please describe): fix typo in documentation

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Fix typo `provies` -> `provides`

Alternatives considered
----

N/A