### PR TITLE
[Hot-fix] fix: remove redundant slash that cause proxy fail

### DIFF
--- a/ui/src/components/NavLink.jsx
+++ b/ui/src/components/NavLink.jsx
@@ -26,7 +26,7 @@ export default React.forwardRef((props, ref) => {
       </Link>
     );
   } else {
-    const href = absolutePath ? url.toString() : cleanDuplicateSlash(getBasename() + "/" + url.toString());
+    const href = absolutePath ? url.toString() : cleanDuplicateSlash(getBasename() + url.toString());
     return (
       <Link ref={ref} target="_blank" href={href}>
         {rest.children}

--- a/ui/src/plugins/AppLogo.jsx
+++ b/ui/src/plugins/AppLogo.jsx
@@ -13,6 +13,6 @@ const useStyles = makeStyles((theme) => ({
 
 export default function AppLogo() {
   const classes = useStyles();
-  const logoPath = getBasename() + '/logo.svg';
+  const logoPath = getBasename() + 'logo.svg';
   return <img src={cleanDuplicateSlash(logoPath)} alt="Conductor" className={classes.logo} />;
 }

--- a/ui/src/plugins/fetch.js
+++ b/ui/src/plugins/fetch.js
@@ -17,7 +17,7 @@ export function fetchWithContext(
   const newParams = { ...fetchParams };
 
   const basename = getBasename();
-  const newPath = basename + `/api/${path}`;
+  const newPath = basename + `api/${path}`;
   const cleanPath = cleanDuplicateSlash(newPath); // Cleanup duplicated slashes
 
   return fetch(cleanPath, newParams)


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #
- Fixing redundant slash that cause the proxy fail when calling API
Slack reference: https://orkes-conductor.slack.com/archives/C02KJ820XPW/p1701315386966159

Alternatives considered
----

_Describe alternative implementation you have considered_
